### PR TITLE
feat(api): implement phase 3 mutualization - add @kairn/api package

### DIFF
--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["@kairn/eslint-config"],
+  "parserOptions": {
+    "project": true
+  },
+  "rules": {
+    "no-console": "off"
+  },
+  "ignorePatterns": ["dist/"]
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@kairn/api",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Handlers API réutilisables pour les sites Kairn",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./middleware": {
+      "types": "./dist/middleware/index.d.ts",
+      "import": "./dist/middleware/index.js"
+    },
+    "./handlers/auth": {
+      "types": "./dist/handlers/auth/index.d.ts",
+      "import": "./dist/handlers/auth/index.js"
+    },
+    "./handlers/blog": {
+      "types": "./dist/handlers/blog/index.d.ts",
+      "import": "./dist/handlers/blog/index.js"
+    },
+    "./handlers/analytics": {
+      "types": "./dist/handlers/analytics/index.d.ts",
+      "import": "./dist/handlers/analytics/index.js"
+    },
+    "./handlers/contact": {
+      "types": "./dist/handlers/contact/index.d.ts",
+      "import": "./dist/handlers/contact/index.js"
+    },
+    "./handlers/testimonials": {
+      "types": "./dist/handlers/testimonials/index.d.ts",
+      "import": "./dist/handlers/testimonials/index.js"
+    },
+    "./handlers/seminars": {
+      "types": "./dist/handlers/seminars/index.d.ts",
+      "import": "./dist/handlers/seminars/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@kairn/config": "workspace:*",
+    "@kairn/core": "workspace:*",
+    "@kairn/db": "workspace:*",
+    "@kairn/blog": "workspace:*",
+    "@kairn/analytics": "workspace:*",
+    "zod": "^3.22.0"
+  },
+  "peerDependencies": {
+    "@prisma/client": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@prisma/client": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@kairn/typescript-config": "workspace:*",
+    "@prisma/client": "^6.0.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/api/src/handlers/analytics/dashboard.ts
+++ b/packages/api/src/handlers/analytics/dashboard.ts
@@ -1,0 +1,162 @@
+/**
+ * Analytics Dashboard Handler
+ *
+ * Returns aggregated analytics data for the dashboard.
+ */
+
+import type { ApiRequest } from '../../middleware/types';
+import { withQueryValidation } from '../../middleware/with-validation';
+import { error, success } from '../../utils/response';
+
+import { dashboardQuerySchema, type DashboardData, type AnalyticsHandlerConfig } from './types';
+
+/**
+ * Dashboard handler result
+ */
+export interface DashboardResult {
+  response:
+    | { success: true; data: DashboardData }
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Calculate date range from period
+ */
+function calculateDateRange(
+  period: string,
+  customStart?: string,
+  customEnd?: string
+): { start: Date; end: Date } {
+  const now = new Date();
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+  let start: Date;
+
+  switch (period) {
+    case 'today':
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+      break;
+
+    case '7d':
+      start = new Date(end);
+      start.setDate(start.getDate() - 6);
+      start.setHours(0, 0, 0, 0);
+      break;
+
+    case '30d':
+      start = new Date(end);
+      start.setDate(start.getDate() - 29);
+      start.setHours(0, 0, 0, 0);
+      break;
+
+    case '90d':
+      start = new Date(end);
+      start.setDate(start.getDate() - 89);
+      start.setHours(0, 0, 0, 0);
+      break;
+
+    case 'custom':
+      if (customStart && customEnd) {
+        start = new Date(customStart);
+        return { start, end: new Date(customEnd) };
+      }
+      // Fallback to 7 days
+      start = new Date(end);
+      start.setDate(start.getDate() - 6);
+      start.setHours(0, 0, 0, 0);
+      break;
+
+    default:
+      start = new Date(end);
+      start.setDate(start.getDate() - 6);
+      start.setHours(0, 0, 0, 0);
+  }
+
+  return { start, end };
+}
+
+/**
+ * Handle dashboard data request
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Dashboard data result
+ *
+ * @example
+ * ```typescript
+ * export async function GET(request: Request) {
+ *   const authResult = await withAdmin(request, { getCookies: () => cookies() });
+ *   if (!authResult.success) {
+ *     return NextResponse.json(authResult.error, { status: authResult.error.statusCode });
+ *   }
+ *
+ *   const result = await handleDashboard(request, {
+ *     getDashboardData: async ({ startDate, endDate }) => {
+ *       // Fetch data from database
+ *       return dashboardData;
+ *     },
+ *   });
+ *
+ *   return NextResponse.json(result.response, {
+ *     status: result.statusCode,
+ *     headers: result.headers,
+ *   });
+ * }
+ * ```
+ */
+export async function handleDashboard(
+  request: ApiRequest,
+  config: AnalyticsHandlerConfig
+): Promise<DashboardResult> {
+  const { getDashboardData, siteId: configSiteId } = config;
+
+  // Parse query parameters
+  const queryResult = withQueryValidation(request, dashboardQuerySchema);
+
+  if (!queryResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Paramètres de requête invalides', {
+        details: queryResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const { period, startDate, endDate, siteId: querySiteId } = queryResult.query;
+
+  // Calculate date range
+  const { start, end } = calculateDateRange(period, startDate, endDate);
+
+  try {
+    const dashboardData = await getDashboardData({
+      startDate: start,
+      endDate: end,
+      siteId: querySiteId || configSiteId,
+    });
+
+    // Cache for 5 minutes (admin data)
+    return {
+      response: success(dashboardData),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': 'private, max-age=300',
+      },
+    };
+  } catch (e) {
+    console.error('[Dashboard API] Error:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des données'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create dashboard handler with preset configuration
+ */
+export function createDashboardHandler(config: AnalyticsHandlerConfig) {
+  return (request: ApiRequest) => handleDashboard(request, config);
+}

--- a/packages/api/src/handlers/analytics/export.ts
+++ b/packages/api/src/handlers/analytics/export.ts
@@ -1,0 +1,167 @@
+/**
+ * Analytics Export Handler
+ *
+ * Exports analytics data in various formats.
+ */
+
+import type { ApiRequest } from '../../middleware/types';
+import { withQueryValidation } from '../../middleware/with-validation';
+import { error } from '../../utils/response';
+
+import { exportQuerySchema, type AnalyticsHandlerConfig } from './types';
+
+/**
+ * Export handler result
+ */
+export type ExportResult =
+  | { success: true; data: Buffer; filename: string; contentType: string }
+  | {
+      success: false;
+      response: { success: false; error: { code: string; message: string; details?: unknown } };
+      statusCode: number;
+      headers: Record<string, string>;
+    };
+
+/**
+ * Content type mapping
+ */
+const CONTENT_TYPES: Record<string, string> = {
+  csv: 'text/csv',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  pdf: 'application/pdf',
+};
+
+/**
+ * Handle export request
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Export result with binary data or error
+ *
+ * @example
+ * ```typescript
+ * export async function GET(request: Request) {
+ *   const authResult = await withAdmin(request, { getCookies: () => cookies() });
+ *   if (!authResult.success) {
+ *     return NextResponse.json(authResult.error, { status: authResult.error.statusCode });
+ *   }
+ *
+ *   const result = await handleExport(request, {
+ *     exportData: async ({ startDate, endDate, format, type }) => {
+ *       // Generate export
+ *       return { data: buffer, filename: 'analytics.csv', contentType: 'text/csv' };
+ *     },
+ *   });
+ *
+ *   if (!result.success) {
+ *     return NextResponse.json(result.response, {
+ *       status: result.statusCode,
+ *       headers: result.headers,
+ *     });
+ *   }
+ *
+ *   return new Response(result.data, {
+ *     headers: {
+ *       'Content-Type': result.contentType,
+ *       'Content-Disposition': `attachment; filename="${result.filename}"`,
+ *     },
+ *   });
+ * }
+ * ```
+ */
+export async function handleExport(
+  request: ApiRequest,
+  config: AnalyticsHandlerConfig
+): Promise<ExportResult> {
+  const { exportData, siteId: configSiteId } = config;
+
+  if (!exportData) {
+    return {
+      success: false,
+      response: error('NOT_IMPLEMENTED', 'Export non disponible'),
+      statusCode: 501,
+      headers: {},
+    };
+  }
+
+  // Parse query parameters
+  const queryResult = withQueryValidation(request, exportQuerySchema);
+
+  if (!queryResult.success) {
+    return {
+      success: false,
+      response: error('VALIDATION_ERROR', 'Paramètres de requête invalides', {
+        details: queryResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const { startDate, endDate, format, type, siteId: querySiteId } = queryResult.query;
+
+  // Validate dates
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+    return {
+      success: false,
+      response: error('VALIDATION_ERROR', 'Dates invalides'),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  if (start > end) {
+    return {
+      success: false,
+      response: error('VALIDATION_ERROR', 'La date de début doit être antérieure à la date de fin'),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  // Limit export range to 1 year
+  const maxRange = 365 * 24 * 60 * 60 * 1000; // 1 year in ms
+  if (end.getTime() - start.getTime() > maxRange) {
+    return {
+      success: false,
+      response: error('VALIDATION_ERROR', "La plage d'export ne peut pas dépasser 1 an"),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  try {
+    const result = await exportData({
+      startDate: start,
+      endDate: end,
+      format,
+      type,
+      siteId: querySiteId || configSiteId,
+    });
+
+    return {
+      success: true,
+      data: result.data,
+      filename: result.filename,
+      contentType: result.contentType || CONTENT_TYPES[format] || 'application/octet-stream',
+    };
+  } catch (e) {
+    console.error('[Export API] Error:', e);
+    return {
+      success: false,
+      response: error('INTERNAL_ERROR', "Erreur lors de la génération de l'export"),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create export handler with preset configuration
+ */
+export function createExportHandler(config: AnalyticsHandlerConfig) {
+  return (request: ApiRequest) => handleExport(request, config);
+}

--- a/packages/api/src/handlers/analytics/index.ts
+++ b/packages/api/src/handlers/analytics/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Analytics Handlers
+ *
+ * Reusable analytics API handlers for tracking, dashboard, realtime, and export.
+ */
+
+// Types and schemas
+export {
+  sessionDataSchema,
+  baseEventSchema,
+  clientInfoSchema,
+  trackingPayloadSchema,
+  dashboardQuerySchema,
+  exportQuerySchema,
+  isBot,
+  extractDomain,
+  hashIP,
+  getCountryName,
+  BOT_PATTERNS,
+  COUNTRY_NAMES,
+  type EventType,
+  type DeviceType,
+  type SessionData,
+  type BaseEvent,
+  type ClientInfo,
+  type TrackingPayload,
+  type GeolocationData,
+  type DashboardQueryParams,
+  type ExportQueryParams,
+  type DashboardMetrics,
+  type TopPage,
+  type TrafficSource,
+  type DeviceBreakdown,
+  type GeoData,
+  type TimeSeriesPoint,
+  type DashboardData,
+  type RealtimeData,
+  type AnalyticsHandlerConfig,
+} from './types';
+
+// Track handler
+export { handleTrack, createTrackHandler, extractGeolocation, type TrackResult } from './track';
+
+// Dashboard handler
+export { handleDashboard, createDashboardHandler, type DashboardResult } from './dashboard';
+
+// Realtime handler
+export { handleRealtime, createRealtimeHandler, type RealtimeResult } from './realtime';
+
+// Export handler
+export { handleExport, createExportHandler, type ExportResult } from './export';

--- a/packages/api/src/handlers/analytics/realtime.ts
+++ b/packages/api/src/handlers/analytics/realtime.ts
@@ -1,0 +1,87 @@
+/**
+ * Analytics Realtime Handler
+ *
+ * Returns real-time visitor data.
+ */
+
+import { error, success } from '../../utils/response';
+
+import { type RealtimeData, type AnalyticsHandlerConfig } from './types';
+
+/**
+ * Realtime handler result
+ */
+export interface RealtimeResult {
+  response:
+    | { success: true; data: RealtimeData }
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Handle realtime data request
+ *
+ * @param config - Handler configuration
+ * @returns Realtime data result
+ *
+ * @example
+ * ```typescript
+ * export async function GET(request: Request) {
+ *   const authResult = await withAdmin(request, { getCookies: () => cookies() });
+ *   if (!authResult.success) {
+ *     return NextResponse.json(authResult.error, { status: authResult.error.statusCode });
+ *   }
+ *
+ *   const result = await handleRealtime({
+ *     getRealtimeData: async () => {
+ *       // Fetch realtime data
+ *       return realtimeData;
+ *     },
+ *   });
+ *
+ *   return NextResponse.json(result.response, {
+ *     status: result.statusCode,
+ *     headers: result.headers,
+ *   });
+ * }
+ * ```
+ */
+export async function handleRealtime(config: AnalyticsHandlerConfig): Promise<RealtimeResult> {
+  const { getRealtimeData, siteId } = config;
+
+  if (!getRealtimeData) {
+    return {
+      response: error('NOT_IMPLEMENTED', 'Données temps réel non disponibles'),
+      statusCode: 501,
+      headers: {},
+    };
+  }
+
+  try {
+    const realtimeData = await getRealtimeData(siteId);
+
+    // Very short cache (10 seconds) for realtime data
+    return {
+      response: success(realtimeData),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': 'private, max-age=10',
+      },
+    };
+  } catch (e) {
+    console.error('[Realtime API] Error:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des données temps réel'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create realtime handler with preset configuration
+ */
+export function createRealtimeHandler(config: AnalyticsHandlerConfig) {
+  return () => handleRealtime(config);
+}

--- a/packages/api/src/handlers/analytics/track.ts
+++ b/packages/api/src/handlers/analytics/track.ts
@@ -1,0 +1,413 @@
+/**
+ * Analytics Track Handler
+ *
+ * Receives and processes tracking events in batches.
+ */
+
+import type { ApiRequest } from '../../middleware/types';
+import { getClientIP, withRateLimit } from '../../middleware/with-rate-limit';
+import { withBodyValidation } from '../../middleware/with-validation';
+
+import {
+  extractDomain,
+  getCountryName,
+  hashIP,
+  isBot,
+  trackingPayloadSchema,
+  type AnalyticsHandlerConfig,
+  type GeolocationData,
+  type TrackingPayload,
+} from './types';
+
+/**
+ * Track handler result
+ */
+export interface TrackResult {
+  response: {
+    success: boolean;
+    processed?: number;
+    errors?: string[];
+    sessionId?: string;
+    message?: string;
+    error?: string;
+    details?: unknown;
+    retryAfter?: number;
+  };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Extract geolocation from request headers
+ */
+export function extractGeolocation(request: ApiRequest): GeolocationData | null {
+  // Cloudflare headers
+  const cfCountry = request.headers.get('cf-ipcountry');
+  const cfCity = request.headers.get('cf-ipcity');
+  const cfRegion = request.headers.get('cf-region');
+  const cfRegionCode = request.headers.get('cf-region-code');
+  const cfLatitude = request.headers.get('cf-iplatitude');
+  const cfLongitude = request.headers.get('cf-iplongitude');
+  const cfTimezone = request.headers.get('cf-timezone');
+
+  // Vercel headers
+  const vercelCountry = request.headers.get('x-vercel-ip-country');
+  const vercelCity = request.headers.get('x-vercel-ip-city');
+  const vercelRegion = request.headers.get('x-vercel-ip-country-region');
+  const vercelLatitude = request.headers.get('x-vercel-ip-latitude');
+  const vercelLongitude = request.headers.get('x-vercel-ip-longitude');
+  const vercelTimezone = request.headers.get('x-vercel-ip-timezone');
+
+  // Priority: Cloudflare > Vercel
+  const country = cfCountry || vercelCountry;
+  const city = cfCity || vercelCity;
+  const region = cfRegion || vercelRegion;
+  const regionCode = cfRegionCode || vercelRegion;
+  const latitude = cfLatitude || vercelLatitude;
+  const longitude = cfLongitude || vercelLongitude;
+  const timezone = cfTimezone || vercelTimezone;
+
+  if (!country) {
+    return null;
+  }
+
+  return {
+    country: getCountryName(country),
+    countryCode: country,
+    region: region || undefined,
+    regionCode: regionCode || undefined,
+    city: city || undefined,
+    latitude: latitude ? parseFloat(latitude) : undefined,
+    longitude: longitude ? parseFloat(longitude) : undefined,
+    timezone: timezone || undefined,
+  };
+}
+
+/**
+ * Process tracking events
+ */
+async function processEvents(
+  payload: TrackingPayload,
+  geolocation: GeolocationData | null,
+  clientIP: string,
+  config: AnalyticsHandlerConfig
+): Promise<{ processed: number; errors: string[] }> {
+  const {
+    trackPageVisit,
+    trackCustomEvent,
+    trackSectionTime,
+    trackConversionEvent,
+    trackFunnelStep,
+    trackGeolocation,
+  } = config;
+
+  const errors: string[] = [];
+  let processed = 0;
+  const { events, session, clientInfo } = payload;
+
+  // Track geolocation for first event if available
+  if (geolocation && events.length > 0 && trackGeolocation) {
+    try {
+      const firstEvent = events[0];
+      if (firstEvent) {
+        await trackGeolocation({
+          sessionId: session.id,
+          timestamp: firstEvent.timestamp,
+          geolocation,
+          ipHash: hashIP(clientIP),
+        });
+      }
+    } catch (e) {
+      console.error('[Track API] Error tracking geolocation:', e);
+    }
+  }
+
+  for (const event of events) {
+    try {
+      switch (event.type) {
+        case 'page_view':
+          await trackPageVisit({
+            timestamp: event.timestamp,
+            sessionId: event.sessionId,
+            page: event.url,
+            referrer: (event as { referrer?: string }).referrer || undefined,
+            userAgent: clientInfo.userAgent,
+            utmSource: session.utmSource || undefined,
+            utmMedium: session.utmMedium || undefined,
+            utmCampaign: session.utmCampaign || undefined,
+            utmTerm: session.utmTerm || undefined,
+            utmContent: session.utmContent || undefined,
+            referrerDomain: extractDomain(session.referrer),
+            deviceType: session.deviceType,
+            browser: session.browser || undefined,
+            os: session.os || undefined,
+            isBot: isBot(clientInfo.userAgent),
+          });
+          break;
+
+        case 'page_exit': {
+          const exitEvent = event as {
+            timeOnPage?: number;
+            scrollDepthPercent?: number;
+            engagementScore?: number;
+          };
+          await trackCustomEvent({
+            timestamp: event.timestamp,
+            sessionId: event.sessionId,
+            category: 'Engagement',
+            action: 'page_exit',
+            label: event.url,
+            value: exitEvent.timeOnPage,
+            metadata: {
+              scrollDepthPercent: exitEvent.scrollDepthPercent,
+              engagementScore: exitEvent.engagementScore,
+            },
+          });
+          break;
+        }
+
+        case 'scroll_depth': {
+          const scrollEvent = event as { depth?: number };
+          await trackCustomEvent({
+            timestamp: event.timestamp,
+            sessionId: event.sessionId,
+            category: 'Engagement',
+            action: 'scroll_depth',
+            label: event.url,
+            value: scrollEvent.depth,
+          });
+          break;
+        }
+
+        case 'section_view': {
+          const sectionViewEvent = event as { sectionId?: string; sectionName?: string };
+          await trackCustomEvent({
+            timestamp: event.timestamp,
+            sessionId: event.sessionId,
+            category: 'Section',
+            action: 'view',
+            label: sectionViewEvent.sectionName || sectionViewEvent.sectionId,
+            metadata: { sectionId: sectionViewEvent.sectionId, page: event.url },
+          });
+          break;
+        }
+
+        case 'section_time':
+          if (trackSectionTime) {
+            const sectionTimeEvent = event as {
+              sectionId?: string;
+              sectionName?: string;
+              timeSpent?: number;
+            };
+            const sectionName = sectionTimeEvent.sectionName || sectionTimeEvent.sectionId;
+            if (sectionName && sectionName.toLowerCase() !== 'unknown') {
+              await trackSectionTime({
+                timestamp: event.timestamp,
+                sessionId: event.sessionId,
+                section: sectionName,
+                timeSpent: sectionTimeEvent.timeSpent || 0,
+              });
+            }
+          }
+          break;
+
+        case 'conversion':
+          if (trackConversionEvent) {
+            const conversionEvent = event as {
+              conversionType?: string;
+              stepName?: string;
+              stepOrder?: number;
+              completed?: boolean;
+              value?: number;
+              metadata?: Record<string, unknown>;
+            };
+
+            await trackConversionEvent({
+              timestamp: event.timestamp,
+              sessionId: event.sessionId,
+              eventType: conversionEvent.conversionType || 'custom',
+              stepName: conversionEvent.stepName || 'unknown',
+              completed: conversionEvent.completed || false,
+              metadata: conversionEvent.metadata,
+            });
+
+            // Also track as funnel step
+            if (trackFunnelStep) {
+              await trackFunnelStep({
+                timestamp: event.timestamp,
+                sessionId: event.sessionId,
+                funnelName: conversionEvent.conversionType || 'default',
+                stepName: conversionEvent.stepName || 'unknown',
+                stepOrder: conversionEvent.stepOrder || 0,
+                metadata: conversionEvent.metadata,
+              });
+            }
+          }
+          break;
+
+        case 'custom_event': {
+          const customEvent = event as {
+            category?: string;
+            action?: string;
+            label?: string;
+            value?: number;
+            metadata?: Record<string, unknown>;
+          };
+          await trackCustomEvent({
+            timestamp: event.timestamp,
+            sessionId: event.sessionId,
+            category: customEvent.category || 'Unknown',
+            action: customEvent.action || 'unknown',
+            label: customEvent.label,
+            value: customEvent.value,
+            metadata: customEvent.metadata,
+          });
+          break;
+        }
+
+        case 'session_start':
+          // Geolocation is tracked automatically
+          break;
+
+        case 'session_end': {
+          const sessionEndEvent = event as {
+            duration?: number;
+            pageViewCount?: number;
+            exitPage?: string;
+            bounced?: boolean;
+          };
+          await trackCustomEvent({
+            timestamp: event.timestamp,
+            sessionId: event.sessionId,
+            category: 'Session',
+            action: 'end',
+            value: sessionEndEvent.duration,
+            metadata: {
+              pageViewCount: sessionEndEvent.pageViewCount,
+              exitPage: sessionEndEvent.exitPage,
+              bounced: sessionEndEvent.bounced,
+            },
+          });
+          break;
+        }
+
+        default:
+          console.warn(`[Track API] Unknown event type: ${event.type}`);
+      }
+
+      processed++;
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error';
+      errors.push(`Event ${event.type}: ${message}`);
+      console.error('[Track API] Error processing event:', e);
+    }
+  }
+
+  return { processed, errors };
+}
+
+/**
+ * Handle tracking request
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Track result
+ */
+export async function handleTrack(
+  request: ApiRequest,
+  config: AnalyticsHandlerConfig
+): Promise<TrackResult> {
+  const clientIP = getClientIP(request);
+  const headers: Record<string, string> = {};
+
+  // Rate limiting (100 requests per minute per IP)
+  const rateLimitResult = await withRateLimit(request, {
+    windowMs: 60 * 1000,
+    maxRequests: 100,
+    keyGenerator: () => `analytics:${clientIP}`,
+  });
+
+  Object.assign(headers, rateLimitResult.headers);
+
+  if (!rateLimitResult.success) {
+    return {
+      response: {
+        success: false,
+        error: 'Rate limit exceeded',
+        retryAfter: rateLimitResult.error.details?.retryAfter as number,
+      },
+      statusCode: 429,
+      headers: {
+        ...headers,
+        'Retry-After': String(rateLimitResult.error.details?.retryAfter || 60),
+      },
+    };
+  }
+
+  // Validate payload
+  const validationResult = await withBodyValidation(request, trackingPayloadSchema);
+
+  if (!validationResult.success) {
+    return {
+      response: {
+        success: false,
+        error: 'Invalid payload',
+        details: validationResult.error.details,
+      },
+      statusCode: 400,
+      headers,
+    };
+  }
+
+  const payload = validationResult.body;
+
+  // Check for bots
+  if (isBot(payload.clientInfo.userAgent)) {
+    return {
+      response: {
+        success: true,
+        processed: 0,
+        sessionId: payload.session.id,
+        message: 'Bot traffic ignored',
+      },
+      statusCode: 200,
+      headers,
+    };
+  }
+
+  // Extract geolocation
+  const geolocation = extractGeolocation(request);
+
+  // Process events
+  try {
+    const result = await processEvents(payload, geolocation, clientIP, config);
+
+    return {
+      response: {
+        success: true,
+        processed: result.processed,
+        errors: result.errors.length > 0 ? result.errors : undefined,
+        sessionId: payload.session.id,
+      },
+      statusCode: 200,
+      headers,
+    };
+  } catch (e) {
+    console.error('[Track API] Error:', e);
+    return {
+      response: {
+        success: false,
+        error: e instanceof Error ? e.message : 'Internal server error',
+      },
+      statusCode: 500,
+      headers,
+    };
+  }
+}
+
+/**
+ * Create track handler with preset configuration
+ */
+export function createTrackHandler(config: AnalyticsHandlerConfig) {
+  return (request: ApiRequest) => handleTrack(request, config);
+}

--- a/packages/api/src/handlers/analytics/types.ts
+++ b/packages/api/src/handlers/analytics/types.ts
@@ -1,0 +1,417 @@
+/**
+ * Analytics Handler Types
+ */
+
+import { z } from 'zod';
+
+/**
+ * Tracking event types
+ */
+export type EventType =
+  | 'page_view'
+  | 'page_exit'
+  | 'scroll_depth'
+  | 'section_view'
+  | 'section_time'
+  | 'conversion'
+  | 'custom_event'
+  | 'session_start'
+  | 'session_end';
+
+/**
+ * Device type
+ */
+export type DeviceType = 'mobile' | 'tablet' | 'desktop';
+
+/**
+ * Session data schema
+ */
+export const sessionDataSchema = z.object({
+  id: z.string().min(1),
+  startedAt: z.string(),
+  lastActivityAt: z.string(),
+  landingPage: z.string(),
+  referrer: z.string().nullable(),
+  utmSource: z.string().nullable(),
+  utmMedium: z.string().nullable(),
+  utmCampaign: z.string().nullable(),
+  utmTerm: z.string().nullable(),
+  utmContent: z.string().nullable(),
+  deviceType: z.enum(['mobile', 'tablet', 'desktop']),
+  browser: z.string().nullable(),
+  os: z.string().nullable(),
+  screenWidth: z.number(),
+  screenHeight: z.number(),
+  pageViewCount: z.number(),
+  isReturning: z.boolean(),
+});
+
+export type SessionData = z.infer<typeof sessionDataSchema>;
+
+/**
+ * Base event schema
+ */
+export const baseEventSchema = z.object({
+  type: z.string(),
+  timestamp: z.string(),
+  sessionId: z.string(),
+  url: z.string(),
+});
+
+export type BaseEvent = z.infer<typeof baseEventSchema>;
+
+/**
+ * Client info schema
+ */
+export const clientInfoSchema = z.object({
+  userAgent: z.string(),
+  language: z.string(),
+  timezone: z.string(),
+  screenWidth: z.number(),
+  screenHeight: z.number(),
+  colorDepth: z.number(),
+  pixelRatio: z.number(),
+  touchSupport: z.boolean(),
+  connectionType: z.string().optional(),
+});
+
+export type ClientInfo = z.infer<typeof clientInfoSchema>;
+
+/**
+ * Tracking payload schema
+ */
+export const trackingPayloadSchema = z.object({
+  events: z.array(baseEventSchema).min(1).max(100),
+  session: sessionDataSchema,
+  clientInfo: clientInfoSchema,
+});
+
+export type TrackingPayload = z.infer<typeof trackingPayloadSchema>;
+
+/**
+ * Geolocation data
+ */
+export interface GeolocationData {
+  country?: string;
+  countryCode?: string;
+  region?: string;
+  regionCode?: string;
+  city?: string;
+  latitude?: number;
+  longitude?: number;
+  timezone?: string;
+}
+
+/**
+ * Dashboard query params
+ */
+export const dashboardQuerySchema = z.object({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  period: z.enum(['today', '7d', '30d', '90d', 'custom']).default('7d'),
+  siteId: z.string().optional(),
+});
+
+export type DashboardQueryParams = z.infer<typeof dashboardQuerySchema>;
+
+/**
+ * Export query params
+ */
+export const exportQuerySchema = z.object({
+  startDate: z.string(),
+  endDate: z.string(),
+  format: z.enum(['csv', 'xlsx', 'pdf']).default('csv'),
+  type: z.enum(['overview', 'pages', 'events', 'conversions', 'full']).default('overview'),
+  siteId: z.string().optional(),
+});
+
+export type ExportQueryParams = z.infer<typeof exportQuerySchema>;
+
+/**
+ * Dashboard metrics
+ */
+export interface DashboardMetrics {
+  /** Total visits in period */
+  totalVisits: number;
+  /** Total unique visitors */
+  uniqueVisitors: number;
+  /** Total page views */
+  pageViews: number;
+  /** Average session duration in seconds */
+  avgSessionDuration: number;
+  /** Bounce rate percentage */
+  bounceRate: number;
+  /** Pages per session */
+  pagesPerSession: number;
+  /** Change from previous period (percentage) */
+  changes: {
+    totalVisits: number;
+    uniqueVisitors: number;
+    pageViews: number;
+    avgSessionDuration: number;
+    bounceRate: number;
+    pagesPerSession: number;
+  };
+}
+
+/**
+ * Top pages data
+ */
+export interface TopPage {
+  path: string;
+  title?: string;
+  views: number;
+  uniqueViews: number;
+  avgTimeOnPage: number;
+  bounceRate: number;
+}
+
+/**
+ * Traffic source
+ */
+export interface TrafficSource {
+  source: string;
+  visits: number;
+  percentage: number;
+}
+
+/**
+ * Device breakdown
+ */
+export interface DeviceBreakdown {
+  device: DeviceType;
+  visits: number;
+  percentage: number;
+}
+
+/**
+ * Geographic data
+ */
+export interface GeoData {
+  country: string;
+  countryCode: string;
+  visits: number;
+  percentage: number;
+}
+
+/**
+ * Time series data point
+ */
+export interface TimeSeriesPoint {
+  date: string;
+  value: number;
+}
+
+/**
+ * Dashboard data
+ */
+export interface DashboardData {
+  metrics: DashboardMetrics;
+  topPages: TopPage[];
+  trafficSources: TrafficSource[];
+  deviceBreakdown: DeviceBreakdown[];
+  geoData: GeoData[];
+  visitsByDay: TimeSeriesPoint[];
+  pageViewsByDay: TimeSeriesPoint[];
+}
+
+/**
+ * Realtime data
+ */
+export interface RealtimeData {
+  activeVisitors: number;
+  activeSessions: Array<{
+    sessionId: string;
+    page: string;
+    startedAt: string;
+    deviceType: DeviceType;
+    country?: string;
+  }>;
+  pageViewsLast5Min: number;
+  topPagesNow: Array<{
+    path: string;
+    activeUsers: number;
+  }>;
+}
+
+/**
+ * Bot patterns for detection
+ */
+export const BOT_PATTERNS = [
+  /bot/i,
+  /crawler/i,
+  /spider/i,
+  /crawling/i,
+  /headless/i,
+  /lighthouse/i,
+  /pingdom/i,
+  /gtmetrix/i,
+  /pagespeed/i,
+  /google/i,
+  /bing/i,
+  /yahoo/i,
+  /yandex/i,
+  /baidu/i,
+  /duckduck/i,
+  /facebookexternalhit/i,
+  /twitterbot/i,
+  /linkedinbot/i,
+  /slackbot/i,
+  /telegrambot/i,
+  /whatsapp/i,
+  /semrush/i,
+  /ahrefs/i,
+  /mj12bot/i,
+  /dotbot/i,
+  /petalbot/i,
+  /bytespider/i,
+  /cypress/i,
+  /playwright/i,
+  /puppeteer/i,
+  /selenium/i,
+  /phantomjs/i,
+];
+
+/**
+ * Check if user agent is a bot
+ */
+export function isBot(userAgent: string): boolean {
+  return BOT_PATTERNS.some(pattern => pattern.test(userAgent));
+}
+
+/**
+ * Analytics handler configuration
+ */
+export interface AnalyticsHandlerConfig {
+  /** Site ID for multi-tenant filtering */
+  siteId?: string;
+  /** Function to track page visit */
+  trackPageVisit: (data: {
+    timestamp: string;
+    sessionId: string;
+    page: string;
+    referrer?: string;
+    userAgent: string;
+    utmSource?: string;
+    utmMedium?: string;
+    utmCampaign?: string;
+    utmTerm?: string;
+    utmContent?: string;
+    referrerDomain?: string;
+    deviceType: DeviceType;
+    browser?: string;
+    os?: string;
+    isBot: boolean;
+  }) => Promise<void>;
+  /** Function to track custom event */
+  trackCustomEvent: (data: {
+    timestamp: string;
+    sessionId: string;
+    category: string;
+    action: string;
+    label?: string;
+    value?: number;
+    metadata?: Record<string, unknown>;
+  }) => Promise<void>;
+  /** Function to track section time */
+  trackSectionTime?: (data: {
+    timestamp: string;
+    sessionId: string;
+    section: string;
+    timeSpent: number;
+  }) => Promise<void>;
+  /** Function to track conversion event */
+  trackConversionEvent?: (data: {
+    timestamp: string;
+    sessionId: string;
+    eventType: string;
+    stepName: string;
+    completed: boolean;
+    metadata?: Record<string, unknown>;
+  }) => Promise<void>;
+  /** Function to track funnel step */
+  trackFunnelStep?: (data: {
+    timestamp: string;
+    sessionId: string;
+    funnelName: string;
+    stepName: string;
+    stepOrder: number;
+    metadata?: Record<string, unknown>;
+  }) => Promise<void>;
+  /** Function to track geolocation */
+  trackGeolocation?: (data: {
+    sessionId: string;
+    timestamp: string;
+    geolocation: GeolocationData;
+    ipHash: string;
+  }) => Promise<void>;
+  /** Function to get dashboard data */
+  getDashboardData: (params: {
+    startDate: Date;
+    endDate: Date;
+    siteId?: string;
+  }) => Promise<DashboardData>;
+  /** Function to get realtime data */
+  getRealtimeData?: (siteId?: string) => Promise<RealtimeData>;
+  /** Function to export data */
+  exportData?: (params: {
+    startDate: Date;
+    endDate: Date;
+    format: string;
+    type: string;
+    siteId?: string;
+  }) => Promise<{ data: Buffer; filename: string; contentType: string }>;
+}
+
+/**
+ * Extract domain from URL
+ */
+export function extractDomain(url: string | null): string | undefined {
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Hash IP address for privacy
+ */
+export function hashIP(ip: string): string {
+  let hash = 0;
+  for (let i = 0; i < ip.length; i++) {
+    const char = ip.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return `ip_${Math.abs(hash).toString(16)}`;
+}
+
+/**
+ * Country code to name mapping
+ */
+export const COUNTRY_NAMES: Record<string, string> = {
+  FR: 'France',
+  BE: 'Belgique',
+  CH: 'Suisse',
+  CA: 'Canada',
+  US: 'États-Unis',
+  GB: 'Royaume-Uni',
+  DE: 'Allemagne',
+  ES: 'Espagne',
+  IT: 'Italie',
+  PT: 'Portugal',
+  NL: 'Pays-Bas',
+  LU: 'Luxembourg',
+  MC: 'Monaco',
+};
+
+/**
+ * Get country name from code
+ */
+export function getCountryName(code: string): string {
+  return COUNTRY_NAMES[code] || code;
+}

--- a/packages/api/src/handlers/auth/forgot-password.ts
+++ b/packages/api/src/handlers/auth/forgot-password.ts
@@ -1,0 +1,189 @@
+/**
+ * Forgot Password Handler
+ *
+ * Handles password reset requests.
+ */
+
+import type { ApiRequest } from '../../middleware/types';
+import { getClientIP, withRateLimit } from '../../middleware/with-rate-limit';
+import { withBodyValidation } from '../../middleware/with-validation';
+import { error } from '../../utils/response';
+
+import { forgotPasswordSchema, type ForgotPasswordResponse } from './types';
+
+/**
+ * Forgot password handler configuration
+ */
+export interface ForgotPasswordHandlerConfig {
+  /** Rate limit configuration */
+  rateLimit?: {
+    windowMs?: number;
+    maxRequests?: number;
+  };
+  /** Function to check if email exists */
+  findUserByEmail: (email: string) => Promise<{ id: string; email: string } | null>;
+  /** Function to generate reset token */
+  generateResetToken: (userId: string) => Promise<string>;
+  /** Function to send reset email */
+  sendResetEmail: (email: string, resetToken: string, resetUrl: string) => Promise<void>;
+  /** Base URL for reset link */
+  resetBaseUrl?: string;
+  /** Custom success message */
+  successMessage?: string;
+}
+
+/**
+ * Default configuration
+ */
+const defaultConfig: Partial<ForgotPasswordHandlerConfig> = {
+  rateLimit: {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    maxRequests: 5, // 5 requests per hour
+  },
+  resetBaseUrl: '/reset-password',
+  successMessage:
+    'Si un compte existe avec cette adresse email, un lien de réinitialisation a été envoyé.',
+};
+
+/**
+ * Forgot password result
+ */
+export interface ForgotPasswordResult {
+  response:
+    | ForgotPasswordResponse
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Handle forgot password request
+ *
+ * Note: This handler always returns a success message even if the email doesn't exist
+ * to prevent email enumeration attacks.
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Forgot password result
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const result = await handleForgotPassword(request, {
+ *     findUserByEmail: async (email) => {
+ *       return prisma.user.findUnique({ where: { email } });
+ *     },
+ *     generateResetToken: async (userId) => {
+ *       const token = crypto.randomUUID();
+ *       await prisma.passwordReset.create({
+ *         data: { userId, token, expiresAt: new Date(Date.now() + 3600000) },
+ *       });
+ *       return token;
+ *     },
+ *     sendResetEmail: async (email, token, resetUrl) => {
+ *       await resend.emails.send({
+ *         to: email,
+ *         subject: 'Réinitialisation de mot de passe',
+ *         html: `<a href="${resetUrl}">Réinitialiser mon mot de passe</a>`,
+ *       });
+ *     },
+ *     resetBaseUrl: 'https://myapp.com/reset-password',
+ *   });
+ *
+ *   return NextResponse.json(result.response, {
+ *     status: result.statusCode,
+ *     headers: result.headers,
+ *   });
+ * }
+ * ```
+ */
+export async function handleForgotPassword(
+  request: ApiRequest,
+  config: ForgotPasswordHandlerConfig
+): Promise<ForgotPasswordResult> {
+  const {
+    rateLimit,
+    findUserByEmail,
+    generateResetToken,
+    sendResetEmail,
+    resetBaseUrl,
+    successMessage,
+  } = { ...defaultConfig, ...config };
+
+  const clientIP = getClientIP(request);
+  const headers: Record<string, string> = {};
+
+  // Check rate limiting
+  const rateLimitResult = await withRateLimit(request, {
+    windowMs: rateLimit?.windowMs || 3600000,
+    maxRequests: rateLimit?.maxRequests || 5,
+    keyGenerator: () => `forgot-password:${clientIP}`,
+  });
+
+  Object.assign(headers, rateLimitResult.headers);
+
+  if (!rateLimitResult.success) {
+    return {
+      response: error('TOO_MANY_REQUESTS', 'Trop de demandes. Veuillez réessayer plus tard.', {
+        retryAfter: rateLimitResult.error.details?.retryAfter,
+      }),
+      statusCode: 429,
+      headers: {
+        ...headers,
+        'Retry-After': String(rateLimitResult.error.details?.retryAfter || 3600),
+      },
+    };
+  }
+
+  // Validate request body
+  const validationResult = await withBodyValidation(request, forgotPasswordSchema);
+
+  if (!validationResult.success) {
+    return {
+      response: error('INVALID_INPUT', 'Adresse email invalide'),
+      statusCode: 400,
+      headers,
+    };
+  }
+
+  const { email } = validationResult.body;
+  const normalizedEmail = email.toLowerCase();
+
+  // Always return success to prevent email enumeration
+  // Process the request in the background
+  void (async () => {
+    try {
+      const user = await findUserByEmail(normalizedEmail);
+
+      if (user) {
+        const resetToken = await generateResetToken(user.id);
+        const resetUrl = `${resetBaseUrl}?token=${resetToken}`;
+        await sendResetEmail(user.email, resetToken, resetUrl);
+      }
+    } catch (e) {
+      // Log error but don't expose to user
+      console.error('Error processing forgot password request:', e);
+    }
+  })();
+
+  const responseMessage =
+    successMessage ??
+    defaultConfig.successMessage ??
+    'Si un compte existe avec cet email, vous recevrez un lien de réinitialisation.';
+
+  return {
+    response: {
+      success: true,
+      message: responseMessage,
+    },
+    statusCode: 200,
+    headers,
+  };
+}
+
+/**
+ * Create a forgot password handler with preset configuration
+ */
+export function createForgotPasswordHandler(config: ForgotPasswordHandlerConfig) {
+  return (request: ApiRequest) => handleForgotPassword(request, config);
+}

--- a/packages/api/src/handlers/auth/index.ts
+++ b/packages/api/src/handlers/auth/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Auth Handlers
+ *
+ * Reusable authentication handlers for API routes.
+ */
+
+// Types and schemas
+export {
+  loginSchema,
+  refreshTokenSchema,
+  forgotPasswordSchema,
+  resetPasswordSchema,
+  getDefaultAuthCookieOptions,
+  type LoginInput,
+  type RefreshTokenInput,
+  type ForgotPasswordInput,
+  type ResetPasswordInput,
+  type AuthUser,
+  type LoginResponse,
+  type LogoutResponse,
+  type RefreshResponse,
+  type ForgotPasswordResponse,
+  type AuthHandlerConfig,
+  type AuthCookieOptions,
+} from './types';
+
+// Login handler
+export { handleLogin, createLoginHandler, type LoginResult } from './login';
+
+// Logout handler
+export {
+  handleLogout,
+  createLogoutHandler,
+  type LogoutHandlerConfig,
+  type LogoutResult,
+} from './logout';
+
+// Refresh handler
+export {
+  handleRefresh,
+  createRefreshHandler,
+  type RefreshHandlerConfig,
+  type RefreshResult,
+} from './refresh';
+
+// Forgot password handler
+export {
+  handleForgotPassword,
+  createForgotPasswordHandler,
+  type ForgotPasswordHandlerConfig,
+  type ForgotPasswordResult,
+} from './forgot-password';

--- a/packages/api/src/handlers/auth/login.ts
+++ b/packages/api/src/handlers/auth/login.ts
@@ -1,0 +1,254 @@
+/**
+ * Login Handler
+ *
+ * Handles user authentication with rate limiting and JWT token generation.
+ */
+
+import { createToken, type JWTPayload } from '@kairn/core';
+
+import type { ApiRequest } from '../../middleware/types';
+import { getClientIP, RATE_LIMIT_PRESETS, withRateLimit } from '../../middleware/with-rate-limit';
+import { withBodyValidation } from '../../middleware/with-validation';
+import { error } from '../../utils/response';
+
+import {
+  getDefaultAuthCookieOptions,
+  loginSchema,
+  type AuthHandlerConfig,
+  type LoginResponse,
+} from './types';
+
+/**
+ * Default configuration
+ */
+const defaultConfig: Partial<AuthHandlerConfig> = {
+  cookieName: 'auth_token',
+  tokenExpiration: '24h',
+  includeTokenInBody: false,
+  rateLimitKey: 'login',
+};
+
+/**
+ * Login handler result
+ */
+export interface LoginResult {
+  response:
+    | LoginResponse
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+  cookie?: {
+    name: string;
+    value: string;
+    options: {
+      maxAge: number;
+      httpOnly: boolean;
+      secure: boolean;
+      sameSite: 'strict' | 'lax' | 'none';
+      path: string;
+    };
+  };
+}
+
+/**
+ * Handle login request
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Login result with response, status code, headers, and optional cookie
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const result = await handleLogin(request, {
+ *     cookieName: 'my_app_token',
+ *     findUserByEmail: async (email) => {
+ *       return prisma.user.findUnique({ where: { email } });
+ *     },
+ *     comparePassword: async (password, hash) => {
+ *       return bcrypt.compare(password, hash);
+ *     },
+ *   });
+ *
+ *   const response = NextResponse.json(result.response, {
+ *     status: result.statusCode,
+ *     headers: result.headers,
+ *   });
+ *
+ *   if (result.cookie) {
+ *     response.cookies.set(result.cookie.name, result.cookie.value, result.cookie.options);
+ *   }
+ *
+ *   return response;
+ * }
+ * ```
+ */
+export async function handleLogin(
+  request: ApiRequest,
+  config: AuthHandlerConfig
+): Promise<LoginResult> {
+  const {
+    cookieName,
+    tokenExpiration,
+    includeTokenInBody,
+    rateLimitKey,
+    findUserByEmail,
+    comparePassword,
+    onFailedAttempt,
+    onSuccessfulLogin,
+  } = { ...defaultConfig, ...config };
+
+  const clientIP = getClientIP(request);
+  const headers: Record<string, string> = {};
+
+  // Check rate limiting
+  const rateLimitResult = await withRateLimit(request, {
+    ...RATE_LIMIT_PRESETS.strict,
+    keyGenerator: () => `${rateLimitKey}:${clientIP}`,
+  });
+
+  Object.assign(headers, rateLimitResult.headers);
+
+  if (!rateLimitResult.success) {
+    return {
+      response: error('TOO_MANY_REQUESTS', rateLimitResult.error.message, {
+        retryAfter: rateLimitResult.error.details?.retryAfter,
+      }),
+      statusCode: 429,
+      headers: {
+        ...headers,
+        'Retry-After': String(rateLimitResult.error.details?.retryAfter || 60),
+      },
+    };
+  }
+
+  // Validate request body
+  const validationResult = await withBodyValidation(request, loginSchema);
+
+  if (!validationResult.success) {
+    return {
+      response: error('INVALID_INPUT', 'Les données fournies sont invalides', {
+        validation: validationResult.error.details,
+      }),
+      statusCode: 400,
+      headers,
+    };
+  }
+
+  const { email, password } = validationResult.body;
+  const normalizedEmail = email.toLowerCase();
+
+  // Find user
+  const user = await findUserByEmail(normalizedEmail);
+
+  if (!user) {
+    onFailedAttempt?.(normalizedEmail, clientIP);
+    return {
+      response: error('INVALID_CREDENTIALS', 'Identifiants invalides'),
+      statusCode: 401,
+      headers,
+    };
+  }
+
+  // Verify password
+  const passwordMatches = await comparePassword(password, user.passwordHash);
+
+  if (!passwordMatches) {
+    onFailedAttempt?.(normalizedEmail, clientIP);
+    return {
+      response: error('INVALID_CREDENTIALS', 'Identifiants invalides'),
+      statusCode: 401,
+      headers,
+    };
+  }
+
+  // Clear rate limiting for this user on successful login
+  onSuccessfulLogin?.(normalizedEmail, clientIP);
+
+  // Generate JWT token
+  const tokenPayload: Omit<JWTPayload, 'iat' | 'exp'> = {
+    sub: user.id,
+    email: user.email,
+    role: user.role,
+  };
+
+  const token = await createToken(tokenPayload, {
+    expiresIn: tokenExpiration,
+  });
+
+  // Calculate expiration
+  const expiresIn = parseExpiration(tokenExpiration || '24h');
+  const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+
+  // Build response
+  const responseData: LoginResponse = {
+    success: true,
+    user: {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+    },
+  };
+
+  if (includeTokenInBody) {
+    responseData.token = token;
+    responseData.expiresAt = expiresAt;
+  }
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  const cookieOptions = getDefaultAuthCookieOptions(
+    cookieName || 'auth_token',
+    expiresIn,
+    isProduction
+  );
+
+  return {
+    response: responseData,
+    statusCode: 200,
+    headers,
+    cookie: {
+      name: cookieOptions.name,
+      value: token,
+      options: {
+        maxAge: cookieOptions.maxAge,
+        httpOnly: cookieOptions.httpOnly,
+        secure: cookieOptions.secure,
+        sameSite: cookieOptions.sameSite,
+        path: cookieOptions.path,
+      },
+    },
+  };
+}
+
+/**
+ * Parse expiration string to seconds
+ */
+function parseExpiration(exp: string): number {
+  const match = exp.match(/^(\d+)([smhd])$/);
+  if (!match) {
+    return 86400; // Default 24 hours
+  }
+
+  const value = parseInt(match[1] || '1', 10);
+  const unit = match[2];
+
+  switch (unit) {
+    case 's':
+      return value;
+    case 'm':
+      return value * 60;
+    case 'h':
+      return value * 3600;
+    case 'd':
+      return value * 86400;
+    default:
+      return 86400;
+  }
+}
+
+/**
+ * Create a login handler with preset configuration
+ */
+export function createLoginHandler(config: AuthHandlerConfig) {
+  return (request: ApiRequest) => handleLogin(request, config);
+}

--- a/packages/api/src/handlers/auth/logout.ts
+++ b/packages/api/src/handlers/auth/logout.ts
@@ -1,0 +1,110 @@
+/**
+ * Logout Handler
+ *
+ * Handles user logout by clearing auth cookies.
+ */
+
+import type { LogoutResponse } from './types';
+
+/**
+ * Logout handler configuration
+ */
+export interface LogoutHandlerConfig {
+  /** Cookie name for auth token */
+  cookieName?: string;
+  /** Additional cookies to clear */
+  additionalCookies?: string[];
+  /** Callback after successful logout */
+  onLogout?: (userId?: string) => Promise<void>;
+}
+
+/**
+ * Default configuration
+ */
+const defaultConfig: LogoutHandlerConfig = {
+  cookieName: 'auth_token',
+  additionalCookies: [],
+};
+
+/**
+ * Logout result
+ */
+export interface LogoutResult {
+  response: LogoutResponse;
+  statusCode: number;
+  cookiesToClear: Array<{
+    name: string;
+    options: {
+      maxAge: number;
+      httpOnly: boolean;
+      secure: boolean;
+      sameSite: 'strict' | 'lax' | 'none';
+      path: string;
+    };
+  }>;
+}
+
+/**
+ * Handle logout request
+ *
+ * @param config - Handler configuration
+ * @returns Logout result with cookies to clear
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const result = await handleLogout({
+ *     cookieName: 'my_app_token',
+ *   });
+ *
+ *   const response = NextResponse.json(result.response, {
+ *     status: result.statusCode,
+ *   });
+ *
+ *   // Clear cookies
+ *   for (const cookie of result.cookiesToClear) {
+ *     response.cookies.set(cookie.name, '', cookie.options);
+ *   }
+ *
+ *   return response;
+ * }
+ * ```
+ */
+export async function handleLogout(config: LogoutHandlerConfig = {}): Promise<LogoutResult> {
+  const { cookieName, additionalCookies, onLogout } = { ...defaultConfig, ...config };
+
+  // Call logout callback if provided
+  if (onLogout) {
+    await onLogout();
+  }
+
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  // Build list of cookies to clear
+  const cookiesToClear = [cookieName, ...(additionalCookies || [])].map(name => ({
+    name: name || 'auth_token',
+    options: {
+      maxAge: 0,
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'strict' as const,
+      path: '/',
+    },
+  }));
+
+  return {
+    response: {
+      success: true,
+      message: 'Déconnexion réussie',
+    },
+    statusCode: 200,
+    cookiesToClear,
+  };
+}
+
+/**
+ * Create a logout handler with preset configuration
+ */
+export function createLogoutHandler(config: LogoutHandlerConfig = {}) {
+  return () => handleLogout(config);
+}

--- a/packages/api/src/handlers/auth/refresh.ts
+++ b/packages/api/src/handlers/auth/refresh.ts
@@ -1,0 +1,322 @@
+/**
+ * Refresh Token Handler
+ *
+ * Handles token refresh for maintaining user sessions.
+ */
+
+import { createToken, type JWTPayload, verifyToken } from '@kairn/core';
+
+import type { ApiRequest } from '../../middleware/types';
+import { error } from '../../utils/response';
+
+import { getDefaultAuthCookieOptions, type RefreshResponse } from './types';
+
+/**
+ * Refresh handler configuration
+ */
+export interface RefreshHandlerConfig {
+  /** Cookie name for auth token */
+  cookieName?: string;
+  /** Cookie name for refresh token (if using separate refresh tokens) */
+  refreshCookieName?: string;
+  /** Token expiration time */
+  tokenExpiration?: string;
+  /** Refresh token expiration time */
+  refreshTokenExpiration?: string;
+  /** Whether to include token in response body */
+  includeTokenInBody?: boolean;
+  /** Function to get cookies */
+  getCookies?: () => Promise<{ get(name: string): { value: string } | undefined }>;
+  /** Function to validate refresh token (for token rotation) */
+  validateRefreshToken?: (token: string) => Promise<boolean>;
+  /** Function to invalidate old refresh token */
+  invalidateRefreshToken?: (token: string) => Promise<void>;
+  /** Function to store new refresh token */
+  storeRefreshToken?: (userId: string, token: string) => Promise<void>;
+}
+
+/**
+ * Default configuration
+ */
+const defaultConfig: Partial<RefreshHandlerConfig> = {
+  cookieName: 'auth_token',
+  refreshCookieName: 'refresh_token',
+  tokenExpiration: '24h',
+  refreshTokenExpiration: '7d',
+  includeTokenInBody: false,
+};
+
+/**
+ * Refresh result
+ */
+export interface RefreshResult {
+  response:
+    | RefreshResponse
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+  cookie?: {
+    name: string;
+    value: string;
+    options: {
+      maxAge: number;
+      httpOnly: boolean;
+      secure: boolean;
+      sameSite: 'strict' | 'lax' | 'none';
+      path: string;
+    };
+  };
+  refreshCookie?: {
+    name: string;
+    value: string;
+    options: {
+      maxAge: number;
+      httpOnly: boolean;
+      secure: boolean;
+      sameSite: 'strict' | 'lax' | 'none';
+      path: string;
+    };
+  };
+}
+
+/**
+ * Parse Cookie header
+ */
+function parseCookieHeader(cookieHeader: string): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  const pairs = cookieHeader.split(';');
+
+  for (const pair of pairs) {
+    const [key, ...valueParts] = pair.trim().split('=');
+    if (key) {
+      cookies[key] = valueParts.join('=');
+    }
+  }
+
+  return cookies;
+}
+
+/**
+ * Handle token refresh request
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Refresh result
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const result = await handleRefresh(request, {
+ *     cookieName: 'my_app_token',
+ *     getCookies: () => cookies(),
+ *   });
+ *
+ *   if (result.statusCode !== 200) {
+ *     return NextResponse.json(result.response, { status: result.statusCode });
+ *   }
+ *
+ *   const response = NextResponse.json(result.response, {
+ *     status: result.statusCode,
+ *     headers: result.headers,
+ *   });
+ *
+ *   if (result.cookie) {
+ *     response.cookies.set(result.cookie.name, result.cookie.value, result.cookie.options);
+ *   }
+ *
+ *   return response;
+ * }
+ * ```
+ */
+export async function handleRefresh(
+  request: ApiRequest,
+  config: RefreshHandlerConfig = {}
+): Promise<RefreshResult> {
+  const {
+    cookieName,
+    refreshCookieName,
+    tokenExpiration,
+    refreshTokenExpiration,
+    includeTokenInBody,
+    getCookies,
+    validateRefreshToken,
+    invalidateRefreshToken,
+    storeRefreshToken,
+  } = { ...defaultConfig, ...config };
+
+  const headers: Record<string, string> = {};
+
+  // Try to get current token from cookies
+  let currentToken: string | null = null;
+  let refreshToken: string | null = null;
+
+  if (getCookies) {
+    try {
+      const cookies = await getCookies();
+      currentToken = cookies.get(cookieName || 'auth_token')?.value || null;
+      refreshToken = cookies.get(refreshCookieName || 'refresh_token')?.value || null;
+    } catch {
+      // Cookie access failed
+    }
+  }
+
+  // Fallback to Cookie header
+  if (!currentToken) {
+    const cookieHeader = request.headers.get('Cookie');
+    if (cookieHeader) {
+      const parsedCookies = parseCookieHeader(cookieHeader);
+      currentToken = parsedCookies[cookieName || 'auth_token'] || null;
+      refreshToken = parsedCookies[refreshCookieName || 'refresh_token'] || null;
+    }
+  }
+
+  // Verify we have a token to refresh
+  const tokenToVerify = refreshToken || currentToken;
+  if (!tokenToVerify) {
+    return {
+      response: error('UNAUTHORIZED', 'Token de rafraîchissement requis'),
+      statusCode: 401,
+      headers,
+    };
+  }
+
+  // Validate refresh token if validation function is provided
+  if (validateRefreshToken && refreshToken) {
+    const isValid = await validateRefreshToken(refreshToken);
+    if (!isValid) {
+      return {
+        response: error('INVALID_TOKEN', 'Token de rafraîchissement invalide'),
+        statusCode: 401,
+        headers,
+      };
+    }
+  }
+
+  // Verify the token
+  const payload = await verifyToken(tokenToVerify);
+
+  if (!payload) {
+    return {
+      response: error('TOKEN_EXPIRED', 'Session expirée. Veuillez vous reconnecter'),
+      statusCode: 401,
+      headers,
+    };
+  }
+
+  // Invalidate old refresh token if using token rotation
+  if (invalidateRefreshToken && refreshToken) {
+    await invalidateRefreshToken(refreshToken);
+  }
+
+  // Create new access token
+  const newTokenPayload: Omit<JWTPayload, 'iat' | 'exp'> = {
+    sub: payload.sub,
+    email: payload.email,
+    role: payload.role,
+  };
+
+  const newToken = await createToken(newTokenPayload, {
+    expiresIn: tokenExpiration,
+  });
+
+  // Calculate expiration
+  const expiresIn = parseExpiration(tokenExpiration || '24h');
+  const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+
+  // Build response
+  const responseData: RefreshResponse = {
+    success: true,
+  };
+
+  if (includeTokenInBody) {
+    responseData.token = newToken;
+    responseData.expiresAt = expiresAt;
+  }
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  const cookieOptions = getDefaultAuthCookieOptions(
+    cookieName || 'auth_token',
+    expiresIn,
+    isProduction
+  );
+
+  const result: RefreshResult = {
+    response: responseData,
+    statusCode: 200,
+    headers,
+    cookie: {
+      name: cookieOptions.name,
+      value: newToken,
+      options: {
+        maxAge: cookieOptions.maxAge,
+        httpOnly: cookieOptions.httpOnly,
+        secure: cookieOptions.secure,
+        sameSite: cookieOptions.sameSite,
+        path: cookieOptions.path,
+      },
+    },
+  };
+
+  // Create new refresh token if using separate refresh tokens
+  if (storeRefreshToken) {
+    const newRefreshToken = await createToken(newTokenPayload, {
+      expiresIn: refreshTokenExpiration,
+    });
+
+    await storeRefreshToken(payload.sub, newRefreshToken);
+
+    const refreshExpiresIn = parseExpiration(refreshTokenExpiration || '7d');
+    const refreshCookieOptions = getDefaultAuthCookieOptions(
+      refreshCookieName || 'refresh_token',
+      refreshExpiresIn,
+      isProduction
+    );
+
+    result.refreshCookie = {
+      name: refreshCookieOptions.name,
+      value: newRefreshToken,
+      options: {
+        maxAge: refreshCookieOptions.maxAge,
+        httpOnly: refreshCookieOptions.httpOnly,
+        secure: refreshCookieOptions.secure,
+        sameSite: refreshCookieOptions.sameSite,
+        path: refreshCookieOptions.path,
+      },
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Parse expiration string to seconds
+ */
+function parseExpiration(exp: string): number {
+  const match = exp.match(/^(\d+)([smhd])$/);
+  if (!match) {
+    return 86400; // Default 24 hours
+  }
+
+  const value = parseInt(match[1] || '1', 10);
+  const unit = match[2];
+
+  switch (unit) {
+    case 's':
+      return value;
+    case 'm':
+      return value * 60;
+    case 'h':
+      return value * 3600;
+    case 'd':
+      return value * 86400;
+    default:
+      return 86400;
+  }
+}
+
+/**
+ * Create a refresh handler with preset configuration
+ */
+export function createRefreshHandler(config: RefreshHandlerConfig = {}) {
+  return (request: ApiRequest) => handleRefresh(request, config);
+}

--- a/packages/api/src/handlers/auth/types.ts
+++ b/packages/api/src/handlers/auth/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Auth Handler Types
+ */
+
+import { z } from 'zod';
+
+/**
+ * Login request schema
+ */
+export const loginSchema = z.object({
+  email: z.string().email('Email invalide'),
+  password: z.string().min(1, 'Mot de passe requis'),
+});
+
+export type LoginInput = z.infer<typeof loginSchema>;
+
+/**
+ * Refresh token request schema
+ */
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1, 'Refresh token requis'),
+});
+
+export type RefreshTokenInput = z.infer<typeof refreshTokenSchema>;
+
+/**
+ * Forgot password request schema
+ */
+export const forgotPasswordSchema = z.object({
+  email: z.string().email('Email invalide'),
+});
+
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
+
+/**
+ * Reset password request schema
+ */
+export const resetPasswordSchema = z
+  .object({
+    token: z.string().min(1, 'Token requis'),
+    password: z.string().min(8, 'Le mot de passe doit contenir au moins 8 caractères'),
+    confirmPassword: z.string(),
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: 'Les mots de passe ne correspondent pas',
+    path: ['confirmPassword'],
+  });
+
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
+
+/**
+ * User info returned after successful auth
+ */
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: string;
+}
+
+/**
+ * Login response
+ */
+export interface LoginResponse {
+  success: true;
+  user: AuthUser;
+  token?: string; // Only included if not using httpOnly cookies
+  expiresAt?: string;
+}
+
+/**
+ * Logout response
+ */
+export interface LogoutResponse {
+  success: true;
+  message: string;
+}
+
+/**
+ * Refresh token response
+ */
+export interface RefreshResponse {
+  success: true;
+  token?: string;
+  expiresAt?: string;
+}
+
+/**
+ * Forgot password response
+ */
+export interface ForgotPasswordResponse {
+  success: true;
+  message: string;
+}
+
+/**
+ * Auth handler configuration
+ */
+export interface AuthHandlerConfig {
+  /** Cookie name for auth token */
+  cookieName?: string;
+  /** Token expiration time (e.g., '24h') */
+  tokenExpiration?: string;
+  /** Whether to include token in response body */
+  includeTokenInBody?: boolean;
+  /** Rate limit configuration key */
+  rateLimitKey?: string;
+  /** User lookup function */
+  findUserByEmail: (email: string) => Promise<{
+    id: string;
+    email: string;
+    role: string;
+    passwordHash: string;
+  } | null>;
+  /** Password comparison function */
+  comparePassword: (password: string, hash: string) => Promise<boolean>;
+  /** Function to record failed login attempt */
+  onFailedAttempt?: (email: string, ip: string) => void;
+  /** Function to clear failed attempts after successful login */
+  onSuccessfulLogin?: (email: string, ip: string) => void;
+  /** Function to generate reset token */
+  generateResetToken?: (email: string) => Promise<string>;
+  /** Function to send reset email (returns void, email is sent async) */
+  sendResetEmail?: (email: string, resetToken: string) => Promise<void>;
+}
+
+/**
+ * Cookie options for auth token
+ */
+export interface AuthCookieOptions {
+  name: string;
+  maxAge: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: 'strict' | 'lax' | 'none';
+  path: string;
+  domain?: string;
+}
+
+/**
+ * Get default cookie options for auth
+ */
+export function getDefaultAuthCookieOptions(
+  name: string,
+  maxAge: number,
+  isProduction: boolean
+): AuthCookieOptions {
+  return {
+    name,
+    maxAge,
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'strict',
+    path: '/',
+  };
+}

--- a/packages/api/src/handlers/blog/index.ts
+++ b/packages/api/src/handlers/blog/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Blog Handlers
+ *
+ * Reusable blog API handlers for posts and tags.
+ */
+
+// Types and schemas
+export {
+  blogPostSchema,
+  blogPostUpdateSchema,
+  tagSchema,
+  checkSlugSchema,
+  postsQuerySchema,
+  validateSlug,
+  generateSlug,
+  type PostStatus,
+  type BlogPostInput,
+  type BlogPostUpdateInput,
+  type TagInput,
+  type CheckSlugInput,
+  type PostsQueryParams,
+  type BlogPost,
+  type Tag,
+  type BlogHandlerConfig,
+} from './types';
+
+// Posts handlers
+export {
+  handleGetPosts,
+  handleGetPostBySlug,
+  handleCreatePost,
+  handleUpdatePost,
+  handleDeletePost,
+  handleCheckSlug,
+  createBlogHandlers,
+  type BlogHandlerResult,
+} from './posts';
+
+// Tags handlers
+export {
+  handleGetTags,
+  handleCreateTag,
+  handleUpdateTag,
+  handleDeleteTag,
+  createTagHandlers,
+  type TagHandlerResult,
+} from './tags';

--- a/packages/api/src/handlers/blog/posts.ts
+++ b/packages/api/src/handlers/blog/posts.ts
@@ -1,0 +1,423 @@
+/**
+ * Blog Posts Handler
+ *
+ * CRUD operations for blog posts.
+ */
+
+import type { ApiRequest, AuthContext } from '../../middleware/types';
+import { withBodyValidation, withQueryValidation } from '../../middleware/with-validation';
+import { error, paginated, success } from '../../utils/response';
+
+import {
+  blogPostSchema,
+  blogPostUpdateSchema,
+  postsQuerySchema,
+  validateSlug,
+  type BlogHandlerConfig,
+  type BlogPost,
+} from './types';
+
+/**
+ * Handler result type
+ */
+export interface BlogHandlerResult<T = unknown> {
+  response:
+    | { success: true; data: T; pagination?: unknown }
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Get all blog posts with filtering and pagination
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns List of posts with pagination
+ */
+export async function handleGetPosts(
+  request: ApiRequest,
+  config: BlogHandlerConfig
+): Promise<BlogHandlerResult<BlogPost[]>> {
+  const { getAllPosts, siteId: configSiteId } = config;
+
+  // Parse query parameters
+  const queryResult = withQueryValidation(request, postsQuerySchema);
+
+  if (!queryResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Paramètres de requête invalides', {
+        details: queryResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const {
+    page,
+    limit,
+    status,
+    category,
+    tag,
+    featured,
+    search,
+    includeUnpublished,
+    featuredFirst,
+    siteId: querySiteId,
+  } = queryResult.query;
+
+  try {
+    const { posts, total } = await getAllPosts({
+      page,
+      limit,
+      status,
+      category,
+      tag,
+      featured,
+      search,
+      includeUnpublished,
+      featuredFirst,
+      siteId: querySiteId || configSiteId,
+    });
+
+    // Cache strategy based on context
+    const cacheControl = includeUnpublished
+      ? 'private, no-cache, no-store, must-revalidate'
+      : 'public, max-age=300, stale-while-revalidate=3600';
+
+    return {
+      response: paginated(posts, { page, limit, total }),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': cacheControl,
+      },
+    };
+  } catch (e) {
+    console.error('Error fetching posts:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des articles'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Get a single blog post by slug
+ *
+ * @param slug - The post slug
+ * @param config - Handler configuration
+ * @returns The post or error
+ */
+export async function handleGetPostBySlug(
+  slug: string,
+  config: BlogHandlerConfig
+): Promise<BlogHandlerResult<BlogPost>> {
+  const { getPostBySlug, siteId } = config;
+
+  try {
+    const post = await getPostBySlug(slug, siteId);
+
+    if (!post) {
+      return {
+        response: error('NOT_FOUND', 'Article non trouvé'),
+        statusCode: 404,
+        headers: {},
+      };
+    }
+
+    // Only published posts are cached publicly
+    const cacheControl =
+      post.status === 'published'
+        ? 'public, max-age=300, stale-while-revalidate=3600'
+        : 'private, no-cache';
+
+    return {
+      response: success(post),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': cacheControl,
+      },
+    };
+  } catch (e) {
+    console.error('Error fetching post:', e);
+    return {
+      response: error('INTERNAL_ERROR', "Erreur lors de la récupération de l'article"),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create a new blog post (requires admin)
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @param _authContext - Auth context (for future use)
+ * @returns The created post
+ */
+export async function handleCreatePost(
+  request: ApiRequest,
+  config: BlogHandlerConfig,
+  _authContext?: AuthContext
+): Promise<BlogHandlerResult<BlogPost>> {
+  const { createPost, slugExists, siteId, onCacheRevalidate } = config;
+
+  // Validate request body
+  const bodyResult = await withBodyValidation(request, blogPostSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  // Validate slug format
+  const slugValidation = validateSlug(data.slug);
+  if (!slugValidation.valid) {
+    return {
+      response: error('VALIDATION_ERROR', slugValidation.error || 'Slug invalide'),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  // Check if slug already exists
+  const exists = await slugExists(data.slug, undefined, siteId);
+  if (exists) {
+    return {
+      response: error('CONFLICT', 'Un article avec ce slug existe déjà'),
+      statusCode: 409,
+      headers: {},
+    };
+  }
+
+  try {
+    // Add siteId if configured
+    const postData = siteId ? { ...data, siteId } : data;
+    const post = await createPost(postData);
+
+    // Invalidate cache
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/blog/posts', '/blog', `/blog/${post.slug}`, '/']);
+    }
+
+    return {
+      response: success(post),
+      statusCode: 201,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error creating post:', e);
+    const message = e instanceof Error ? e.message : 'Erreur lors de la création';
+
+    return {
+      response: error('INTERNAL_ERROR', message),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Update a blog post (requires admin)
+ *
+ * @param postId - The post ID
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @param _authContext - Auth context (for future use)
+ * @returns The updated post
+ */
+export async function handleUpdatePost(
+  postId: string,
+  request: ApiRequest,
+  config: BlogHandlerConfig,
+  _authContext?: AuthContext
+): Promise<BlogHandlerResult<BlogPost>> {
+  const { getPostById, updatePost, onCacheRevalidate } = config;
+
+  // Validate request body
+  const bodyResult = await withBodyValidation(request, blogPostUpdateSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  // Check if post exists
+  const existingPost = await getPostById(postId);
+  if (!existingPost) {
+    return {
+      response: error('NOT_FOUND', 'Article non trouvé'),
+      statusCode: 404,
+      headers: {},
+    };
+  }
+
+  try {
+    const post = await updatePost(postId, data);
+
+    // Invalidate cache
+    if (onCacheRevalidate) {
+      await onCacheRevalidate([
+        '/api/blog/posts',
+        '/blog',
+        `/blog/${existingPost.slug}`,
+        `/blog/${post.slug}`,
+        '/',
+      ]);
+    }
+
+    return {
+      response: success(post),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error updating post:', e);
+    const message = e instanceof Error ? e.message : 'Erreur lors de la mise à jour';
+
+    return {
+      response: error('INTERNAL_ERROR', message),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Delete a blog post (requires admin)
+ *
+ * @param postId - The post ID
+ * @param config - Handler configuration
+ * @param _authContext - Auth context (for future use)
+ * @returns Success response
+ */
+export async function handleDeletePost(
+  postId: string,
+  config: BlogHandlerConfig,
+  _authContext?: AuthContext
+): Promise<BlogHandlerResult<{ deleted: boolean }>> {
+  const { getPostById, deletePost, onCacheRevalidate } = config;
+
+  // Check if post exists
+  const existingPost = await getPostById(postId);
+  if (!existingPost) {
+    return {
+      response: error('NOT_FOUND', 'Article non trouvé'),
+      statusCode: 404,
+      headers: {},
+    };
+  }
+
+  try {
+    await deletePost(postId);
+
+    // Invalidate cache
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/blog/posts', '/blog', `/blog/${existingPost.slug}`, '/']);
+    }
+
+    return {
+      response: success({ deleted: true }),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error deleting post:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la suppression'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Check if a slug is available
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Availability result
+ */
+export async function handleCheckSlug(
+  request: ApiRequest,
+  config: BlogHandlerConfig
+): Promise<BlogHandlerResult<{ available: boolean; suggestion?: string }>> {
+  const { slugExists, siteId } = config;
+
+  let slug: string;
+  let excludeId: string | undefined;
+
+  try {
+    const body = (await request.json()) as { slug?: string; excludeId?: string };
+    slug = body.slug || '';
+    excludeId = body.excludeId;
+  } catch {
+    return {
+      response: error('VALIDATION_ERROR', 'Body JSON invalide'),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  // Validate slug format
+  const slugValidation = validateSlug(slug);
+  if (!slugValidation.valid) {
+    return {
+      response: success({ available: false, suggestion: undefined }),
+      statusCode: 200,
+      headers: {},
+    };
+  }
+
+  const exists = await slugExists(slug, excludeId, siteId);
+
+  if (exists) {
+    // Generate a suggestion
+    const suggestion = `${slug}-${Date.now().toString(36)}`;
+    return {
+      response: success({ available: false, suggestion }),
+      statusCode: 200,
+      headers: {},
+    };
+  }
+
+  return {
+    response: success({ available: true }),
+    statusCode: 200,
+    headers: {},
+  };
+}
+
+/**
+ * Create blog handlers with preset configuration
+ */
+export function createBlogHandlers(config: BlogHandlerConfig) {
+  return {
+    getPosts: (request: ApiRequest) => handleGetPosts(request, config),
+    getPostBySlug: (slug: string) => handleGetPostBySlug(slug, config),
+    createPost: (request: ApiRequest, authContext?: AuthContext) =>
+      handleCreatePost(request, config, authContext),
+    updatePost: (postId: string, request: ApiRequest, authContext?: AuthContext) =>
+      handleUpdatePost(postId, request, config, authContext),
+    deletePost: (postId: string, authContext?: AuthContext) =>
+      handleDeletePost(postId, config, authContext),
+    checkSlug: (request: ApiRequest) => handleCheckSlug(request, config),
+  };
+}

--- a/packages/api/src/handlers/blog/tags.ts
+++ b/packages/api/src/handlers/blog/tags.ts
@@ -1,0 +1,275 @@
+/**
+ * Blog Tags Handler
+ *
+ * CRUD operations for blog tags.
+ */
+
+import type { ApiRequest, AuthContext } from '../../middleware/types';
+import { withBodyValidation } from '../../middleware/with-validation';
+import { error, success } from '../../utils/response';
+
+import { tagSchema, type BlogHandlerConfig, type Tag, type TagInput } from './types';
+
+/**
+ * Handler result type
+ */
+export interface TagHandlerResult<T = unknown> {
+  response:
+    | { success: true; data: T }
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Get all tags
+ *
+ * @param config - Handler configuration
+ * @returns List of tags
+ */
+export async function handleGetTags(config: BlogHandlerConfig): Promise<TagHandlerResult<Tag[]>> {
+  const { getAllTags, siteId } = config;
+
+  if (!getAllTags) {
+    return {
+      response: error('NOT_IMPLEMENTED', 'Tags non supportés'),
+      statusCode: 501,
+      headers: {},
+    };
+  }
+
+  try {
+    const tags = await getAllTags(siteId);
+
+    return {
+      response: success(tags),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    };
+  } catch (e) {
+    console.error('Error fetching tags:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des tags'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create a new tag (requires admin)
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @param _authContext - Auth context (for future use)
+ * @returns The created tag
+ */
+export async function handleCreateTag(
+  request: ApiRequest,
+  config: BlogHandlerConfig,
+  _authContext?: AuthContext
+): Promise<TagHandlerResult<Tag>> {
+  const { createTag, onCacheRevalidate } = config;
+
+  if (!createTag) {
+    return {
+      response: error('NOT_IMPLEMENTED', 'Création de tags non supportée'),
+      statusCode: 501,
+      headers: {},
+    };
+  }
+
+  // Validate request body
+  const bodyResult = await withBodyValidation(request, tagSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  try {
+    const tag = await createTag(data);
+
+    // Invalidate cache
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/blog/tags']);
+    }
+
+    return {
+      response: success(tag),
+      statusCode: 201,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error creating tag:', e);
+    const message = e instanceof Error ? e.message : 'Erreur lors de la création';
+
+    // Check for duplicate error
+    if (message.includes('existe déjà') || message.includes('duplicate')) {
+      return {
+        response: error('CONFLICT', 'Un tag avec ce nom ou slug existe déjà'),
+        statusCode: 409,
+        headers: {},
+      };
+    }
+
+    return {
+      response: error('INTERNAL_ERROR', message),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Update a tag (requires admin)
+ *
+ * @param tagId - The tag ID
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @param _authContext - Auth context (for future use)
+ * @returns The updated tag
+ */
+export async function handleUpdateTag(
+  tagId: string,
+  request: ApiRequest,
+  config: BlogHandlerConfig,
+  _authContext?: AuthContext
+): Promise<TagHandlerResult<Tag>> {
+  const { updateTag, onCacheRevalidate } = config;
+
+  if (!updateTag) {
+    return {
+      response: error('NOT_IMPLEMENTED', 'Mise à jour de tags non supportée'),
+      statusCode: 501,
+      headers: {},
+    };
+  }
+
+  // Validate request body (partial schema)
+  const bodyResult = await withBodyValidation(request, tagSchema.partial());
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body as Partial<TagInput>;
+
+  try {
+    const tag = await updateTag(tagId, data);
+
+    // Invalidate cache
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/blog/tags']);
+    }
+
+    return {
+      response: success(tag),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error updating tag:', e);
+    const message = e instanceof Error ? e.message : 'Erreur lors de la mise à jour';
+
+    if (message.includes('not found') || message.includes('introuvable')) {
+      return {
+        response: error('NOT_FOUND', 'Tag non trouvé'),
+        statusCode: 404,
+        headers: {},
+      };
+    }
+
+    return {
+      response: error('INTERNAL_ERROR', message),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Delete a tag (requires admin)
+ *
+ * @param tagId - The tag ID
+ * @param config - Handler configuration
+ * @param _authContext - Auth context (for future use)
+ * @returns Success response
+ */
+export async function handleDeleteTag(
+  tagId: string,
+  config: BlogHandlerConfig,
+  _authContext?: AuthContext
+): Promise<TagHandlerResult<{ deleted: boolean }>> {
+  const { deleteTag, onCacheRevalidate } = config;
+
+  if (!deleteTag) {
+    return {
+      response: error('NOT_IMPLEMENTED', 'Suppression de tags non supportée'),
+      statusCode: 501,
+      headers: {},
+    };
+  }
+
+  try {
+    await deleteTag(tagId);
+
+    // Invalidate cache
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/blog/tags']);
+    }
+
+    return {
+      response: success({ deleted: true }),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error deleting tag:', e);
+    const message = e instanceof Error ? e.message : 'Erreur lors de la suppression';
+
+    if (message.includes('not found') || message.includes('introuvable')) {
+      return {
+        response: error('NOT_FOUND', 'Tag non trouvé'),
+        statusCode: 404,
+        headers: {},
+      };
+    }
+
+    return {
+      response: error('INTERNAL_ERROR', message),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create tag handlers with preset configuration
+ */
+export function createTagHandlers(config: BlogHandlerConfig) {
+  return {
+    getTags: () => handleGetTags(config),
+    createTag: (request: ApiRequest, authContext?: AuthContext) =>
+      handleCreateTag(request, config, authContext),
+    updateTag: (tagId: string, request: ApiRequest, authContext?: AuthContext) =>
+      handleUpdateTag(tagId, request, config, authContext),
+    deleteTag: (tagId: string, authContext?: AuthContext) =>
+      handleDeleteTag(tagId, config, authContext),
+  };
+}

--- a/packages/api/src/handlers/blog/types.ts
+++ b/packages/api/src/handlers/blog/types.ts
@@ -1,0 +1,205 @@
+/**
+ * Blog Handler Types
+ */
+
+import { z } from 'zod';
+
+/**
+ * Blog post status
+ */
+export type PostStatus = 'draft' | 'published' | 'archived';
+
+/**
+ * Blog post schema for creation/update
+ */
+export const blogPostSchema = z.object({
+  title: z.string().min(1, 'Le titre est requis').max(200),
+  slug: z
+    .string()
+    .min(1, 'Le slug est requis')
+    .max(200)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Le slug doit être en minuscules avec des tirets'),
+  content: z.string().min(1, 'Le contenu est requis'),
+  excerpt: z.string().max(500).optional(),
+  coverImage: z.string().url().optional().nullable(),
+  category: z.string().max(100).optional(),
+  tags: z.array(z.string()).default([]),
+  status: z.enum(['draft', 'published', 'archived']).default('draft'),
+  featured: z.boolean().default(false),
+  publishedAt: z.string().datetime().optional().nullable(),
+  metaTitle: z.string().max(70).optional(),
+  metaDescription: z.string().max(160).optional(),
+  siteId: z.string().optional(), // For multi-tenant support
+});
+
+export type BlogPostInput = z.infer<typeof blogPostSchema>;
+
+/**
+ * Blog post update schema (all fields optional)
+ */
+export const blogPostUpdateSchema = blogPostSchema.partial().omit({ slug: true });
+
+export type BlogPostUpdateInput = z.infer<typeof blogPostUpdateSchema>;
+
+/**
+ * Blog tag schema
+ */
+export const tagSchema = z.object({
+  name: z.string().min(1, 'Le nom du tag est requis').max(50),
+  slug: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Le slug doit être en minuscules avec des tirets'),
+  description: z.string().max(200).optional(),
+});
+
+export type TagInput = z.infer<typeof tagSchema>;
+
+/**
+ * Check slug schema
+ */
+export const checkSlugSchema = z.object({
+  slug: z.string().min(1).max(200),
+  excludeId: z.string().optional(), // Exclude current post when updating
+});
+
+export type CheckSlugInput = z.infer<typeof checkSlugSchema>;
+
+/**
+ * Blog post list query params
+ */
+export const postsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  status: z.enum(['draft', 'published', 'archived', 'all']).optional(),
+  category: z.string().optional(),
+  tag: z.string().optional(),
+  featured: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform(v => (v === 'true' ? true : v === 'false' ? false : undefined)),
+  search: z.string().max(200).optional(),
+  includeUnpublished: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform(v => v === 'true'),
+  featuredFirst: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform(v => v === 'true'),
+  siteId: z.string().optional(),
+});
+
+export type PostsQueryParams = z.infer<typeof postsQuerySchema>;
+
+/**
+ * Blog post returned from API
+ */
+export interface BlogPost {
+  id: string;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt?: string | null;
+  coverImage?: string | null;
+  category?: string | null;
+  tags: string[];
+  status: PostStatus;
+  featured: boolean;
+  publishedAt?: string | null;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  readingTime?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Tag returned from API
+ */
+export interface Tag {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string | null;
+  postCount?: number;
+}
+
+/**
+ * Blog handler configuration
+ */
+export interface BlogHandlerConfig {
+  /** Site ID for multi-tenant filtering */
+  siteId?: string;
+  /** Function to get all posts */
+  getAllPosts: (options: {
+    page?: number;
+    limit?: number;
+    status?: string;
+    category?: string;
+    tag?: string;
+    featured?: boolean;
+    search?: string;
+    includeUnpublished?: boolean;
+    featuredFirst?: boolean;
+    siteId?: string;
+  }) => Promise<{ posts: BlogPost[]; total: number }>;
+  /** Function to get post by slug */
+  getPostBySlug: (slug: string, siteId?: string) => Promise<BlogPost | null>;
+  /** Function to get post by ID */
+  getPostById: (id: string) => Promise<BlogPost | null>;
+  /** Function to create a post */
+  createPost: (data: BlogPostInput) => Promise<BlogPost>;
+  /** Function to update a post */
+  updatePost: (id: string, data: BlogPostUpdateInput) => Promise<BlogPost>;
+  /** Function to delete a post */
+  deletePost: (id: string) => Promise<void>;
+  /** Function to check if slug exists */
+  slugExists: (slug: string, excludeId?: string, siteId?: string) => Promise<boolean>;
+  /** Function to get all tags */
+  getAllTags?: (siteId?: string) => Promise<Tag[]>;
+  /** Function to create a tag */
+  createTag?: (data: TagInput) => Promise<Tag>;
+  /** Function to update a tag */
+  updateTag?: (id: string, data: Partial<TagInput>) => Promise<Tag>;
+  /** Function to delete a tag */
+  deleteTag?: (id: string) => Promise<void>;
+  /** Cache revalidation callback */
+  onCacheRevalidate?: (paths: string[]) => Promise<void>;
+}
+
+/**
+ * Validate slug format
+ */
+export function validateSlug(slug: string): { valid: boolean; error?: string } {
+  if (!slug) {
+    return { valid: false, error: 'Le slug est requis' };
+  }
+
+  if (slug.length > 200) {
+    return { valid: false, error: 'Le slug ne doit pas dépasser 200 caractères' };
+  }
+
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+    return {
+      valid: false,
+      error: 'Le slug doit être en minuscules, avec uniquement des lettres, chiffres et tirets',
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Generate slug from title
+ */
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // Remove accents
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 200);
+}

--- a/packages/api/src/handlers/contact/index.ts
+++ b/packages/api/src/handlers/contact/index.ts
@@ -1,0 +1,308 @@
+/**
+ * Contact Form Handler
+ *
+ * Handles contact form submissions with CSRF, rate limiting, and honeypot protection.
+ */
+
+import { z } from 'zod';
+
+import type { ApiRequest } from '../../middleware/types';
+import { withCSRF } from '../../middleware/with-csrf';
+import { getClientIP, withRateLimit } from '../../middleware/with-rate-limit';
+import { withBodyValidation } from '../../middleware/with-validation';
+import { error } from '../../utils/response';
+
+/**
+ * Contact form schema
+ */
+export const contactSchema = z.object({
+  name: z.string().trim().min(2, 'Le nom doit contenir au moins 2 caractères').max(100),
+  email: z.string().email('Email invalide').max(255),
+  message: z.string().trim().min(10, 'Le message doit contenir au moins 10 caractères').max(5000),
+  phone: z.string().max(20).optional(),
+  subject: z.string().max(200).optional(),
+  meta: z
+    .object({
+      honeypot: z
+        .string()
+        .optional()
+        .transform(value => value?.trim() ?? ''),
+      submitted_at: z.string().optional(),
+      source_page: z.string().optional(),
+    })
+    .default({ honeypot: '', submitted_at: undefined, source_page: undefined }),
+});
+
+export type ContactInput = z.infer<typeof contactSchema>;
+
+/**
+ * Contact handler configuration
+ */
+export interface ContactHandlerConfig {
+  /** Enable CSRF protection */
+  csrfEnabled?: boolean;
+  /** Rate limit (requests per hour) */
+  rateLimitPerHour?: number;
+  /** Function to send email to recipient */
+  sendEmail: (data: {
+    to: string;
+    subject: string;
+    text: string;
+    html: string;
+    replyTo?: string;
+  }) => Promise<void>;
+  /** Recipient email */
+  recipient: string;
+  /** From email address */
+  fromAddress?: string;
+  /** Send confirmation to user */
+  sendConfirmation?: boolean;
+  /** Custom confirmation message */
+  confirmationSubject?: string;
+  confirmationText?: string;
+  confirmationHtml?: string;
+  /** Site name for emails */
+  siteName?: string;
+}
+
+/**
+ * Contact handler result
+ */
+export interface ContactResult {
+  response:
+    | { success: true }
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Escape HTML for XSS prevention
+ */
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Format email content
+ */
+function formatEmailContent(
+  payload: ContactInput,
+  siteName: string
+): { subject: string; text: string; html: string } {
+  const submittedAtRaw = payload.meta.submitted_at ? new Date(payload.meta.submitted_at) : null;
+  const submittedAtIso =
+    submittedAtRaw && !Number.isNaN(submittedAtRaw.getTime())
+      ? submittedAtRaw.toISOString()
+      : 'Non précisé';
+
+  const text =
+    `Nouveau message via le formulaire de contact ${siteName}\n\n` +
+    `Nom : ${payload.name}\n` +
+    `Email : ${payload.email}\n` +
+    (payload.phone ? `Téléphone : ${payload.phone}\n` : '') +
+    (payload.subject ? `Sujet : ${payload.subject}\n` : '') +
+    `Message :\n${payload.message}\n\n` +
+    `Soumis le : ${submittedAtIso}\n`;
+
+  const escapedName = escapeHtml(payload.name);
+  const escapedEmail = escapeHtml(payload.email);
+  const escapedMessage = escapeHtml(payload.message).replace(/\n/g, '<br />');
+  const escapedSubmittedAt = escapeHtml(submittedAtIso);
+  const escapedPhone = payload.phone ? escapeHtml(payload.phone) : null;
+  const escapedSubject = payload.subject ? escapeHtml(payload.subject) : null;
+
+  const html =
+    `<!doctype html><html lang="fr"><body style="font-family:Arial,Helvetica,sans-serif;line-height:1.6;color:#0b0b0d;">` +
+    `<h2>Nouveau message via le formulaire de contact ${siteName}</h2>` +
+    `<p><strong>Nom :</strong> ${escapedName}</p>` +
+    `<p><strong>Email :</strong> ${escapedEmail}</p>` +
+    (escapedPhone ? `<p><strong>Téléphone :</strong> ${escapedPhone}</p>` : '') +
+    (escapedSubject ? `<p><strong>Sujet :</strong> ${escapedSubject}</p>` : '') +
+    `<p><strong>Message :</strong><br />${escapedMessage}</p>` +
+    `<p><strong>Soumis le :</strong> ${escapedSubmittedAt}</p>` +
+    `</body></html>`;
+
+  return {
+    subject: payload.subject
+      ? `[${siteName}] ${payload.subject}`
+      : `Nouveau message de contact ${siteName}`,
+    text,
+    html,
+  };
+}
+
+/**
+ * Handle contact form submission
+ *
+ * @param request - The incoming request
+ * @param config - Handler configuration
+ * @returns Contact result
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const result = await handleContact(request, {
+ *     recipient: 'contact@mysite.com',
+ *     siteName: 'My Site',
+ *     sendEmail: async ({ to, subject, text, html, replyTo }) => {
+ *       await resend.emails.send({
+ *         from: 'My Site <no-reply@mysite.com>',
+ *         to: [to],
+ *         reply_to: replyTo ? [replyTo] : undefined,
+ *         subject,
+ *         text,
+ *         html,
+ *       });
+ *     },
+ *   });
+ *
+ *   return NextResponse.json(result.response, {
+ *     status: result.statusCode,
+ *     headers: result.headers,
+ *   });
+ * }
+ * ```
+ */
+export async function handleContact(
+  request: ApiRequest,
+  config: ContactHandlerConfig
+): Promise<ContactResult> {
+  const {
+    csrfEnabled = true,
+    rateLimitPerHour = 5,
+    sendEmail,
+    recipient,
+    sendConfirmation = true,
+    confirmationSubject,
+    confirmationText,
+    confirmationHtml,
+    siteName = 'Site',
+  } = config;
+
+  const clientIP = getClientIP(request);
+  const headers: Record<string, string> = {};
+
+  // Rate limiting
+  const rateLimitResult = await withRateLimit(request, {
+    windowMs: 60 * 60 * 1000, // 1 hour
+    maxRequests: rateLimitPerHour,
+    keyGenerator: () => `contact:${clientIP}`,
+  });
+
+  Object.assign(headers, rateLimitResult.headers);
+
+  if (!rateLimitResult.success) {
+    return {
+      response: error(
+        'TOO_MANY_REQUESTS',
+        'Trop de tentatives. Veuillez réessayer dans quelques instants.',
+        {
+          retryAfter: rateLimitResult.error.details?.retryAfter,
+        }
+      ),
+      statusCode: 429,
+      headers: {
+        ...headers,
+        'Retry-After': String(rateLimitResult.error.details?.retryAfter || 3600),
+      },
+    };
+  }
+
+  // CSRF validation
+  if (csrfEnabled) {
+    const csrfResult = await withCSRF(request);
+    if (!csrfResult.success) {
+      return {
+        response: error(csrfResult.error.code, csrfResult.error.message),
+        statusCode: csrfResult.error.statusCode,
+        headers,
+      };
+    }
+  }
+
+  // Validate body
+  const bodyResult = await withBodyValidation(request, contactSchema);
+
+  if (!bodyResult.success) {
+    // Generic error message to not reveal validation details
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides.'),
+      statusCode: 400,
+      headers,
+    };
+  }
+
+  const payload = bodyResult.body;
+
+  // Check honeypot (bot detection)
+  if (payload.meta.honeypot) {
+    // Silently succeed for bots
+    return {
+      response: { success: true },
+      statusCode: 200,
+      headers,
+    };
+  }
+
+  // Format email content
+  const emailContent = formatEmailContent(payload, siteName);
+
+  try {
+    // Send main email
+    await sendEmail({
+      to: recipient,
+      subject: emailContent.subject,
+      text: emailContent.text,
+      html: emailContent.html,
+      replyTo: payload.email,
+    });
+
+    // Send confirmation to user
+    if (sendConfirmation) {
+      try {
+        await sendEmail({
+          to: payload.email,
+          subject: confirmationSubject || 'Votre message a bien été reçu',
+          text:
+            confirmationText ||
+            `Bonjour,\n\nMerci pour votre message. Nous vous répondons dans les plus brefs délais.\n\nBien à vous,\n${siteName}`,
+          html:
+            confirmationHtml ||
+            `<!doctype html><html lang="fr"><body style="font-family:Arial,Helvetica,sans-serif;line-height:1.6;color:#0b0b0d;"><p>Bonjour,</p><p>Merci pour votre message. Nous vous répondons dans les plus brefs délais.</p><p>Bien à vous,<br />${siteName}</p></body></html>`,
+        });
+      } catch (confirmationError) {
+        console.error('Failed to send confirmation email:', confirmationError);
+        // Don't fail the main request if confirmation fails
+      }
+    }
+
+    return {
+      response: { success: true },
+      statusCode: 200,
+      headers,
+    };
+  } catch (e) {
+    console.error('Failed to send contact email:', e);
+    return {
+      response: error(
+        'INTERNAL_ERROR',
+        'Une erreur est survenue. Veuillez réessayer dans quelques instants.'
+      ),
+      statusCode: 500,
+      headers,
+    };
+  }
+}
+
+/**
+ * Create contact handler with preset configuration
+ */
+export function createContactHandler(config: ContactHandlerConfig) {
+  return (request: ApiRequest) => handleContact(request, config);
+}

--- a/packages/api/src/handlers/seminars/index.ts
+++ b/packages/api/src/handlers/seminars/index.ts
@@ -1,0 +1,539 @@
+/**
+ * Seminars Handler
+ *
+ * CRUD operations for seminars/events.
+ */
+
+import { z } from 'zod';
+
+import type { ApiRequest, AuthContext } from '../../middleware/types';
+import { withBodyValidation, withQueryValidation } from '../../middleware/with-validation';
+import { error, paginated, success } from '../../utils/response';
+
+/**
+ * Seminar status
+ */
+export type SeminarStatus = 'draft' | 'published' | 'cancelled' | 'completed';
+
+/**
+ * Seminar schema
+ */
+export const seminarSchema = z.object({
+  title: z.string().min(1, 'Le titre est requis').max(200),
+  slug: z
+    .string()
+    .min(1)
+    .max(200)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Le slug doit être en minuscules avec des tirets'),
+  description: z.string().min(10, 'La description doit contenir au moins 10 caractères').max(5000),
+  shortDescription: z.string().max(500).optional(),
+  coverImage: z.string().url().optional().nullable(),
+  date: z.string().datetime(),
+  endDate: z.string().datetime().optional(),
+  location: z.string().max(200).optional(),
+  locationAddress: z.string().max(500).optional(),
+  isOnline: z.boolean().default(false),
+  onlineUrl: z.string().url().optional().nullable(),
+  maxParticipants: z.number().int().min(1).optional(),
+  price: z.number().min(0).optional(),
+  currency: z.string().length(3).default('EUR'),
+  status: z.enum(['draft', 'published', 'cancelled', 'completed']).default('draft'),
+  featured: z.boolean().default(false),
+  tags: z.array(z.string()).default([]),
+  siteId: z.string().optional(),
+});
+
+export type SeminarInput = z.infer<typeof seminarSchema>;
+
+/**
+ * Seminar update schema
+ */
+export const seminarUpdateSchema = seminarSchema.partial().omit({ slug: true });
+
+export type SeminarUpdateInput = z.infer<typeof seminarUpdateSchema>;
+
+/**
+ * Registration schema
+ */
+export const registrationSchema = z.object({
+  seminarId: z.string(),
+  firstName: z.string().min(1).max(100),
+  lastName: z.string().min(1).max(100),
+  email: z.string().email().max(255),
+  phone: z.string().max(20).optional(),
+  company: z.string().max(100).optional(),
+  message: z.string().max(1000).optional(),
+});
+
+export type RegistrationInput = z.infer<typeof registrationSchema>;
+
+/**
+ * Seminar list query params
+ */
+export const seminarsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  status: z.enum(['draft', 'published', 'cancelled', 'completed', 'all']).optional(),
+  upcoming: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform(v => v === 'true'),
+  featured: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform(v => (v === 'true' ? true : v === 'false' ? false : undefined)),
+  tag: z.string().optional(),
+  siteId: z.string().optional(),
+});
+
+export type SeminarsQueryParams = z.infer<typeof seminarsQuerySchema>;
+
+/**
+ * Seminar returned from API
+ */
+export interface Seminar {
+  id: string;
+  title: string;
+  slug: string;
+  description: string;
+  shortDescription?: string | null;
+  coverImage?: string | null;
+  date: string;
+  endDate?: string | null;
+  location?: string | null;
+  locationAddress?: string | null;
+  isOnline: boolean;
+  onlineUrl?: string | null;
+  maxParticipants?: number | null;
+  currentParticipants?: number;
+  price?: number | null;
+  currency: string;
+  status: SeminarStatus;
+  featured: boolean;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Registration returned from API
+ */
+export interface Registration {
+  id: string;
+  seminarId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string | null;
+  company?: string | null;
+  message?: string | null;
+  status: 'pending' | 'confirmed' | 'cancelled';
+  createdAt: string;
+}
+
+/**
+ * Seminars handler configuration
+ */
+export interface SeminarsHandlerConfig {
+  /** Site ID for multi-tenant filtering */
+  siteId?: string;
+  /** Function to get all seminars */
+  getAllSeminars: (options: {
+    page?: number;
+    limit?: number;
+    status?: string;
+    upcoming?: boolean;
+    featured?: boolean;
+    tag?: string;
+    siteId?: string;
+  }) => Promise<{ seminars: Seminar[]; total: number }>;
+  /** Function to get seminar by slug */
+  getSeminarBySlug: (slug: string, siteId?: string) => Promise<Seminar | null>;
+  /** Function to get seminar by ID */
+  getSeminarById: (id: string) => Promise<Seminar | null>;
+  /** Function to create a seminar */
+  createSeminar: (data: SeminarInput) => Promise<Seminar>;
+  /** Function to update a seminar */
+  updateSeminar: (id: string, data: SeminarUpdateInput) => Promise<Seminar>;
+  /** Function to delete a seminar */
+  deleteSeminar: (id: string) => Promise<void>;
+  /** Function to check if slug exists */
+  slugExists: (slug: string, excludeId?: string, siteId?: string) => Promise<boolean>;
+  /** Function to create a registration */
+  createRegistration?: (data: RegistrationInput) => Promise<Registration>;
+  /** Function to get registrations for a seminar */
+  getRegistrations?: (seminarId: string) => Promise<Registration[]>;
+  /** Send confirmation email for registration */
+  sendRegistrationConfirmation?: (registration: Registration, seminar: Seminar) => Promise<void>;
+  /** Cache revalidation callback */
+  onCacheRevalidate?: (paths: string[]) => Promise<void>;
+}
+
+/**
+ * Handler result type
+ */
+export interface SeminarHandlerResult<T = unknown> {
+  response:
+    | { success: true; data: T; pagination?: unknown }
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Get all seminars with filtering and pagination
+ */
+export async function handleGetSeminars(
+  request: ApiRequest,
+  config: SeminarsHandlerConfig
+): Promise<SeminarHandlerResult<Seminar[]>> {
+  const { getAllSeminars, siteId: configSiteId } = config;
+
+  const queryResult = withQueryValidation(request, seminarsQuerySchema);
+
+  if (!queryResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Paramètres de requête invalides'),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const { page, limit, status, upcoming, featured, tag, siteId: querySiteId } = queryResult.query;
+
+  try {
+    const { seminars, total } = await getAllSeminars({
+      page,
+      limit,
+      status,
+      upcoming,
+      featured,
+      tag,
+      siteId: querySiteId || configSiteId,
+    });
+
+    // Public seminars (published) can be cached
+    const isPublic = status === 'published' || upcoming;
+    const cacheControl = isPublic
+      ? 'public, max-age=300, stale-while-revalidate=3600'
+      : 'private, no-cache';
+
+    return {
+      response: paginated(seminars, { page, limit, total }),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': cacheControl,
+      },
+    };
+  } catch (e) {
+    console.error('Error fetching seminars:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des séminaires'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Get a single seminar by slug
+ */
+export async function handleGetSeminarBySlug(
+  slug: string,
+  config: SeminarsHandlerConfig
+): Promise<SeminarHandlerResult<Seminar>> {
+  const { getSeminarBySlug, siteId } = config;
+
+  try {
+    const seminar = await getSeminarBySlug(slug, siteId);
+
+    if (!seminar) {
+      return {
+        response: error('NOT_FOUND', 'Séminaire non trouvé'),
+        statusCode: 404,
+        headers: {},
+      };
+    }
+
+    const cacheControl =
+      seminar.status === 'published'
+        ? 'public, max-age=300, stale-while-revalidate=3600'
+        : 'private, no-cache';
+
+    return {
+      response: success(seminar),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': cacheControl,
+      },
+    };
+  } catch (e) {
+    console.error('Error fetching seminar:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération du séminaire'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create a new seminar (requires admin)
+ */
+export async function handleCreateSeminar(
+  request: ApiRequest,
+  config: SeminarsHandlerConfig,
+  _authContext?: AuthContext
+): Promise<SeminarHandlerResult<Seminar>> {
+  const { createSeminar, slugExists, siteId, onCacheRevalidate } = config;
+
+  const bodyResult = await withBodyValidation(request, seminarSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  // Check if slug already exists
+  const exists = await slugExists(data.slug, undefined, siteId);
+  if (exists) {
+    return {
+      response: error('CONFLICT', 'Un séminaire avec ce slug existe déjà'),
+      statusCode: 409,
+      headers: {},
+    };
+  }
+
+  try {
+    const seminarData = siteId ? { ...data, siteId } : data;
+    const seminar = await createSeminar(seminarData);
+
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/seminars', `/seminars/${seminar.slug}`]);
+    }
+
+    return {
+      response: success(seminar),
+      statusCode: 201,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error creating seminar:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la création du séminaire'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Update a seminar (requires admin)
+ */
+export async function handleUpdateSeminar(
+  id: string,
+  request: ApiRequest,
+  config: SeminarsHandlerConfig,
+  _authContext?: AuthContext
+): Promise<SeminarHandlerResult<Seminar>> {
+  const { getSeminarById, updateSeminar, onCacheRevalidate } = config;
+
+  const bodyResult = await withBodyValidation(request, seminarUpdateSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  const existing = await getSeminarById(id);
+  if (!existing) {
+    return {
+      response: error('NOT_FOUND', 'Séminaire non trouvé'),
+      statusCode: 404,
+      headers: {},
+    };
+  }
+
+  try {
+    const seminar = await updateSeminar(id, data);
+
+    if (onCacheRevalidate) {
+      await onCacheRevalidate([
+        '/api/seminars',
+        `/seminars/${existing.slug}`,
+        `/seminars/${seminar.slug}`,
+      ]);
+    }
+
+    return {
+      response: success(seminar),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error updating seminar:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la mise à jour du séminaire'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Delete a seminar (requires admin)
+ */
+export async function handleDeleteSeminar(
+  id: string,
+  config: SeminarsHandlerConfig,
+  _authContext?: AuthContext
+): Promise<SeminarHandlerResult<{ deleted: boolean }>> {
+  const { getSeminarById, deleteSeminar, onCacheRevalidate } = config;
+
+  const existing = await getSeminarById(id);
+  if (!existing) {
+    return {
+      response: error('NOT_FOUND', 'Séminaire non trouvé'),
+      statusCode: 404,
+      headers: {},
+    };
+  }
+
+  try {
+    await deleteSeminar(id);
+
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/seminars', `/seminars/${existing.slug}`]);
+    }
+
+    return {
+      response: success({ deleted: true }),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error deleting seminar:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la suppression du séminaire'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Register for a seminar
+ */
+export async function handleRegister(
+  request: ApiRequest,
+  config: SeminarsHandlerConfig
+): Promise<SeminarHandlerResult<Registration>> {
+  const { getSeminarById, createRegistration, sendRegistrationConfirmation } = config;
+
+  if (!createRegistration) {
+    return {
+      response: error('NOT_IMPLEMENTED', 'Inscriptions non disponibles'),
+      statusCode: 501,
+      headers: {},
+    };
+  }
+
+  const bodyResult = await withBodyValidation(request, registrationSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  // Check seminar exists and is open
+  const seminar = await getSeminarById(data.seminarId);
+  if (!seminar) {
+    return {
+      response: error('NOT_FOUND', 'Séminaire non trouvé'),
+      statusCode: 404,
+      headers: {},
+    };
+  }
+
+  if (seminar.status !== 'published') {
+    return {
+      response: error('VALIDATION_ERROR', "Ce séminaire n'accepte plus d'inscriptions"),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  // Check capacity
+  if (seminar.maxParticipants && seminar.currentParticipants !== undefined) {
+    if (seminar.currentParticipants >= seminar.maxParticipants) {
+      return {
+        response: error('CONFLICT', 'Ce séminaire est complet'),
+        statusCode: 409,
+        headers: {},
+      };
+    }
+  }
+
+  try {
+    const registration = await createRegistration(data);
+
+    // Send confirmation email
+    if (sendRegistrationConfirmation) {
+      try {
+        await sendRegistrationConfirmation(registration, seminar);
+      } catch (e) {
+        console.error('Failed to send registration confirmation:', e);
+      }
+    }
+
+    return {
+      response: success(registration),
+      statusCode: 201,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error creating registration:', e);
+    return {
+      response: error('INTERNAL_ERROR', "Erreur lors de l'inscription"),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create seminars handlers with preset configuration
+ */
+export function createSeminarsHandlers(config: SeminarsHandlerConfig) {
+  return {
+    getAll: (request: ApiRequest) => handleGetSeminars(request, config),
+    getBySlug: (slug: string) => handleGetSeminarBySlug(slug, config),
+    create: (request: ApiRequest, authContext?: AuthContext) =>
+      handleCreateSeminar(request, config, authContext),
+    update: (id: string, request: ApiRequest, authContext?: AuthContext) =>
+      handleUpdateSeminar(id, request, config, authContext),
+    delete: (id: string, authContext?: AuthContext) => handleDeleteSeminar(id, config, authContext),
+    register: (request: ApiRequest) => handleRegister(request, config),
+  };
+}

--- a/packages/api/src/handlers/testimonials/index.ts
+++ b/packages/api/src/handlers/testimonials/index.ts
@@ -1,0 +1,358 @@
+/**
+ * Testimonials Handler
+ *
+ * CRUD operations for testimonials.
+ */
+
+import { z } from 'zod';
+
+import type { ApiRequest, AuthContext } from '../../middleware/types';
+import { withBodyValidation, withQueryValidation } from '../../middleware/with-validation';
+import { error, paginated, success } from '../../utils/response';
+
+/**
+ * Testimonial schema
+ */
+export const testimonialSchema = z.object({
+  name: z.string().min(1, 'Le nom est requis').max(100),
+  content: z.string().min(10, 'Le témoignage doit contenir au moins 10 caractères').max(2000),
+  rating: z.number().int().min(1).max(5).optional(),
+  image: z.string().url().optional().nullable(),
+  role: z.string().max(100).optional(),
+  company: z.string().max(100).optional(),
+  featured: z.boolean().default(false),
+  approved: z.boolean().default(false),
+  siteId: z.string().optional(),
+});
+
+export type TestimonialInput = z.infer<typeof testimonialSchema>;
+
+/**
+ * Testimonial update schema
+ */
+export const testimonialUpdateSchema = testimonialSchema.partial();
+
+export type TestimonialUpdateInput = z.infer<typeof testimonialUpdateSchema>;
+
+/**
+ * Testimonial list query params
+ */
+export const testimonialsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  approved: z
+    .enum(['true', 'false', 'all'])
+    .optional()
+    .transform(v => (v === 'true' ? true : v === 'false' ? false : undefined)),
+  featured: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform(v => (v === 'true' ? true : v === 'false' ? false : undefined)),
+  siteId: z.string().optional(),
+});
+
+export type TestimonialsQueryParams = z.infer<typeof testimonialsQuerySchema>;
+
+/**
+ * Testimonial returned from API
+ */
+export interface Testimonial {
+  id: string;
+  name: string;
+  content: string;
+  rating?: number | null;
+  image?: string | null;
+  role?: string | null;
+  company?: string | null;
+  featured: boolean;
+  approved: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Testimonials handler configuration
+ */
+export interface TestimonialsHandlerConfig {
+  /** Site ID for multi-tenant filtering */
+  siteId?: string;
+  /** Function to get all testimonials */
+  getAllTestimonials: (options: {
+    page?: number;
+    limit?: number;
+    approved?: boolean;
+    featured?: boolean;
+    siteId?: string;
+  }) => Promise<{ testimonials: Testimonial[]; total: number }>;
+  /** Function to get testimonial by ID */
+  getTestimonialById: (id: string) => Promise<Testimonial | null>;
+  /** Function to create a testimonial */
+  createTestimonial: (data: TestimonialInput) => Promise<Testimonial>;
+  /** Function to update a testimonial */
+  updateTestimonial: (id: string, data: TestimonialUpdateInput) => Promise<Testimonial>;
+  /** Function to delete a testimonial */
+  deleteTestimonial: (id: string) => Promise<void>;
+  /** Cache revalidation callback */
+  onCacheRevalidate?: (paths: string[]) => Promise<void>;
+}
+
+/**
+ * Handler result type
+ */
+export interface TestimonialHandlerResult<T = unknown> {
+  response:
+    | { success: true; data: T; pagination?: unknown }
+    | { success: false; error: { code: string; message: string; details?: unknown } };
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+/**
+ * Get all testimonials with filtering and pagination
+ */
+export async function handleGetTestimonials(
+  request: ApiRequest,
+  config: TestimonialsHandlerConfig
+): Promise<TestimonialHandlerResult<Testimonial[]>> {
+  const { getAllTestimonials, siteId: configSiteId } = config;
+
+  const queryResult = withQueryValidation(request, testimonialsQuerySchema);
+
+  if (!queryResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Paramètres de requête invalides'),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const { page, limit, approved, featured, siteId: querySiteId } = queryResult.query;
+
+  try {
+    const { testimonials, total } = await getAllTestimonials({
+      page,
+      limit,
+      approved,
+      featured,
+      siteId: querySiteId || configSiteId,
+    });
+
+    // Public testimonials (approved only) can be cached
+    const isPublic = approved === true;
+    const cacheControl = isPublic
+      ? 'public, s-maxage=3600, max-age=3600, stale-while-revalidate=86400'
+      : 'private, no-cache';
+
+    return {
+      response: paginated(testimonials, { page, limit, total }),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': cacheControl,
+      },
+    };
+  } catch (e) {
+    console.error('Error fetching testimonials:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des témoignages'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Get a single testimonial by ID
+ */
+export async function handleGetTestimonialById(
+  id: string,
+  config: TestimonialsHandlerConfig
+): Promise<TestimonialHandlerResult<Testimonial>> {
+  const { getTestimonialById } = config;
+
+  try {
+    const testimonial = await getTestimonialById(id);
+
+    if (!testimonial) {
+      return {
+        response: error('NOT_FOUND', 'Témoignage non trouvé'),
+        statusCode: 404,
+        headers: {},
+      };
+    }
+
+    return {
+      response: success(testimonial),
+      statusCode: 200,
+      headers: {
+        'Cache-Control': testimonial.approved ? 'public, max-age=3600' : 'private, no-cache',
+      },
+    };
+  } catch (e) {
+    console.error('Error fetching testimonial:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la récupération du témoignage'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create a new testimonial (requires admin)
+ */
+export async function handleCreateTestimonial(
+  request: ApiRequest,
+  config: TestimonialsHandlerConfig,
+  _authContext?: AuthContext
+): Promise<TestimonialHandlerResult<Testimonial>> {
+  const { createTestimonial, siteId, onCacheRevalidate } = config;
+
+  const bodyResult = await withBodyValidation(request, testimonialSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  try {
+    const testimonialData = siteId ? { ...data, siteId } : data;
+    const testimonial = await createTestimonial(testimonialData);
+
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/testimonials']);
+    }
+
+    return {
+      response: success(testimonial),
+      statusCode: 201,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error creating testimonial:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la création du témoignage'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Update a testimonial (requires admin)
+ */
+export async function handleUpdateTestimonial(
+  id: string,
+  request: ApiRequest,
+  config: TestimonialsHandlerConfig,
+  _authContext?: AuthContext
+): Promise<TestimonialHandlerResult<Testimonial>> {
+  const { getTestimonialById, updateTestimonial, onCacheRevalidate } = config;
+
+  const bodyResult = await withBodyValidation(request, testimonialUpdateSchema);
+
+  if (!bodyResult.success) {
+    return {
+      response: error('VALIDATION_ERROR', 'Données invalides', {
+        details: bodyResult.error.details,
+      }),
+      statusCode: 400,
+      headers: {},
+    };
+  }
+
+  const data = bodyResult.body;
+
+  const existing = await getTestimonialById(id);
+  if (!existing) {
+    return {
+      response: error('NOT_FOUND', 'Témoignage non trouvé'),
+      statusCode: 404,
+      headers: {},
+    };
+  }
+
+  try {
+    const testimonial = await updateTestimonial(id, data);
+
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/testimonials']);
+    }
+
+    return {
+      response: success(testimonial),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error updating testimonial:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la mise à jour du témoignage'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Delete a testimonial (requires admin)
+ */
+export async function handleDeleteTestimonial(
+  id: string,
+  config: TestimonialsHandlerConfig,
+  _authContext?: AuthContext
+): Promise<TestimonialHandlerResult<{ deleted: boolean }>> {
+  const { getTestimonialById, deleteTestimonial, onCacheRevalidate } = config;
+
+  const existing = await getTestimonialById(id);
+  if (!existing) {
+    return {
+      response: error('NOT_FOUND', 'Témoignage non trouvé'),
+      statusCode: 404,
+      headers: {},
+    };
+  }
+
+  try {
+    await deleteTestimonial(id);
+
+    if (onCacheRevalidate) {
+      await onCacheRevalidate(['/api/testimonials']);
+    }
+
+    return {
+      response: success({ deleted: true }),
+      statusCode: 200,
+      headers: {},
+    };
+  } catch (e) {
+    console.error('Error deleting testimonial:', e);
+    return {
+      response: error('INTERNAL_ERROR', 'Erreur lors de la suppression du témoignage'),
+      statusCode: 500,
+      headers: {},
+    };
+  }
+}
+
+/**
+ * Create testimonials handlers with preset configuration
+ */
+export function createTestimonialsHandlers(config: TestimonialsHandlerConfig) {
+  return {
+    getAll: (request: ApiRequest) => handleGetTestimonials(request, config),
+    getById: (id: string) => handleGetTestimonialById(id, config),
+    create: (request: ApiRequest, authContext?: AuthContext) =>
+      handleCreateTestimonial(request, config, authContext),
+    update: (id: string, request: ApiRequest, authContext?: AuthContext) =>
+      handleUpdateTestimonial(id, request, config, authContext),
+    delete: (id: string, authContext?: AuthContext) =>
+      handleDeleteTestimonial(id, config, authContext),
+  };
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,333 @@
+/**
+ * @kairn/api
+ *
+ * Reusable API handlers, middlewares, and utilities for Kairn sites.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   withAuth,
+ *   withAdmin,
+ *   withRateLimit,
+ *   handleLogin,
+ *   handleGetPosts,
+ *   success,
+ *   error,
+ *   paginated,
+ * } from '@kairn/api';
+ * ```
+ */
+
+// ============================================
+// Middleware
+// ============================================
+
+export {
+  // Auth middleware
+  withAuth,
+  createAuthMiddleware,
+  AuthErrorCode,
+
+  // Admin middleware
+  withAdmin,
+  createAdminMiddleware,
+  AdminErrorCode,
+
+  // Rate limit middleware
+  withRateLimit,
+  createRateLimitMiddleware,
+  createKeyGenerator,
+  getClientIP,
+  RATE_LIMIT_PRESETS,
+  MemoryRateLimitStore,
+
+  // CSRF middleware
+  withCSRF,
+  createCSRFMiddleware,
+  generateCSRFToken,
+  validateCSRFToken,
+  getCSRFConfig,
+
+  // Validation middleware
+  withBodyValidation,
+  withQueryValidation,
+  withValidation,
+  createValidationMiddleware,
+  commonSchemas,
+
+  // Types
+  type ApiRequest,
+  type AuthContext,
+  type AuthResult,
+  type ApiErrorResponse,
+  type AuthMiddlewareConfig,
+  type AdminMiddlewareConfig,
+  type CSRFConfig,
+  type CSRFResult,
+  type RateLimitResult,
+  type RateLimitConfig,
+  type RateLimitRequest,
+  type RateLimitInfo,
+  type RateLimitStore,
+  type JWTPayload,
+} from './middleware';
+
+// ============================================
+// Utilities
+// ============================================
+
+export {
+  // Response helpers
+  success,
+  error,
+  paginated,
+  buildHeaders,
+  getStatusForError,
+  ErrorCodes,
+  HttpStatus,
+  ErrorCodeToStatus,
+  CacheControl,
+
+  // Pagination
+  parsePagination,
+  calculatePagination,
+  getCursorPagination,
+  buildPaginationLinks,
+  createPaginator,
+  DEFAULT_PAGINATION,
+
+  // Filters
+  parseFilters,
+  parseSort,
+  parseDateRange,
+  parseSearch,
+  buildPrismaFilters,
+  buildPrismaSort,
+  createFilterParser,
+
+  // Types
+  type SuccessResponse,
+  type ErrorResponse,
+  type PaginatedResponse,
+  type PaginationParams,
+  type PaginationQuery,
+  type PaginationMeta,
+  type FilterOperator,
+  type ParsedFilter,
+  type FilterConfig,
+  type SortDirection,
+  type ParsedSort,
+} from './utils';
+
+// ============================================
+// Auth Handlers
+// ============================================
+
+export {
+  handleLogin,
+  createLoginHandler,
+  handleLogout,
+  createLogoutHandler,
+  handleRefresh,
+  createRefreshHandler,
+  handleForgotPassword,
+  createForgotPasswordHandler,
+
+  // Schemas
+  loginSchema,
+  refreshTokenSchema,
+  forgotPasswordSchema,
+  resetPasswordSchema,
+  getDefaultAuthCookieOptions,
+
+  // Types
+  type LoginInput,
+  type RefreshTokenInput,
+  type ForgotPasswordInput,
+  type ResetPasswordInput,
+  type AuthUser,
+  type LoginResponse,
+  type LogoutResponse,
+  type RefreshResponse,
+  type ForgotPasswordResponse,
+  type AuthHandlerConfig,
+  type AuthCookieOptions,
+  type LoginResult,
+  type LogoutHandlerConfig,
+  type LogoutResult,
+  type RefreshHandlerConfig,
+  type RefreshResult,
+  type ForgotPasswordHandlerConfig,
+  type ForgotPasswordResult,
+} from './handlers/auth';
+
+// ============================================
+// Blog Handlers
+// ============================================
+
+export {
+  handleGetPosts,
+  handleGetPostBySlug,
+  handleCreatePost,
+  handleUpdatePost,
+  handleDeletePost,
+  handleCheckSlug,
+  createBlogHandlers,
+  handleGetTags,
+  handleCreateTag,
+  handleUpdateTag,
+  handleDeleteTag,
+  createTagHandlers,
+
+  // Schemas
+  blogPostSchema,
+  blogPostUpdateSchema,
+  tagSchema,
+  checkSlugSchema,
+  postsQuerySchema,
+  validateSlug,
+  generateSlug,
+
+  // Types
+  type PostStatus,
+  type BlogPostInput,
+  type BlogPostUpdateInput,
+  type TagInput,
+  type CheckSlugInput,
+  type PostsQueryParams,
+  type BlogPost,
+  type Tag,
+  type BlogHandlerConfig,
+  type BlogHandlerResult,
+  type TagHandlerResult,
+} from './handlers/blog';
+
+// ============================================
+// Analytics Handlers
+// ============================================
+
+export {
+  handleTrack,
+  createTrackHandler,
+  extractGeolocation,
+  handleDashboard,
+  createDashboardHandler,
+  handleRealtime,
+  createRealtimeHandler,
+  handleExport,
+  createExportHandler,
+
+  // Schemas
+  sessionDataSchema,
+  baseEventSchema,
+  clientInfoSchema,
+  trackingPayloadSchema,
+  dashboardQuerySchema,
+  exportQuerySchema,
+
+  // Utilities
+  isBot,
+  extractDomain,
+  hashIP,
+  getCountryName,
+  BOT_PATTERNS,
+  COUNTRY_NAMES,
+
+  // Types
+  type EventType,
+  type DeviceType,
+  type SessionData,
+  type BaseEvent,
+  type ClientInfo,
+  type TrackingPayload,
+  type GeolocationData,
+  type DashboardQueryParams,
+  type ExportQueryParams,
+  type DashboardMetrics,
+  type TopPage,
+  type TrafficSource,
+  type DeviceBreakdown,
+  type GeoData,
+  type TimeSeriesPoint,
+  type DashboardData,
+  type RealtimeData,
+  type AnalyticsHandlerConfig,
+  type TrackResult,
+  type DashboardResult,
+  type RealtimeResult,
+  type ExportResult,
+} from './handlers/analytics';
+
+// ============================================
+// Contact Handler
+// ============================================
+
+export {
+  handleContact,
+  createContactHandler,
+
+  // Schema
+  contactSchema,
+
+  // Types
+  type ContactInput,
+  type ContactHandlerConfig,
+  type ContactResult,
+} from './handlers/contact';
+
+// ============================================
+// Testimonials Handlers
+// ============================================
+
+export {
+  handleGetTestimonials,
+  handleGetTestimonialById,
+  handleCreateTestimonial,
+  handleUpdateTestimonial,
+  handleDeleteTestimonial,
+  createTestimonialsHandlers,
+
+  // Schemas
+  testimonialSchema,
+  testimonialUpdateSchema,
+  testimonialsQuerySchema,
+
+  // Types
+  type TestimonialInput,
+  type TestimonialUpdateInput,
+  type TestimonialsQueryParams,
+  type Testimonial,
+  type TestimonialsHandlerConfig,
+  type TestimonialHandlerResult,
+} from './handlers/testimonials';
+
+// ============================================
+// Seminars Handlers
+// ============================================
+
+export {
+  handleGetSeminars,
+  handleGetSeminarBySlug,
+  handleCreateSeminar,
+  handleUpdateSeminar,
+  handleDeleteSeminar,
+  handleRegister,
+  createSeminarsHandlers,
+
+  // Schemas
+  seminarSchema,
+  seminarUpdateSchema,
+  registrationSchema,
+  seminarsQuerySchema,
+
+  // Types
+  type SeminarStatus,
+  type SeminarInput,
+  type SeminarUpdateInput,
+  type RegistrationInput,
+  type SeminarsQueryParams,
+  type Seminar,
+  type Registration,
+  type SeminarsHandlerConfig,
+  type SeminarHandlerResult,
+} from './handlers/seminars';

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -1,0 +1,63 @@
+/**
+ * @kairn/api Middleware
+ *
+ * Reusable middleware for API routes.
+ */
+
+// Types
+export type {
+  ApiRequest,
+  AuthContext,
+  AuthResult,
+  ApiErrorResponse,
+  AuthMiddlewareConfig,
+  CSRFConfig,
+  ValidationConfig,
+  ValidationResult,
+} from './types';
+
+// Auth middleware
+export { withAuth, createAuthMiddleware, AuthErrorCode, type JWTPayload } from './with-auth';
+
+// Admin middleware
+export {
+  withAdmin,
+  createAdminMiddleware,
+  AdminErrorCode,
+  type AdminMiddlewareConfig,
+} from './with-admin';
+
+// Rate limit middleware
+export {
+  withRateLimit,
+  createRateLimitMiddleware,
+  createKeyGenerator,
+  getClientIP,
+  RATE_LIMIT_PRESETS,
+  MemoryRateLimitStore,
+  type RateLimitResult,
+  type RateLimitConfig,
+  type RateLimitRequest,
+  type RateLimitInfo,
+  type RateLimitStore,
+} from './with-rate-limit';
+
+// CSRF middleware
+export {
+  withCSRF,
+  createCSRFMiddleware,
+  generateCSRFToken,
+  validateCSRFToken,
+  getCSRFConfig,
+  type CSRFResult,
+} from './with-csrf';
+
+// Validation middleware
+export {
+  withBodyValidation,
+  withQueryValidation,
+  withValidation,
+  createValidationMiddleware,
+  commonSchemas,
+  type ValidationResult as BodyValidationResult,
+} from './with-validation';

--- a/packages/api/src/middleware/types.ts
+++ b/packages/api/src/middleware/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Types for API middlewares
+ */
+
+import type { JWTPayload } from '@kairn/core';
+
+/**
+ * Minimal request interface for middlewares
+ */
+export interface ApiRequest {
+  headers: {
+    get(name: string): string | null;
+  };
+  url?: string;
+  method?: string;
+  clone(): ApiRequest & { json(): Promise<unknown>; formData(): Promise<FormData> };
+  json(): Promise<unknown>;
+}
+
+/**
+ * Authentication context passed to handlers
+ */
+export interface AuthContext {
+  user: JWTPayload;
+  token: string;
+}
+
+/**
+ * Result of an auth middleware check
+ */
+export type AuthResult =
+  | { success: true; context: AuthContext }
+  | { success: false; error: ApiErrorResponse };
+
+/**
+ * API error response structure
+ */
+export interface ApiErrorResponse {
+  code: string;
+  message: string;
+  statusCode: number;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Middleware configuration for auth
+ */
+export interface AuthMiddlewareConfig {
+  /** Cookie name to look for token */
+  cookieName?: string;
+  /** Header name for Bearer token */
+  headerName?: string;
+  /** Required role (e.g., 'admin') */
+  requiredRole?: string;
+  /** Function to get cookies (for Next.js) */
+  getCookies?: () => Promise<{ get(name: string): { value: string } | undefined }>;
+}
+
+/**
+ * CSRF middleware configuration
+ */
+export interface CSRFConfig {
+  /** Cookie name for CSRF token */
+  cookieName?: string;
+  /** Header name for CSRF token */
+  headerName?: string;
+  /** Token lifetime in seconds */
+  tokenLifetime?: number;
+  /** Secret for signing (defaults to env CSRF_SECRET or JWT_SECRET) */
+  secret?: string;
+}
+
+/**
+ * Validation middleware configuration
+ */
+export interface ValidationConfig<T> {
+  /** Zod schema for body validation */
+  body?: {
+    safeParse: (
+      data: unknown
+    ) => { success: true; data: T } | { success: false; error: { flatten: () => unknown } };
+  };
+  /** Zod schema for query params validation */
+  query?: {
+    safeParse: (
+      data: unknown
+    ) => { success: true; data: T } | { success: false; error: { flatten: () => unknown } };
+  };
+}
+
+/**
+ * Validation result
+ */
+export type ValidationResult<TBody = unknown, TQuery = unknown> =
+  | { success: true; body?: TBody; query?: TQuery }
+  | { success: false; error: ApiErrorResponse };

--- a/packages/api/src/middleware/with-admin.ts
+++ b/packages/api/src/middleware/with-admin.ts
@@ -1,0 +1,102 @@
+/**
+ * Admin Authentication Middleware
+ *
+ * Verifies that the user is authenticated AND has admin role.
+ */
+
+import type { ApiRequest, AuthMiddlewareConfig, AuthResult, ApiErrorResponse } from './types';
+import { withAuth } from './with-auth';
+
+/**
+ * Error codes for authorization failures
+ */
+export const AdminErrorCode = {
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  INSUFFICIENT_PERMISSIONS: 'INSUFFICIENT_PERMISSIONS',
+} as const;
+
+/**
+ * Create an authorization error response
+ */
+function createAdminError(code: keyof typeof AdminErrorCode, message?: string): ApiErrorResponse {
+  const messages: Record<keyof typeof AdminErrorCode, { msg: string; status: number }> = {
+    UNAUTHORIZED: { msg: 'Authentification requise', status: 401 },
+    INSUFFICIENT_PERMISSIONS: { msg: 'Permissions insuffisantes', status: 403 },
+  };
+
+  const { msg, status } = messages[code];
+  return {
+    code: AdminErrorCode[code],
+    message: message || msg,
+    statusCode: status,
+  };
+}
+
+/**
+ * Admin middleware configuration
+ */
+export interface AdminMiddlewareConfig extends AuthMiddlewareConfig {
+  /** Required admin role name (default: 'admin') */
+  adminRole?: string;
+}
+
+/**
+ * Verify admin authentication for a request
+ *
+ * @param request - The incoming request
+ * @param config - Admin authentication configuration
+ * @returns Authentication result with admin user context or error
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const authResult = await withAdmin(request, {
+ *     cookieName: 'my_app_admin_token',
+ *     getCookies: () => cookies(),
+ *   });
+ *
+ *   if (!authResult.success) {
+ *     return NextResponse.json(authResult.error, { status: authResult.error.statusCode });
+ *   }
+ *
+ *   const { user } = authResult.context;
+ *   // Continue with admin-only operation...
+ * }
+ * ```
+ */
+export async function withAdmin(
+  request: ApiRequest,
+  config: AdminMiddlewareConfig = {}
+): Promise<AuthResult> {
+  const { adminRole = 'admin', ...authConfig } = config;
+
+  // First verify authentication
+  const authResult = await withAuth(request, authConfig);
+
+  if (!authResult.success) {
+    return authResult;
+  }
+
+  // Check admin role
+  const { user } = authResult.context;
+
+  if (user.role !== adminRole) {
+    return {
+      success: false,
+      error: createAdminError('INSUFFICIENT_PERMISSIONS'),
+    };
+  }
+
+  return authResult;
+}
+
+/**
+ * Factory to create an admin middleware with preset configuration
+ *
+ * @param config - Default configuration
+ * @returns Configured admin middleware function
+ */
+export function createAdminMiddleware(config: AdminMiddlewareConfig = {}) {
+  return (request: ApiRequest, overrides?: AdminMiddlewareConfig) =>
+    withAdmin(request, { ...config, ...overrides });
+}

--- a/packages/api/src/middleware/with-auth.ts
+++ b/packages/api/src/middleware/with-auth.ts
@@ -1,0 +1,188 @@
+/**
+ * Authentication Middleware
+ *
+ * Verifies JWT tokens from cookies or Authorization header.
+ */
+
+import { getTokenFromHeader, type JWTPayload, verifyToken } from '@kairn/core';
+
+import type { ApiErrorResponse, ApiRequest, AuthMiddlewareConfig, AuthResult } from './types';
+
+/**
+ * Error codes for authentication failures
+ */
+export const AuthErrorCode = {
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+  INVALID_TOKEN: 'INVALID_TOKEN',
+} as const;
+
+/**
+ * Create an authentication error response
+ */
+function createAuthError(code: keyof typeof AuthErrorCode, message?: string): ApiErrorResponse {
+  const messages: Record<keyof typeof AuthErrorCode, { msg: string; status: number }> = {
+    UNAUTHORIZED: { msg: 'Authentification requise', status: 401 },
+    TOKEN_EXPIRED: { msg: 'Votre session a expiré. Veuillez vous reconnecter', status: 401 },
+    INVALID_TOKEN: { msg: 'Token invalide', status: 401 },
+  };
+
+  const { msg, status } = messages[code];
+  return {
+    code: AuthErrorCode[code],
+    message: message || msg,
+    statusCode: status,
+  };
+}
+
+/**
+ * Default configuration
+ */
+const defaultConfig: Required<Omit<AuthMiddlewareConfig, 'getCookies'>> = {
+  cookieName: 'auth_token',
+  headerName: 'Authorization',
+  requiredRole: '',
+};
+
+/**
+ * Extract token from request
+ */
+async function extractToken(
+  request: ApiRequest,
+  config: AuthMiddlewareConfig
+): Promise<string | null> {
+  const { cookieName, headerName, getCookies } = { ...defaultConfig, ...config };
+
+  // Try Authorization header first
+  const authHeader = request.headers.get(headerName);
+  const headerToken = getTokenFromHeader(authHeader || undefined);
+  if (headerToken) {
+    return headerToken;
+  }
+
+  // Try cookies if getCookies function is provided
+  if (getCookies) {
+    try {
+      const cookies = await getCookies();
+      const cookie = cookies.get(cookieName);
+      if (cookie?.value) {
+        return cookie.value;
+      }
+    } catch {
+      // Cookie access failed
+    }
+  }
+
+  // Try to parse Cookie header manually
+  const cookieHeader = request.headers.get('Cookie');
+  if (cookieHeader) {
+    const cookies = parseCookieHeader(cookieHeader);
+    const tokenFromCookie = cookies[cookieName];
+    if (tokenFromCookie) {
+      return tokenFromCookie;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse Cookie header into key-value pairs
+ */
+function parseCookieHeader(cookieHeader: string): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  const pairs = cookieHeader.split(';');
+
+  for (const pair of pairs) {
+    const [key, ...valueParts] = pair.trim().split('=');
+    if (key) {
+      cookies[key] = valueParts.join('=');
+    }
+  }
+
+  return cookies;
+}
+
+/**
+ * Verify authentication for a request
+ *
+ * @param request - The incoming request
+ * @param config - Authentication configuration
+ * @returns Authentication result with user context or error
+ *
+ * @example
+ * ```typescript
+ * export async function GET(request: Request) {
+ *   const authResult = await withAuth(request, {
+ *     cookieName: 'my_app_token',
+ *     getCookies: () => cookies(),
+ *   });
+ *
+ *   if (!authResult.success) {
+ *     return NextResponse.json(authResult.error, { status: authResult.error.statusCode });
+ *   }
+ *
+ *   const { user } = authResult.context;
+ *   // Continue with authenticated request...
+ * }
+ * ```
+ */
+export async function withAuth(
+  request: ApiRequest,
+  config: AuthMiddlewareConfig = {}
+): Promise<AuthResult> {
+  try {
+    const token = await extractToken(request, config);
+
+    if (!token) {
+      return {
+        success: false,
+        error: createAuthError('UNAUTHORIZED'),
+      };
+    }
+
+    const payload = await verifyToken(token);
+
+    if (!payload) {
+      return {
+        success: false,
+        error: createAuthError('INVALID_TOKEN'),
+      };
+    }
+
+    // Check token expiration (verifyToken should handle this, but double-check)
+    if (payload.exp && payload.exp * 1000 < Date.now()) {
+      return {
+        success: false,
+        error: createAuthError('TOKEN_EXPIRED'),
+      };
+    }
+
+    return {
+      success: true,
+      context: {
+        user: payload,
+        token,
+      },
+    };
+  } catch (error) {
+    console.error('Auth middleware error:', error);
+    return {
+      success: false,
+      error: createAuthError('INVALID_TOKEN'),
+    };
+  }
+}
+
+/**
+ * Factory to create an auth middleware with preset configuration
+ *
+ * @param config - Default configuration
+ * @returns Configured auth middleware function
+ */
+export function createAuthMiddleware(config: AuthMiddlewareConfig = {}) {
+  return (request: ApiRequest, overrides?: AuthMiddlewareConfig) =>
+    withAuth(request, { ...config, ...overrides });
+}
+
+export type { JWTPayload };

--- a/packages/api/src/middleware/with-csrf.ts
+++ b/packages/api/src/middleware/with-csrf.ts
@@ -1,0 +1,268 @@
+/**
+ * CSRF Protection Middleware
+ *
+ * Implements CSRF token validation using HMAC-signed tokens.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+import type { ApiErrorResponse, ApiRequest, CSRFConfig } from './types';
+
+/**
+ * CSRF token structure
+ */
+interface CSRFToken {
+  value: string;
+  timestamp: number;
+  signature: string;
+}
+
+/**
+ * Default CSRF configuration
+ */
+const defaultConfig: Required<Omit<CSRFConfig, 'secret'>> = {
+  cookieName: 'csrf_token',
+  headerName: 'x-csrf-token',
+  tokenLifetime: 3600, // 1 hour
+};
+
+/**
+ * CSRF validation result
+ */
+export type CSRFResult = { success: true } | { success: false; error: ApiErrorResponse };
+
+/**
+ * Get CSRF secret from config or environment
+ */
+function getCSRFSecret(config?: CSRFConfig): string {
+  const secret = config?.secret || process.env.CSRF_SECRET || process.env.JWT_SECRET;
+
+  if (!secret) {
+    throw new Error('CSRF_SECRET or JWT_SECRET must be defined in environment variables');
+  }
+
+  return secret;
+}
+
+/**
+ * Generate a new CSRF token
+ *
+ * @param config - Optional CSRF configuration
+ * @returns Base64-encoded CSRF token
+ *
+ * @example
+ * ```typescript
+ * // Generate a token to send to the client
+ * const token = generateCSRFToken();
+ *
+ * // Set it in a cookie
+ * response.cookies.set('csrf_token', token, {
+ *   httpOnly: true,
+ *   secure: process.env.NODE_ENV === 'production',
+ *   sameSite: 'strict',
+ *   maxAge: 3600,
+ * });
+ * ```
+ */
+export function generateCSRFToken(config?: CSRFConfig): string {
+  const value = randomBytes(32).toString('base64');
+  const timestamp = Date.now();
+  const secret = getCSRFSecret(config);
+
+  // Create HMAC signature
+  const signature = createHmac('sha256', secret).update(`${value}:${timestamp}`).digest('base64');
+
+  const token: CSRFToken = {
+    value,
+    timestamp,
+    signature,
+  };
+
+  return Buffer.from(JSON.stringify(token)).toString('base64');
+}
+
+/**
+ * Validate a CSRF token
+ *
+ * @param token - Token to validate
+ * @param cookieToken - Optional token from cookie to compare against
+ * @param config - Optional CSRF configuration
+ * @returns True if token is valid
+ */
+export function validateCSRFToken(
+  token: string | null | undefined,
+  cookieToken?: string | null,
+  config?: CSRFConfig
+): boolean {
+  if (!token) {
+    return false;
+  }
+
+  const { tokenLifetime } = { ...defaultConfig, ...config };
+
+  try {
+    // Decode the token
+    const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf-8')) as CSRFToken;
+
+    // Verify required fields
+    if (!decoded.value || !decoded.timestamp || !decoded.signature) {
+      return false;
+    }
+
+    // Check expiration
+    const now = Date.now();
+    const age = (now - decoded.timestamp) / 1000;
+
+    if (age > tokenLifetime) {
+      return false;
+    }
+
+    // Verify signature
+    const secret = getCSRFSecret(config);
+    const expectedSignature = createHmac('sha256', secret)
+      .update(`${decoded.value}:${decoded.timestamp}`)
+      .digest('base64');
+
+    const tokenSignatureBuffer = Buffer.from(decoded.signature, 'base64');
+    const expectedSignatureBuffer = Buffer.from(expectedSignature, 'base64');
+
+    if (tokenSignatureBuffer.length !== expectedSignatureBuffer.length) {
+      return false;
+    }
+
+    // Use timing-safe comparison to prevent timing attacks
+    if (!timingSafeEqual(tokenSignatureBuffer, expectedSignatureBuffer)) {
+      return false;
+    }
+
+    // If cookie token is provided, verify it matches
+    if (cookieToken && cookieToken !== token) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract CSRF token from request
+ */
+async function getCSRFTokenFromRequest(
+  request: ApiRequest,
+  config?: CSRFConfig
+): Promise<string | null> {
+  const { headerName } = { ...defaultConfig, ...config };
+
+  // Try header first
+  const headerToken = request.headers.get(headerName);
+  if (headerToken) {
+    return headerToken;
+  }
+
+  // Try body for JSON or form data
+  try {
+    const contentType = request.headers.get('content-type') || '';
+
+    if (contentType.includes('application/json')) {
+      const clonedRequest = request.clone();
+      const body = (await clonedRequest.json()) as Record<string, unknown>;
+      return (body.csrf_token as string) || null;
+    }
+
+    if (
+      contentType.includes('application/x-www-form-urlencoded') ||
+      contentType.includes('multipart/form-data')
+    ) {
+      const clonedRequest = request.clone();
+      const formData = await clonedRequest.formData();
+      return formData.get('csrf_token') as string | null;
+    }
+  } catch {
+    // Parsing error
+  }
+
+  return null;
+}
+
+/**
+ * Get CSRF token from Cookie header
+ */
+function getCSRFTokenFromCookies(request: ApiRequest, config?: CSRFConfig): string | null {
+  const { cookieName } = { ...defaultConfig, ...config };
+  const cookieHeader = request.headers.get('Cookie');
+
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const cookies = cookieHeader.split(';');
+  for (const cookie of cookies) {
+    const [key, ...valueParts] = cookie.trim().split('=');
+    if (key === cookieName) {
+      return valueParts.join('=');
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validate CSRF protection for a request
+ *
+ * @param request - The incoming request
+ * @param config - Optional CSRF configuration
+ * @returns CSRF validation result
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const csrfResult = await withCSRF(request);
+ *
+ *   if (!csrfResult.success) {
+ *     return NextResponse.json(csrfResult.error, { status: csrfResult.error.statusCode });
+ *   }
+ *
+ *   // Continue with protected operation...
+ * }
+ * ```
+ */
+export async function withCSRF(request: ApiRequest, config?: CSRFConfig): Promise<CSRFResult> {
+  const requestToken = await getCSRFTokenFromRequest(request, config);
+  const cookieToken = getCSRFTokenFromCookies(request, config);
+
+  const isValid = validateCSRFToken(requestToken, cookieToken, config);
+
+  if (!isValid) {
+    return {
+      success: false,
+      error: {
+        code: 'CSRF_INVALID',
+        message: 'Token CSRF invalide ou expiré. Veuillez rafraîchir la page.',
+        statusCode: 403,
+      },
+    };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Create a CSRF middleware with preset configuration
+ *
+ * @param config - Default configuration
+ * @returns Configured CSRF middleware function
+ */
+export function createCSRFMiddleware(config?: CSRFConfig) {
+  return (request: ApiRequest, overrides?: CSRFConfig) =>
+    withCSRF(request, { ...config, ...overrides });
+}
+
+/**
+ * Get CSRF configuration names (useful for client-side forms)
+ */
+export function getCSRFConfig(config?: CSRFConfig) {
+  const { cookieName, headerName } = { ...defaultConfig, ...config };
+  return { cookieName, headerName };
+}

--- a/packages/api/src/middleware/with-rate-limit.ts
+++ b/packages/api/src/middleware/with-rate-limit.ts
@@ -1,0 +1,166 @@
+/**
+ * Rate Limiting Middleware Wrapper
+ *
+ * Wraps the @kairn/core rate limiter for easy API route usage.
+ */
+
+import {
+  createRateLimiter,
+  MemoryRateLimitStore,
+  RATE_LIMIT_PRESETS,
+  RateLimitError,
+  type RateLimitConfig,
+  type RateLimitInfo,
+  type RateLimitRequest,
+  type RateLimitStore,
+} from '@kairn/core';
+
+import type { ApiErrorResponse } from './types';
+
+/**
+ * Rate limit result
+ */
+export type RateLimitResult =
+  | { success: true; info: RateLimitInfo; headers: Record<string, string> }
+  | { success: false; error: ApiErrorResponse; headers: Record<string, string> };
+
+/**
+ * Extract client IP from request
+ */
+export function getClientIP(request: RateLimitRequest): string {
+  // Check various headers for proxied requests
+  const forwardedFor = request.headers?.get('x-forwarded-for');
+  if (forwardedFor) {
+    // Take the first IP in the chain (client IP)
+    const firstIp = forwardedFor.split(',')[0]?.trim();
+    if (firstIp) return firstIp;
+  }
+
+  const realIp = request.headers?.get('x-real-ip');
+  if (realIp) return realIp;
+
+  // Vercel-specific header
+  const vercelIp = request.headers?.get('x-vercel-forwarded-for');
+  if (vercelIp) {
+    const firstIp = vercelIp.split(',')[0]?.trim();
+    if (firstIp) return firstIp;
+  }
+
+  // Cloudflare-specific header
+  const cfIp = request.headers?.get('cf-connecting-ip');
+  if (cfIp) return cfIp;
+
+  return request.ip || 'unknown';
+}
+
+/**
+ * Check rate limit for a request
+ *
+ * @param request - The incoming request
+ * @param config - Rate limit configuration or preset name
+ * @param store - Optional custom rate limit store
+ * @returns Rate limit result with info and headers
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: Request) {
+ *   const rateLimitResult = await withRateLimit(request, 'strict');
+ *
+ *   if (!rateLimitResult.success) {
+ *     return NextResponse.json(rateLimitResult.error, {
+ *       status: rateLimitResult.error.statusCode,
+ *       headers: rateLimitResult.headers,
+ *     });
+ *   }
+ *
+ *   // Continue with request...
+ *   return NextResponse.json(data, { headers: rateLimitResult.headers });
+ * }
+ * ```
+ */
+export async function withRateLimit(
+  request: RateLimitRequest,
+  config: Partial<RateLimitConfig> | keyof typeof RATE_LIMIT_PRESETS = 'standard',
+  store?: RateLimitStore
+): Promise<RateLimitResult> {
+  const rateLimitConfig = typeof config === 'string' ? RATE_LIMIT_PRESETS[config] : config;
+  const limiter = createRateLimiter(rateLimitConfig, store);
+
+  try {
+    const info = await limiter.checkRateLimit(request);
+    const headers = limiter.getRateLimitHeaders(info);
+
+    return {
+      success: true,
+      info,
+      headers,
+    };
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      const headers = {
+        'X-RateLimit-Limit': String(rateLimitConfig.maxRequests || 100),
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': String(Date.now() + (rateLimitConfig.windowMs || 900000)),
+        'Retry-After': String(err.retryAfter),
+      };
+
+      return {
+        success: false,
+        error: {
+          code: 'TOO_MANY_REQUESTS',
+          message: err.message,
+          statusCode: 429,
+          details: {
+            retryAfter: err.retryAfter,
+          },
+        },
+        headers,
+      };
+    }
+
+    throw err;
+  }
+}
+
+/**
+ * Create a rate limit middleware with preset configuration
+ *
+ * @param config - Default configuration
+ * @param store - Optional custom rate limit store
+ * @returns Configured rate limit middleware function
+ */
+export function createRateLimitMiddleware(
+  config: Partial<RateLimitConfig> | keyof typeof RATE_LIMIT_PRESETS = 'standard',
+  store?: RateLimitStore
+) {
+  return (request: RateLimitRequest, overrides?: Partial<RateLimitConfig>) => {
+    const finalConfig =
+      typeof config === 'string'
+        ? { ...RATE_LIMIT_PRESETS[config], ...overrides }
+        : { ...config, ...overrides };
+    return withRateLimit(request, finalConfig, store);
+  };
+}
+
+/**
+ * Create a key generator that combines IP with a custom identifier
+ *
+ * @param prefix - Prefix for the rate limit key (e.g., 'login', 'contact')
+ * @returns Key generator function
+ */
+export function createKeyGenerator(prefix: string) {
+  return (request: RateLimitRequest) => {
+    const ip = getClientIP(request);
+    return `${prefix}:${ip}`;
+  };
+}
+
+// Re-export useful types and presets
+export {
+  RATE_LIMIT_PRESETS,
+  MemoryRateLimitStore,
+  type RateLimitConfig,
+  type RateLimitRequest,
+  type RateLimitInfo,
+  type RateLimitStore,
+};

--- a/packages/api/src/middleware/with-validation.ts
+++ b/packages/api/src/middleware/with-validation.ts
@@ -1,0 +1,246 @@
+/**
+ * Validation Middleware
+ *
+ * Validates request body and query parameters using Zod schemas.
+ */
+
+import { z } from 'zod';
+
+import type { ApiErrorResponse, ApiRequest } from './types';
+
+/**
+ * Validation result type
+ */
+export type ValidationResult<TBody = unknown, TQuery = unknown> =
+  | { success: true; body: TBody; query: TQuery }
+  | { success: false; error: ApiErrorResponse };
+
+/**
+ * Parse query string from URL
+ */
+function parseQueryString(url?: string): Record<string, string | string[]> {
+  if (!url) return {};
+
+  try {
+    const urlObj = new URL(url);
+    const params: Record<string, string | string[]> = {};
+
+    urlObj.searchParams.forEach((value, key) => {
+      const existing = params[key];
+      if (existing) {
+        // Convert to array if multiple values
+        params[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+      } else {
+        params[key] = value;
+      }
+    });
+
+    return params;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Create validation error response
+ */
+function createValidationError(details: unknown, type: 'body' | 'query'): ApiErrorResponse {
+  return {
+    code: 'VALIDATION_ERROR',
+    message:
+      type === 'body'
+        ? 'Les données fournies sont invalides'
+        : 'Les paramètres de requête sont invalides',
+    statusCode: 400,
+    details: {
+      type,
+      errors: details,
+    },
+  };
+}
+
+/**
+ * Validate request body with Zod schema
+ *
+ * @param request - The incoming request
+ * @param schema - Zod schema for validation
+ * @returns Validation result with parsed body or error
+ *
+ * @example
+ * ```typescript
+ * const schema = z.object({
+ *   email: z.string().email(),
+ *   password: z.string().min(8),
+ * });
+ *
+ * export async function POST(request: Request) {
+ *   const result = await withBodyValidation(request, schema);
+ *
+ *   if (!result.success) {
+ *     return NextResponse.json(result.error, { status: result.error.statusCode });
+ *   }
+ *
+ *   const { email, password } = result.body;
+ *   // Continue with validated data...
+ * }
+ * ```
+ */
+export async function withBodyValidation<T extends z.ZodTypeAny>(
+  request: ApiRequest,
+  schema: T
+): Promise<{ success: true; body: z.infer<T> } | { success: false; error: ApiErrorResponse }> {
+  try {
+    const body = await request.json();
+    const result = schema.safeParse(body);
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: createValidationError(result.error.flatten(), 'body'),
+      };
+    }
+
+    return {
+      success: true,
+      body: result.data as z.infer<T>,
+    };
+  } catch {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_JSON',
+        message: 'Le corps de la requête doit être du JSON valide',
+        statusCode: 400,
+      },
+    };
+  }
+}
+
+/**
+ * Validate query parameters with Zod schema
+ *
+ * @param request - The incoming request
+ * @param schema - Zod schema for validation
+ * @returns Validation result with parsed query params or error
+ *
+ * @example
+ * ```typescript
+ * const schema = z.object({
+ *   page: z.coerce.number().int().min(1).default(1),
+ *   limit: z.coerce.number().int().min(1).max(100).default(20),
+ *   search: z.string().optional(),
+ * });
+ *
+ * export async function GET(request: Request) {
+ *   const result = withQueryValidation(request, schema);
+ *
+ *   if (!result.success) {
+ *     return NextResponse.json(result.error, { status: result.error.statusCode });
+ *   }
+ *
+ *   const { page, limit, search } = result.query;
+ *   // Continue with validated params...
+ * }
+ * ```
+ */
+export function withQueryValidation<T extends z.ZodTypeAny>(
+  request: ApiRequest,
+  schema: T
+): { success: true; query: z.infer<T> } | { success: false; error: ApiErrorResponse } {
+  const queryParams = parseQueryString(request.url);
+  const result = schema.safeParse(queryParams);
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: createValidationError(result.error.flatten(), 'query'),
+    };
+  }
+
+  return {
+    success: true,
+    query: result.data as z.infer<T>,
+  };
+}
+
+/**
+ * Validate both body and query parameters
+ *
+ * @param request - The incoming request
+ * @param bodySchema - Zod schema for body validation
+ * @param querySchema - Zod schema for query validation
+ * @returns Validation result with parsed body and query or error
+ */
+export async function withValidation<TBody extends z.ZodTypeAny, TQuery extends z.ZodTypeAny>(
+  request: ApiRequest,
+  bodySchema: TBody,
+  querySchema: TQuery
+): Promise<ValidationResult<z.infer<TBody>, z.infer<TQuery>>> {
+  // Validate query first (synchronous)
+  const queryResult = withQueryValidation(request, querySchema);
+  if (!queryResult.success) {
+    return queryResult;
+  }
+
+  // Then validate body
+  const bodyResult = await withBodyValidation(request, bodySchema);
+  if (!bodyResult.success) {
+    return bodyResult;
+  }
+
+  return {
+    success: true,
+    body: bodyResult.body,
+    query: queryResult.query,
+  };
+}
+
+/**
+ * Common validation schemas
+ */
+export const commonSchemas = {
+  /** Pagination query parameters */
+  pagination: z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(20),
+  }),
+
+  /** ID parameter */
+  id: z.object({
+    id: z.string().min(1),
+  }),
+
+  /** Slug parameter */
+  slug: z.object({
+    slug: z.string().min(1).max(200),
+  }),
+
+  /** Search query */
+  search: z.object({
+    q: z.string().max(200).optional(),
+  }),
+
+  /** Date range query */
+  dateRange: z.object({
+    startDate: z.string().datetime().optional(),
+    endDate: z.string().datetime().optional(),
+  }),
+
+  /** Email field */
+  email: z.string().email().max(255).toLowerCase(),
+
+  /** Non-empty string */
+  nonEmptyString: z.string().trim().min(1),
+};
+
+/**
+ * Create a factory for validation middleware with common options
+ */
+export function createValidationMiddleware() {
+  return {
+    body: withBodyValidation,
+    query: withQueryValidation,
+    both: withValidation,
+    schemas: commonSchemas,
+  };
+}

--- a/packages/api/src/utils/filters.ts
+++ b/packages/api/src/utils/filters.ts
@@ -1,0 +1,392 @@
+/**
+ * Filter Utilities
+ *
+ * Helper functions for parsing and applying filters from query parameters.
+ */
+
+/**
+ * Filter operator types
+ */
+export type FilterOperator =
+  | 'eq' // equals
+  | 'ne' // not equals
+  | 'gt' // greater than
+  | 'gte' // greater than or equal
+  | 'lt' // less than
+  | 'lte' // less than or equal
+  | 'in' // in array
+  | 'nin' // not in array
+  | 'contains' // string contains
+  | 'startsWith' // string starts with
+  | 'endsWith' // string ends with
+  | 'between'; // between two values
+
+/**
+ * Parsed filter value
+ */
+export interface ParsedFilter {
+  field: string;
+  operator: FilterOperator;
+  value: unknown;
+}
+
+/**
+ * Filter configuration
+ */
+export interface FilterConfig {
+  /** Allowed fields for filtering */
+  allowedFields?: string[];
+  /** Field type mappings for proper parsing */
+  fieldTypes?: Record<string, 'string' | 'number' | 'boolean' | 'date' | 'array'>;
+  /** Default operator if not specified */
+  defaultOperator?: FilterOperator;
+}
+
+/**
+ * Sort direction
+ */
+export type SortDirection = 'asc' | 'desc';
+
+/**
+ * Parsed sort value
+ */
+export interface ParsedSort {
+  field: string;
+  direction: SortDirection;
+}
+
+/**
+ * Parse filter value based on field type
+ */
+function parseValue(value: string, type?: string): unknown {
+  if (!type || type === 'string') {
+    return value;
+  }
+
+  switch (type) {
+    case 'number': {
+      const num = parseFloat(value);
+      return isNaN(num) ? value : num;
+    }
+
+    case 'boolean':
+      return value === 'true' || value === '1';
+
+    case 'date': {
+      const date = new Date(value);
+      return isNaN(date.getTime()) ? value : date;
+    }
+
+    case 'array':
+      return value.split(',').map(v => v.trim());
+
+    default:
+      return value;
+  }
+}
+
+/**
+ * Parse filters from query parameters
+ *
+ * Supports various filter formats:
+ * - Simple: ?status=published
+ * - Operator: ?price[gte]=100
+ * - Array: ?tags[in]=news,tech
+ *
+ * @param params - URL search params or query object
+ * @param config - Filter configuration
+ * @returns Array of parsed filters
+ *
+ * @example
+ * ```typescript
+ * const url = new URL(request.url);
+ * const filters = parseFilters(url.searchParams, {
+ *   allowedFields: ['status', 'category', 'createdAt'],
+ *   fieldTypes: { createdAt: 'date' },
+ * });
+ *
+ * // Build Prisma where clause
+ * const where = buildPrismaFilters(filters);
+ * ```
+ */
+export function parseFilters(
+  params: URLSearchParams | Record<string, string | string[] | undefined>,
+  config: FilterConfig = {}
+): ParsedFilter[] {
+  const { allowedFields, fieldTypes = {}, defaultOperator = 'eq' } = config;
+  const filters: ParsedFilter[] = [];
+
+  // Convert to entries
+  const entries: [string, string][] =
+    params instanceof URLSearchParams
+      ? Array.from(params.entries())
+      : Object.entries(params)
+          .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+          .concat(
+            Object.entries(params)
+              .filter((entry): entry is [string, string[]] => Array.isArray(entry[1]))
+              .flatMap(([key, values]) => values.map(v => [key, v] as [string, string]))
+          );
+
+  for (const [key, value] of entries) {
+    // Skip pagination and sorting params
+    if (['page', 'limit', 'sort', 'order', 'cursor'].includes(key)) {
+      continue;
+    }
+
+    // Parse key for operator: field[operator]=value
+    const match = key.match(/^(\w+)(?:\[(\w+)\])?$/);
+    if (!match) continue;
+
+    const [, field, operatorStr] = match;
+    if (!field) continue;
+
+    // Check if field is allowed
+    if (allowedFields && !allowedFields.includes(field)) {
+      continue;
+    }
+
+    // Parse operator
+    const operator = (operatorStr as FilterOperator) || defaultOperator;
+
+    // Parse value based on field type
+    const parsedValue = parseValue(value, fieldTypes[field]);
+
+    // Handle special cases
+    if (operator === 'in' || operator === 'nin') {
+      // Split comma-separated values
+      const arrayValue =
+        typeof parsedValue === 'string'
+          ? parsedValue.split(',').map(v => parseValue(v.trim(), fieldTypes[field]))
+          : Array.isArray(parsedValue)
+            ? parsedValue
+            : [parsedValue];
+
+      filters.push({ field, operator, value: arrayValue });
+    } else if (operator === 'between') {
+      // Expect format: min,max
+      const [min, max] =
+        typeof parsedValue === 'string'
+          ? parsedValue.split(',').map(v => parseValue(v.trim(), fieldTypes[field]))
+          : [parsedValue, parsedValue];
+
+      filters.push({ field, operator, value: { min, max } });
+    } else {
+      filters.push({ field, operator, value: parsedValue });
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Parse sort parameters from query
+ *
+ * Supports formats:
+ * - Simple: ?sort=createdAt
+ * - With direction: ?sort=createdAt&order=desc
+ * - Combined: ?sort=-createdAt (- prefix for desc)
+ * - Multiple: ?sort=category,-createdAt
+ *
+ * @param params - URL search params or query object
+ * @param allowedFields - Optional list of allowed sort fields
+ * @returns Array of parsed sort values
+ */
+export function parseSort(
+  params: URLSearchParams | Record<string, string | undefined>,
+  allowedFields?: string[]
+): ParsedSort[] {
+  const getValue = (key: string) =>
+    params instanceof URLSearchParams ? params.get(key) : params[key];
+
+  const sortParam = getValue('sort');
+  const orderParam = getValue('order');
+
+  if (!sortParam) {
+    return [];
+  }
+
+  const sorts: ParsedSort[] = [];
+  const fields = sortParam.split(',');
+
+  for (let field of fields) {
+    field = field.trim();
+    if (!field) continue;
+
+    // Check for direction prefix
+    let direction: SortDirection = 'asc';
+    if (field.startsWith('-')) {
+      direction = 'desc';
+      field = field.slice(1);
+    } else if (field.startsWith('+')) {
+      field = field.slice(1);
+    }
+
+    // Check if field is allowed
+    if (allowedFields && !allowedFields.includes(field)) {
+      continue;
+    }
+
+    // Use order param for first field if no prefix was used
+    if (
+      sorts.length === 0 &&
+      orderParam &&
+      !sortParam.startsWith('-') &&
+      !sortParam.startsWith('+')
+    ) {
+      direction = orderParam === 'desc' ? 'desc' : 'asc';
+    }
+
+    sorts.push({ field, direction });
+  }
+
+  return sorts;
+}
+
+/**
+ * Convert parsed filters to Prisma where clause
+ *
+ * @param filters - Parsed filters
+ * @returns Prisma-compatible where object
+ */
+export function buildPrismaFilters(filters: ParsedFilter[]): Record<string, unknown> {
+  const where: Record<string, unknown> = {};
+
+  for (const { field, operator, value } of filters) {
+    switch (operator) {
+      case 'eq':
+        where[field] = value;
+        break;
+
+      case 'ne':
+        where[field] = { not: value };
+        break;
+
+      case 'gt':
+        where[field] = { gt: value };
+        break;
+
+      case 'gte':
+        where[field] = { gte: value };
+        break;
+
+      case 'lt':
+        where[field] = { lt: value };
+        break;
+
+      case 'lte':
+        where[field] = { lte: value };
+        break;
+
+      case 'in':
+        where[field] = { in: value };
+        break;
+
+      case 'nin':
+        where[field] = { notIn: value };
+        break;
+
+      case 'contains':
+        where[field] = { contains: value, mode: 'insensitive' };
+        break;
+
+      case 'startsWith':
+        where[field] = { startsWith: value, mode: 'insensitive' };
+        break;
+
+      case 'endsWith':
+        where[field] = { endsWith: value, mode: 'insensitive' };
+        break;
+
+      case 'between': {
+        const { min, max } = value as { min: unknown; max: unknown };
+        where[field] = { gte: min, lte: max };
+        break;
+      }
+    }
+  }
+
+  return where;
+}
+
+/**
+ * Convert parsed sorts to Prisma orderBy clause
+ *
+ * @param sorts - Parsed sorts
+ * @returns Prisma-compatible orderBy array
+ */
+export function buildPrismaSort(sorts: ParsedSort[]): Record<string, SortDirection>[] {
+  return sorts.map(({ field, direction }) => ({ [field]: direction }));
+}
+
+/**
+ * Parse date range from query parameters
+ *
+ * @param params - URL search params or query object
+ * @param startKey - Key for start date (default: 'startDate')
+ * @param endKey - Key for end date (default: 'endDate')
+ * @returns Date range object or null if not specified
+ */
+export function parseDateRange(
+  params: URLSearchParams | Record<string, string | undefined>,
+  startKey = 'startDate',
+  endKey = 'endDate'
+): { start: Date | null; end: Date | null } {
+  const getValue = (key: string) =>
+    params instanceof URLSearchParams ? params.get(key) : params[key];
+
+  const startStr = getValue(startKey);
+  const endStr = getValue(endKey);
+
+  const start = startStr ? new Date(startStr) : null;
+  const end = endStr ? new Date(endStr) : null;
+
+  return {
+    start: start && !isNaN(start.getTime()) ? start : null,
+    end: end && !isNaN(end.getTime()) ? end : null,
+  };
+}
+
+/**
+ * Parse search query from parameters
+ *
+ * @param params - URL search params or query object
+ * @param keys - Keys to check for search query (default: ['q', 'search', 'query'])
+ * @returns Search query string or null
+ */
+export function parseSearch(
+  params: URLSearchParams | Record<string, string | undefined>,
+  keys = ['q', 'search', 'query']
+): string | null {
+  const getValue = (key: string) =>
+    params instanceof URLSearchParams ? params.get(key) : params[key];
+
+  for (const key of keys) {
+    const value = getValue(key);
+    if (value && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Create a filter parser with preset configuration
+ */
+export function createFilterParser(config: FilterConfig = {}) {
+  return {
+    filters: (params: URLSearchParams | Record<string, string | string[] | undefined>) =>
+      parseFilters(params, config),
+    sort: (
+      params: URLSearchParams | Record<string, string | undefined>,
+      allowedFields?: string[]
+    ) => parseSort(params, allowedFields || config.allowedFields),
+    dateRange: parseDateRange,
+    search: parseSearch,
+    toPrisma: {
+      where: buildPrismaFilters,
+      orderBy: buildPrismaSort,
+    },
+  };
+}

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -1,0 +1,50 @@
+/**
+ * @kairn/api Utilities
+ *
+ * Helper functions for API handlers.
+ */
+
+// Response utilities
+export {
+  success,
+  error,
+  paginated,
+  buildHeaders,
+  getStatusForError,
+  ErrorCodes,
+  HttpStatus,
+  ErrorCodeToStatus,
+  CacheControl,
+  type SuccessResponse,
+  type ErrorResponse,
+  type PaginatedResponse,
+} from './response';
+
+// Pagination utilities
+export {
+  parsePagination,
+  calculatePagination,
+  getCursorPagination,
+  buildPaginationLinks,
+  createPaginator,
+  DEFAULT_PAGINATION,
+  type PaginationParams,
+  type PaginationQuery,
+  type PaginationMeta,
+} from './pagination';
+
+// Filter utilities
+export {
+  parseFilters,
+  parseSort,
+  parseDateRange,
+  parseSearch,
+  buildPrismaFilters,
+  buildPrismaSort,
+  createFilterParser,
+  type FilterOperator,
+  type ParsedFilter,
+  type FilterConfig,
+  type SortDirection,
+  type ParsedSort,
+} from './filters';

--- a/packages/api/src/utils/pagination.ts
+++ b/packages/api/src/utils/pagination.ts
@@ -1,0 +1,240 @@
+/**
+ * Pagination Utilities
+ *
+ * Helper functions for handling pagination in API responses.
+ */
+
+/**
+ * Pagination parameters
+ */
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+}
+
+/**
+ * Calculated pagination values for database queries
+ */
+export interface PaginationQuery {
+  skip: number;
+  take: number;
+  page: number;
+  limit: number;
+}
+
+/**
+ * Pagination result metadata
+ */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+  nextPage: number | null;
+  previousPage: number | null;
+}
+
+/**
+ * Default pagination configuration
+ */
+export const DEFAULT_PAGINATION = {
+  page: 1,
+  limit: 20,
+  maxLimit: 100,
+  minLimit: 1,
+} as const;
+
+/**
+ * Parse and validate pagination parameters
+ *
+ * @param params - Raw pagination parameters
+ * @param options - Configuration options
+ * @returns Validated pagination query values
+ *
+ * @example
+ * ```typescript
+ * const { skip, take, page, limit } = parsePagination({
+ *   page: searchParams.get('page'),
+ *   limit: searchParams.get('limit'),
+ * });
+ *
+ * const posts = await prisma.post.findMany({
+ *   skip,
+ *   take,
+ * });
+ * ```
+ */
+export function parsePagination(
+  params: PaginationParams | { page?: string | null; limit?: string | null },
+  options: {
+    defaultLimit?: number;
+    maxLimit?: number;
+    minLimit?: number;
+  } = {}
+): PaginationQuery {
+  const {
+    defaultLimit = DEFAULT_PAGINATION.limit,
+    maxLimit = DEFAULT_PAGINATION.maxLimit,
+    minLimit = DEFAULT_PAGINATION.minLimit,
+  } = options;
+
+  // Parse page
+  let page: number = DEFAULT_PAGINATION.page;
+  const rawPage = params.page;
+  if (rawPage !== undefined && rawPage !== null) {
+    const parsed = typeof rawPage === 'string' ? parseInt(rawPage, 10) : rawPage;
+    if (!isNaN(parsed) && parsed >= 1) {
+      page = parsed;
+    }
+  }
+
+  // Parse limit
+  let limit = defaultLimit;
+  const rawLimit = params.limit;
+  if (rawLimit !== undefined && rawLimit !== null) {
+    const parsed = typeof rawLimit === 'string' ? parseInt(rawLimit, 10) : rawLimit;
+    if (!isNaN(parsed)) {
+      limit = Math.max(minLimit, Math.min(maxLimit, parsed));
+    }
+  }
+
+  return {
+    skip: (page - 1) * limit,
+    take: limit,
+    page,
+    limit,
+  };
+}
+
+/**
+ * Calculate pagination metadata from results
+ *
+ * @param page - Current page number
+ * @param limit - Items per page
+ * @param total - Total number of items
+ * @returns Pagination metadata
+ *
+ * @example
+ * ```typescript
+ * const total = await prisma.post.count({ where: { published: true } });
+ * const pagination = calculatePagination(page, limit, total);
+ *
+ * return NextResponse.json({
+ *   data: posts,
+ *   pagination,
+ * });
+ * ```
+ */
+export function calculatePagination(page: number, limit: number, total: number): PaginationMeta {
+  const totalPages = Math.ceil(total / limit) || 1;
+  const hasNext = page < totalPages;
+  const hasPrevious = page > 1;
+
+  return {
+    page,
+    limit,
+    total,
+    totalPages,
+    hasNext,
+    hasPrevious,
+    nextPage: hasNext ? page + 1 : null,
+    previousPage: hasPrevious ? page - 1 : null,
+  };
+}
+
+/**
+ * Get offset for cursor-based pagination
+ *
+ * @param cursor - Cursor value (e.g., last item ID)
+ * @param limit - Number of items to fetch
+ * @returns Prisma cursor configuration
+ *
+ * @example
+ * ```typescript
+ * const posts = await prisma.post.findMany({
+ *   ...getCursorPagination(cursor, limit),
+ *   orderBy: { createdAt: 'desc' },
+ * });
+ * ```
+ */
+export function getCursorPagination(
+  cursor: string | null | undefined,
+  limit: number
+): {
+  take: number;
+  skip?: number;
+  cursor?: { id: string };
+} {
+  if (!cursor) {
+    return { take: limit };
+  }
+
+  return {
+    take: limit,
+    skip: 1, // Skip the cursor item
+    cursor: { id: cursor },
+  };
+}
+
+/**
+ * Build pagination links for API responses
+ *
+ * @param baseUrl - Base URL for pagination links
+ * @param pagination - Pagination metadata
+ * @returns Object with pagination URLs
+ *
+ * @example
+ * ```typescript
+ * const links = buildPaginationLinks('/api/posts', pagination);
+ * // { first: '/api/posts?page=1', last: '/api/posts?page=5', next: '/api/posts?page=3', prev: '/api/posts?page=1' }
+ * ```
+ */
+export function buildPaginationLinks(
+  baseUrl: string,
+  pagination: PaginationMeta
+): {
+  first: string;
+  last: string;
+  next: string | null;
+  prev: string | null;
+} {
+  const { page, limit, totalPages, hasNext, hasPrevious } = pagination;
+
+  // Parse existing URL and preserve other query params
+  const url = new URL(baseUrl, 'http://localhost');
+  const setPage = (p: number) => {
+    const newUrl = new URL(url);
+    newUrl.searchParams.set('page', String(p));
+    newUrl.searchParams.set('limit', String(limit));
+    return newUrl.pathname + newUrl.search;
+  };
+
+  return {
+    first: setPage(1),
+    last: setPage(totalPages),
+    next: hasNext ? setPage(page + 1) : null,
+    prev: hasPrevious ? setPage(page - 1) : null,
+  };
+}
+
+/**
+ * Create a reusable paginator for a specific configuration
+ *
+ * @param config - Default pagination configuration
+ * @returns Paginator functions
+ */
+export function createPaginator(
+  config: {
+    defaultLimit?: number;
+    maxLimit?: number;
+  } = {}
+) {
+  return {
+    parse: (params: PaginationParams) => parsePagination(params, config),
+    calculate: calculatePagination,
+    cursor: getCursorPagination,
+    links: buildPaginationLinks,
+  };
+}

--- a/packages/api/src/utils/response.ts
+++ b/packages/api/src/utils/response.ts
@@ -1,0 +1,256 @@
+/**
+ * API Response Utilities
+ *
+ * Helper functions for creating standardized API responses.
+ */
+
+/**
+ * Success response structure
+ */
+export interface SuccessResponse<T = unknown> {
+  success: true;
+  data: T;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Error response structure
+ */
+export interface ErrorResponse {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+}
+
+/**
+ * Paginated response structure
+ */
+export interface PaginatedResponse<T = unknown> {
+  success: true;
+  data: T[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrevious: boolean;
+  };
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Create a success response
+ *
+ * @param data - Response data
+ * @param meta - Optional metadata
+ * @returns Success response object
+ *
+ * @example
+ * ```typescript
+ * return NextResponse.json(success({ user: { id: '1', name: 'John' } }));
+ * ```
+ */
+export function success<T>(data: T, meta?: Record<string, unknown>): SuccessResponse<T> {
+  return {
+    success: true,
+    data,
+    ...(meta && { meta }),
+  };
+}
+
+/**
+ * Create an error response
+ *
+ * @param code - Error code
+ * @param message - Error message
+ * @param details - Optional error details
+ * @returns Error response object
+ *
+ * @example
+ * ```typescript
+ * return NextResponse.json(error('NOT_FOUND', 'User not found'), { status: 404 });
+ * ```
+ */
+export function error(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>
+): ErrorResponse {
+  return {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(details && { details }),
+    },
+  };
+}
+
+/**
+ * Create a paginated response
+ *
+ * @param data - Array of items
+ * @param pagination - Pagination info
+ * @param meta - Optional metadata
+ * @returns Paginated response object
+ *
+ * @example
+ * ```typescript
+ * return NextResponse.json(paginated(posts, {
+ *   page: 1,
+ *   limit: 20,
+ *   total: 100,
+ * }));
+ * ```
+ */
+export function paginated<T>(
+  data: T[],
+  pagination: { page: number; limit: number; total: number },
+  meta?: Record<string, unknown>
+): PaginatedResponse<T> {
+  const { page, limit, total } = pagination;
+  const totalPages = Math.ceil(total / limit);
+
+  return {
+    success: true,
+    data,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages,
+      hasNext: page < totalPages,
+      hasPrevious: page > 1,
+    },
+    ...(meta && { meta }),
+  };
+}
+
+/**
+ * Standard error codes
+ */
+export const ErrorCodes = {
+  // Validation
+  INVALID_INPUT: 'INVALID_INPUT',
+  MISSING_FIELD: 'MISSING_FIELD',
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+
+  // Authentication
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+  TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+  INVALID_TOKEN: 'INVALID_TOKEN',
+  INSUFFICIENT_PERMISSIONS: 'INSUFFICIENT_PERMISSIONS',
+
+  // Resources
+  NOT_FOUND: 'NOT_FOUND',
+  ALREADY_EXISTS: 'ALREADY_EXISTS',
+  CONFLICT: 'CONFLICT',
+
+  // Rate limiting
+  TOO_MANY_REQUESTS: 'TOO_MANY_REQUESTS',
+
+  // Server
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+
+  // CSRF
+  CSRF_INVALID: 'CSRF_INVALID',
+} as const;
+
+/**
+ * Standard HTTP status codes with their default messages
+ */
+export const HttpStatus = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  UNPROCESSABLE_ENTITY: 422,
+  TOO_MANY_REQUESTS: 429,
+  INTERNAL_SERVER_ERROR: 500,
+  SERVICE_UNAVAILABLE: 503,
+} as const;
+
+/**
+ * Map error codes to HTTP status codes
+ */
+export const ErrorCodeToStatus: Record<string, number> = {
+  [ErrorCodes.INVALID_INPUT]: HttpStatus.BAD_REQUEST,
+  [ErrorCodes.MISSING_FIELD]: HttpStatus.BAD_REQUEST,
+  [ErrorCodes.VALIDATION_ERROR]: HttpStatus.BAD_REQUEST,
+  [ErrorCodes.UNAUTHORIZED]: HttpStatus.UNAUTHORIZED,
+  [ErrorCodes.INVALID_CREDENTIALS]: HttpStatus.UNAUTHORIZED,
+  [ErrorCodes.TOKEN_EXPIRED]: HttpStatus.UNAUTHORIZED,
+  [ErrorCodes.INVALID_TOKEN]: HttpStatus.UNAUTHORIZED,
+  [ErrorCodes.INSUFFICIENT_PERMISSIONS]: HttpStatus.FORBIDDEN,
+  [ErrorCodes.NOT_FOUND]: HttpStatus.NOT_FOUND,
+  [ErrorCodes.ALREADY_EXISTS]: HttpStatus.CONFLICT,
+  [ErrorCodes.CONFLICT]: HttpStatus.CONFLICT,
+  [ErrorCodes.TOO_MANY_REQUESTS]: HttpStatus.TOO_MANY_REQUESTS,
+  [ErrorCodes.INTERNAL_ERROR]: HttpStatus.INTERNAL_SERVER_ERROR,
+  [ErrorCodes.SERVICE_UNAVAILABLE]: HttpStatus.SERVICE_UNAVAILABLE,
+  [ErrorCodes.CSRF_INVALID]: HttpStatus.FORBIDDEN,
+};
+
+/**
+ * Get status code for an error code
+ */
+export function getStatusForError(code: string): number {
+  return ErrorCodeToStatus[code] || HttpStatus.INTERNAL_SERVER_ERROR;
+}
+
+/**
+ * Common cache control headers
+ */
+export const CacheControl = {
+  /** No caching at all */
+  noCache: 'private, no-cache, no-store, must-revalidate',
+
+  /** Short cache (5 minutes) */
+  short: 'public, max-age=300, stale-while-revalidate=3600',
+
+  /** Medium cache (1 hour) */
+  medium: 'public, s-maxage=3600, max-age=3600, stale-while-revalidate=86400',
+
+  /** Long cache (24 hours) */
+  long: 'public, s-maxage=86400, max-age=86400, stale-while-revalidate=604800',
+
+  /** Private, revalidate on each request */
+  private: 'private, must-revalidate',
+} as const;
+
+/**
+ * Build common response headers
+ */
+export function buildHeaders(options: {
+  cacheControl?: keyof typeof CacheControl;
+  rateLimitHeaders?: Record<string, string>;
+  custom?: Record<string, string>;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (options.cacheControl) {
+    headers['Cache-Control'] = CacheControl[options.cacheControl];
+  }
+
+  if (options.rateLimitHeaders) {
+    Object.assign(headers, options.rateLimitHeaders);
+  }
+
+  if (options.custom) {
+    Object.assign(headers, options.custom);
+  }
+
+  return headers;
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@kairn/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,40 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
+  packages/api:
+    dependencies:
+      '@kairn/analytics':
+        specifier: workspace:*
+        version: link:../analytics
+      '@kairn/blog':
+        specifier: workspace:*
+        version: link:../blog
+      '@kairn/config':
+        specifier: workspace:*
+        version: link:../config
+      '@kairn/core':
+        specifier: workspace:*
+        version: link:../core
+      '@kairn/db':
+        specifier: workspace:*
+        version: link:../db
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+    devDependencies:
+      '@kairn/typescript-config':
+        specifier: workspace:*
+        version: link:../../tooling/typescript-config
+      '@prisma/client':
+        specifier: ^6.0.0
+        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.30
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   packages/blog:
     dependencies:
       reading-time:
@@ -490,9 +524,12 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.2(eslint@8.57.1)
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.0
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y:
         specifier: ^6.8.0
         version: 6.10.2(eslint@8.57.1)
@@ -604,8 +641,14 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@emnapi/core@1.8.1':
+    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1115,6 +1158,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@next/env@14.2.33':
     resolution: {integrity: sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==}
 
@@ -1186,6 +1232,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nolyfill/is-core-module@1.0.39':
+    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
+    engines: {node: '>=12.4.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1394,6 +1444,9 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@types/bcrypt@6.0.0':
     resolution: {integrity: sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==}
 
@@ -1567,6 +1620,101 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -2261,6 +2409,19 @@ packages:
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
+  eslint-import-resolver-typescript@3.10.1:
+    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
+
   eslint-module-utils@2.12.1:
     resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
     engines: {node: '>=4'}
@@ -2736,6 +2897,9 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-bun-module@2.0.0:
+    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -3259,6 +3423,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -3980,6 +4149,9 @@ packages:
     resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
     engines: {node: '>=0.8'}
 
+  stable-hash@0.0.5:
+    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4338,6 +4510,9 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -4626,7 +4801,18 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@emnapi/core@1.8.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4947,6 +5133,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.8.1
+      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@14.2.33': {}
 
   '@next/env@14.2.35': {}
@@ -4989,6 +5182,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@nolyfill/is-core-module@1.0.39': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5156,6 +5351,11 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/bcrypt@6.0.0':
     dependencies:
@@ -5373,6 +5573,65 @@ snapshots:
       - supports-color
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@20.19.30)(jsdom@27.4.0))':
     dependencies:
@@ -6170,17 +6429,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 8.57.1
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6191,7 +6466,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -6849,6 +7124,10 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-bun-module@2.0.0:
+    dependencies:
+      semver: 7.7.3
 
   is-callable@1.2.7: {}
 
@@ -7596,6 +7875,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
 
@@ -8438,6 +8719,8 @@ snapshots:
     dependencies:
       frac: 1.1.2
 
+  stable-hash@0.0.5: {}
+
   stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
@@ -8882,6 +9165,30 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:

--- a/tooling/eslint-config/package.json
+++ b/tooling/eslint-config/package.json
@@ -13,6 +13,7 @@
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-import-resolver-typescript": "^3.6.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
Create new @kairn/api package with reusable API handlers, middlewares,
and utilities for the Kairn platform.

Middlewares:
- withAuth: JWT authentication with cookie/header support
- withAdmin: Admin role verification
- withRateLimit: Rate limiting wrapper using @kairn/core
- withCSRF: CSRF protection with HMAC-signed tokens
- withValidation: Zod schema validation for body/query params

Utilities:
- response: success, error, paginated response helpers
- pagination: offset/cursor pagination utilities
- filters: query filter parsing with Prisma builders

Handlers:
- auth: login, logout, refresh, forgot-password
- blog: posts CRUD, tags CRUD
- analytics: track, dashboard, realtime, export
- contact: contact form with CSRF/rate limiting
- testimonials: CRUD operations
- seminars: CRUD with registration support

Also adds eslint-import-resolver-typescript to fix ESLint import
resolution in the monorepo.