### PR TITLE
feat(ai): implement phase 4 mutualization - add @kairn/ai package

### DIFF
--- a/packages/ai/.eslintrc.json
+++ b/packages/ai/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["@kairn/eslint-config"],
+  "parserOptions": {
+    "project": true
+  },
+  "rules": {
+    "no-console": "off"
+  },
+  "ignorePatterns": ["dist/"]
+}

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@kairn/ai",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Abstraction des services IA pour la plateforme Kairn",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./providers": {
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/providers/index.js"
+    },
+    "./services": {
+      "types": "./dist/services/index.d.ts",
+      "import": "./dist/services/index.js"
+    },
+    "./prompts": {
+      "types": "./dist/prompts/index.d.ts",
+      "import": "./dist/prompts/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@kairn/config": "workspace:*",
+    "@kairn/core": "workspace:*",
+    "zod": "^3.22.0"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/sdk": ">=0.20.0",
+    "openai": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "openai": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@anthropic-ai/sdk": "^0.26.0",
+    "@kairn/eslint-config": "workspace:*",
+    "@kairn/typescript-config": "workspace:*",
+    "eslint": "^8.57.0",
+    "openai": "^4.52.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,0 +1,202 @@
+/**
+ * @kairn/ai - AI Services Abstraction for Kairn Platform
+ *
+ * This package provides a unified interface for AI services including:
+ * - Text generation (Anthropic Claude, OpenAI GPT)
+ * - Image generation (OpenAI DALL-E)
+ * - Content generation (blog articles)
+ * - Social media post generation
+ * - Text improvement
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   createAnthropicProviderFromEnv,
+ *   createOpenAIProviderFromEnv,
+ *   createContentGenerator,
+ *   createSocialGenerator,
+ *   createImageGenerator,
+ * } from "@kairn/ai";
+ *
+ * // Create providers
+ * const anthropic = createAnthropicProviderFromEnv();
+ * const openai = createOpenAIProviderFromEnv();
+ *
+ * // Create services
+ * const contentGenerator = createContentGenerator(anthropic);
+ * const socialGenerator = createSocialGenerator(anthropic);
+ * const imageGenerator = createImageGenerator(anthropic, openai);
+ *
+ * // Generate content
+ * const article = await contentGenerator.generateFullArticle({
+ *   topic: "Les bienfaits de la méditation",
+ *   length: "medium",
+ *   tone: "educational",
+ * });
+ *
+ * // Generate social posts
+ * const posts = await socialGenerator.generateForPlatforms(
+ *   article.content,
+ *   article.title,
+ *   ["linkedin", "instagram", "facebook"]
+ * );
+ *
+ * // Generate images
+ * const images = await imageGenerator.generateFromArticle(
+ *   article.title,
+ *   article.content,
+ *   { name: "MyBrand", colors: ["#c7a962", "#0e1f2f"] }
+ * );
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// ============================================
+// Providers
+// ============================================
+
+export {
+  // Types
+  type AIProvider,
+  type GenerateTextOptions,
+  type GenerateImageOptions,
+  type TextGenerationResult,
+  type ImageGenerationResult,
+  type AnthropicProviderConfig,
+  type OpenAIProviderConfig,
+  type RetryOptions,
+
+  // Error classes
+  AIProviderError,
+  AITimeoutError,
+  AIRateLimitError,
+  AIAuthenticationError,
+
+  // Zod schemas
+  GenerateTextOptionsSchema,
+  GenerateImageOptionsSchema,
+
+  // Anthropic
+  AnthropicProvider,
+  createAnthropicProvider,
+  createAnthropicProviderFromEnv,
+
+  // OpenAI
+  OpenAIProvider,
+  createOpenAIProvider,
+  createOpenAIProviderFromEnv,
+} from './providers/index.js';
+
+// ============================================
+// Services
+// ============================================
+
+export {
+  // Types
+  type ArticleTone,
+  type ArticleLength,
+  type ArticleCategory,
+  type ArticleGenerationOptions,
+  type GeneratedArticle,
+  type ArticleOutline,
+  type SocialPlatform,
+  type SocialTone,
+  type SocialAngle,
+  type SocialFormat,
+  type SocialPostGenerationOptions,
+  type GeneratedSocialPost,
+  type MultiPlatformPosts,
+  type ImageGenerationOptions,
+  type GeneratedImage,
+  type ImprovementType,
+  type TextImprovementOptions,
+  type ImprovedText,
+
+  // Zod schemas
+  ArticleGenerationOptionsSchema,
+  SocialPostGenerationOptionsSchema,
+  TextImprovementOptionsSchema,
+
+  // Content Generator
+  ContentGenerator,
+  createContentGenerator,
+
+  // Social Generator
+  SocialGenerator,
+  createSocialGenerator,
+
+  // Image Generator
+  ImageGenerator,
+  createImageGenerator,
+  createImageGeneratorSingleProvider,
+
+  // Text Improver
+  TextImprover,
+  createTextImprover,
+} from './services/index.js';
+
+// ============================================
+// Prompts
+// ============================================
+
+export {
+  // Blog article prompts
+  buildArticlePrompt,
+  buildOutlinePrompt,
+  buildSectionPrompt,
+  buildFaqPrompt,
+  buildMetaDescriptionPrompt,
+  buildTagsPrompt,
+  LENGTH_CONFIG,
+  TONE_DESCRIPTIONS,
+  DEFAULT_SYSTEM_PROMPT,
+  type ArticlePromptConfig,
+
+  // Social post prompts
+  buildSocialPostPrompt,
+  buildMultiPlatformPrompt,
+  PLATFORM_CONFIG,
+  SOCIAL_TONE_DESCRIPTIONS,
+  SOCIAL_ANGLE_DESCRIPTIONS,
+  INSTAGRAM_FORMATS,
+  THREADS_FORMATS,
+  LINKEDIN_FORMATS,
+  type SocialPromptConfig,
+
+  // Image prompts
+  buildImagePrompt,
+  buildBrandedImagePrompt,
+  buildImageDescriptionPrompt,
+  buildImageVariationsPrompt,
+  STYLE_DESCRIPTIONS,
+  MOOD_DESCRIPTIONS,
+  type ImagePromptConfig,
+  type BrandedImageConfig,
+  type ImageStyle,
+  type ImageMood,
+  type ImageSubject,
+} from './prompts/index.js';
+
+// ============================================
+// Utilities
+// ============================================
+
+export {
+  // Retry utilities
+  withRetry,
+  createRetryable,
+  isRetriableError,
+  sleep,
+  calculateDelay,
+  type RetryConfig,
+
+  // Parsing utilities
+  parseJsonSafe,
+  extractXmlBlock,
+  extractAllXmlBlocks,
+  validateXmlTags,
+  parseList,
+  parseFaq,
+  cleanMarkdown,
+} from './utils/index.js';

--- a/packages/ai/src/prompts/blog-article.ts
+++ b/packages/ai/src/prompts/blog-article.ts
@@ -1,0 +1,302 @@
+/**
+ * Blog article generation prompt templates
+ * @package @kairn/ai
+ */
+
+import type { ArticleTone, ArticleLength, ArticleCategory } from '../services/types.js';
+
+// ============================================
+// Prompt Configuration Types
+// ============================================
+
+export interface ArticlePromptConfig {
+  topic: string;
+  category?: ArticleCategory;
+  length?: ArticleLength;
+  tone?: ArticleTone;
+  tones?: ArticleTone[];
+  keywords?: string[];
+  targetAudience?: string;
+  seoQuery?: string;
+  searchIntent?: string;
+  language?: 'fr' | 'en';
+  customSystemPrompt?: string;
+}
+
+// ============================================
+// Length Configuration
+// ============================================
+
+export const LENGTH_CONFIG = {
+  short: {
+    wordRange: '800-1000',
+    maxTokens: 6000,
+    sectionCount: '3-4',
+  },
+  medium: {
+    wordRange: '1000-1500',
+    maxTokens: 10000,
+    sectionCount: '4-6',
+  },
+  long: {
+    wordRange: '1500-2000',
+    maxTokens: 16000,
+    sectionCount: '6-8',
+  },
+} as const;
+
+// ============================================
+// Tone Descriptions
+// ============================================
+
+export const TONE_DESCRIPTIONS: Record<ArticleTone, string> = {
+  professional: 'Formel, expert, basé sur des faits',
+  casual: 'Décontracté, conversationnel, accessible',
+  educational: 'Pédagogique, explicatif, didactique',
+  inspirational: 'Motivant, encourageant, positif',
+  analytical: 'Analytique, logique, structuré',
+  poetic: 'Poétique, évocateur, imagé',
+  introspective: 'Introspectif, réflexif, contemplatif',
+  narrative: 'Narratif, storytelling, engageant',
+  conversational: 'Dialogue, questions-réponses, interactif',
+  provocative: 'Provocateur, questionnant, challengeant',
+  humorous: 'Humoristique, léger, divertissant',
+  scientific: 'Scientifique, rigoureux, sourcé',
+  practical: 'Pratique, actionnable, concret',
+};
+
+// ============================================
+// Default System Prompt
+// ============================================
+
+export const DEFAULT_SYSTEM_PROMPT = `Tu es un rédacteur web senior spécialisé en SEO et en création de contenu de qualité.
+
+Règles de rédaction :
+1. Structure claire avec introduction, corps et conclusion
+2. Utilise des sous-titres H2 et H3 pour organiser le contenu
+3. Une idée par paragraphe de 3-4 lignes
+4. Pas de retour à la ligne à l'intérieur des paragraphes
+5. Utilise le gras (**texte**) pour les concepts clés
+6. Utilise l'italique (*texte*) pour les nuances ou réflexions
+7. Listes à puces pour les énumérations (3-5 éléments max)
+8. Citations en blockquote: > « Citation » — Auteur
+9. Pas de tableaux, pas de MAJUSCULES excessives
+10. Capitalisation naturelle dans les titres (pas de Title Case)
+
+Format de sortie attendu avec des balises XML:
+<TITLE>Titre de l'article</TITLE>
+<DESCRIPTION>Meta description SEO de 150-160 caractères</DESCRIPTION>
+<CONTENT>
+Contenu Markdown de l'article
+</CONTENT>
+<TAGS>tag1, tag2, tag3</TAGS>
+<FAQ>
+[{"question": "Question 1?", "answer": "Réponse 1"}, {"question": "Question 2?", "answer": "Réponse 2"}]
+</FAQ>
+<IMAGE_PROMPT>Description détaillée pour générer une image d'illustration</IMAGE_PROMPT>`;
+
+// ============================================
+// Prompt Builders
+// ============================================
+
+/**
+ * Build the main article generation prompt
+ */
+export function buildArticlePrompt(config: ArticlePromptConfig): string {
+  const {
+    topic,
+    category,
+    length = 'medium',
+    tone,
+    tones,
+    keywords,
+    targetAudience,
+    seoQuery,
+    searchIntent,
+    language = 'fr',
+  } = config;
+
+  const lengthConfig = LENGTH_CONFIG[length];
+  const activeTones: ArticleTone[] = tones?.length ? tones : tone ? [tone] : ['professional'];
+
+  const toneDescriptions = activeTones.map((t: ArticleTone) => TONE_DESCRIPTIONS[t]).join(', ');
+
+  const parts: string[] = [
+    `Rédige un article de blog complet sur le sujet suivant : "${topic}"`,
+    '',
+  ];
+
+  // Specifications
+  parts.push('Spécifications :');
+  parts.push(`- Longueur : ${lengthConfig.wordRange} mots`);
+  parts.push(`- Structure : ${lengthConfig.sectionCount} sections`);
+  parts.push(`- Ton : ${toneDescriptions}`);
+  parts.push(`- Langue : ${language === 'fr' ? 'Français' : 'Anglais'}`);
+
+  if (category) {
+    parts.push(`- Catégorie : ${category}`);
+  }
+
+  if (keywords?.length) {
+    parts.push(`- Mots-clés SEO à intégrer naturellement : ${keywords.join(', ')}`);
+  }
+
+  if (seoQuery) {
+    parts.push(`- Requête SEO cible : "${seoQuery}"`);
+  }
+
+  if (searchIntent) {
+    parts.push(`- Intention de recherche : ${searchIntent}`);
+  }
+
+  if (targetAudience) {
+    parts.push(`- Public cible : ${targetAudience}`);
+  }
+
+  parts.push('');
+  parts.push(
+    "Génère l'article complet avec tous les éléments demandés dans le format XML spécifié."
+  );
+
+  return parts.join('\n');
+}
+
+/**
+ * Build prompt for outline generation
+ */
+export function buildOutlinePrompt(config: ArticlePromptConfig): string {
+  const { topic, category, length = 'medium', keywords } = config;
+  const lengthConfig = LENGTH_CONFIG[length];
+
+  return `Crée un plan détaillé pour un article sur : "${topic}"
+
+${category ? `Catégorie : ${category}` : ''}
+${keywords?.length ? `Mots-clés à couvrir : ${keywords.join(', ')}` : ''}
+
+Le plan doit contenir ${lengthConfig.sectionCount} sections.
+
+Format de sortie JSON :
+{
+  "title": "Titre proposé pour l'article",
+  "sections": [
+    {
+      "heading": "Titre de la section",
+      "level": 2,
+      "keyPoints": ["Point 1", "Point 2", "Point 3"],
+      "subsections": [
+        {
+          "heading": "Sous-titre",
+          "level": 3,
+          "keyPoints": ["Point 1", "Point 2"]
+        }
+      ]
+    }
+  ],
+  "introduction": "Bref résumé de l'introduction",
+  "conclusion": "Bref résumé de la conclusion"
+}`;
+}
+
+/**
+ * Build prompt for section generation
+ */
+export function buildSectionPrompt(
+  sectionTitle: string,
+  keyPoints: string[],
+  context: {
+    articleTopic: string;
+    previousSections?: string[];
+    tone?: ArticleTone;
+  }
+): string {
+  const { articleTopic, previousSections, tone = 'professional' } = context;
+
+  return `Rédige la section suivante d'un article sur "${articleTopic}":
+
+## ${sectionTitle}
+
+Points clés à développer :
+${keyPoints.map(p => `- ${p}`).join('\n')}
+
+Ton : ${TONE_DESCRIPTIONS[tone]}
+
+${
+  previousSections?.length
+    ? `Sections précédentes pour contexte :\n${previousSections.join('\n\n')}`
+    : ''
+}
+
+Règles :
+- Une idée par paragraphe
+- 150-300 mots pour cette section
+- Transitions fluides avec le contenu précédent
+- Utilise le Markdown (gras, italique, listes si pertinent)
+
+Génère uniquement le contenu de cette section, sans le titre H2.`;
+}
+
+/**
+ * Build prompt for FAQ generation
+ */
+export function buildFaqPrompt(articleContent: string, topic: string, count: number = 5): string {
+  return `À partir de l'article suivant sur "${topic}", génère ${count} questions fréquemment posées avec leurs réponses.
+
+Article :
+${articleContent}
+
+Règles :
+- Questions que les lecteurs pourraient se poser
+- Réponses concises (2-3 phrases)
+- Questions variées couvrant différents aspects
+- Format naturel et conversationnel
+
+Format JSON attendu :
+[
+  {"question": "Question 1?", "answer": "Réponse 1"},
+  {"question": "Question 2?", "answer": "Réponse 2"}
+]`;
+}
+
+/**
+ * Build prompt for meta description generation
+ */
+export function buildMetaDescriptionPrompt(
+  articleTitle: string,
+  articleContent: string,
+  seoQuery?: string
+): string {
+  return `Génère une meta description SEO pour cet article :
+
+Titre : ${articleTitle}
+${seoQuery ? `Requête SEO cible : ${seoQuery}` : ''}
+
+Contenu (extrait) :
+${articleContent.slice(0, 1000)}...
+
+Règles :
+- 150-160 caractères maximum
+- Inclure le mot-clé principal naturellement
+- Donner envie de cliquer
+- Résumer la valeur apportée au lecteur
+
+Réponds uniquement avec la meta description, sans guillemets ni explications.`;
+}
+
+/**
+ * Build prompt for tags extraction
+ */
+export function buildTagsPrompt(articleContent: string, existingTags?: string[]): string {
+  return `Extrais 5-10 tags SEO pertinents pour cet article :
+
+${articleContent.slice(0, 2000)}...
+
+${existingTags?.length ? `Tags existants dans le système : ${existingTags.join(', ')}` : ''}
+
+Règles :
+- Tags courts (1-3 mots)
+- Mélange de tags génériques et spécifiques
+- Pertinents pour le SEO
+- En minuscules, séparés par des virgules
+
+Réponds uniquement avec les tags séparés par des virgules, sans explications.`;
+}

--- a/packages/ai/src/prompts/image-prompt.ts
+++ b/packages/ai/src/prompts/image-prompt.ts
@@ -1,0 +1,277 @@
+/**
+ * Image generation prompt templates
+ * @package @kairn/ai
+ */
+
+// ============================================
+// Image Style Types
+// ============================================
+
+export type ImageStyle =
+  | 'minimalist'
+  | 'photorealistic'
+  | 'illustration'
+  | 'abstract'
+  | 'watercolor'
+  | 'digital_art'
+  | 'vintage'
+  | 'modern';
+
+export type ImageMood =
+  | 'serene'
+  | 'energetic'
+  | 'professional'
+  | 'warm'
+  | 'mysterious'
+  | 'hopeful'
+  | 'contemplative';
+
+export type ImageSubject = 'person' | 'landscape' | 'abstract' | 'object' | 'concept' | 'scene';
+
+// ============================================
+// Configuration Types
+// ============================================
+
+export interface ImagePromptConfig {
+  topic: string;
+  style?: ImageStyle;
+  mood?: ImageMood;
+  subject?: ImageSubject;
+  colors?: string[];
+  avoidElements?: string[];
+  aspectRatio?: 'square' | 'landscape' | 'portrait';
+  additionalInstructions?: string;
+}
+
+export interface BrandedImageConfig extends ImagePromptConfig {
+  brandName: string;
+  brandColors: {
+    primary: string;
+    secondary?: string;
+    accent?: string;
+  };
+  visualIdentity?: string;
+}
+
+// ============================================
+// Style Descriptions
+// ============================================
+
+export const STYLE_DESCRIPTIONS: Record<ImageStyle, string> = {
+  minimalist:
+    'Clean, simple composition with lots of negative space, subtle details, modern aesthetic',
+  photorealistic: 'Highly detailed, realistic photography style, natural lighting, sharp focus',
+  illustration: 'Hand-drawn illustration style, artistic linework, creative interpretation',
+  abstract: 'Non-representational, shapes and colors, conceptual, artistic expression',
+  watercolor: 'Soft watercolor painting style, gentle color bleeding, organic textures',
+  digital_art: 'Modern digital artwork, vibrant colors, polished finish, contemporary',
+  vintage: 'Retro aesthetic, muted colors, film grain, nostalgic feel',
+  modern: 'Contemporary design, bold shapes, trendy aesthetic, clean lines',
+};
+
+export const MOOD_DESCRIPTIONS: Record<ImageMood, string> = {
+  serene: 'Peaceful, calm, tranquil atmosphere with soft tones',
+  energetic: 'Dynamic, vibrant, full of movement and energy',
+  professional: 'Polished, business-appropriate, trustworthy',
+  warm: 'Inviting, cozy, comfortable, welcoming tones',
+  mysterious: 'Intriguing, shadowy, evocative, thought-provoking',
+  hopeful: 'Optimistic, uplifting, bright, forward-looking',
+  contemplative: 'Thoughtful, reflective, meditative quality',
+};
+
+// ============================================
+// Prompt Builders
+// ============================================
+
+/**
+ * Build a basic image generation prompt
+ */
+export function buildImagePrompt(config: ImagePromptConfig): string {
+  const {
+    topic,
+    style = 'modern',
+    mood = 'professional',
+    subject = 'concept',
+    colors,
+    avoidElements,
+    aspectRatio = 'landscape',
+    additionalInstructions,
+  } = config;
+
+  const parts: string[] = [];
+
+  // Main subject
+  parts.push(`Create an image representing: "${topic}"`);
+  parts.push('');
+
+  // Style and mood
+  parts.push(`Style: ${STYLE_DESCRIPTIONS[style]}`);
+  parts.push(`Mood: ${MOOD_DESCRIPTIONS[mood]}`);
+  parts.push('');
+
+  // Subject treatment
+  if (subject === 'person') {
+    parts.push('Include a human figure or silhouette as the focal point');
+  } else if (subject === 'landscape') {
+    parts.push('Focus on environment and scenery');
+  } else if (subject === 'abstract') {
+    parts.push('Use abstract shapes and forms to represent the concept');
+  } else if (subject === 'object') {
+    parts.push('Feature a central object that symbolizes the topic');
+  } else if (subject === 'scene') {
+    parts.push('Depict a scene that illustrates the concept');
+  }
+
+  // Colors
+  if (colors?.length) {
+    parts.push(`\nColor palette: ${colors.join(', ')}`);
+  }
+
+  // Aspect ratio guidance
+  parts.push(`\nComposition: Optimized for ${aspectRatio} format`);
+
+  // Elements to avoid
+  if (avoidElements?.length) {
+    parts.push(`\nAvoid: ${avoidElements.join(', ')}`);
+  }
+
+  // Additional instructions
+  if (additionalInstructions) {
+    parts.push(`\n${additionalInstructions}`);
+  }
+
+  // Quality guidance
+  parts.push('\nQuality: High resolution, professional quality, attention to detail');
+
+  return parts.join('\n');
+}
+
+/**
+ * Build an image prompt with brand guidelines
+ */
+export function buildBrandedImagePrompt(config: BrandedImageConfig): string {
+  const {
+    topic,
+    brandName,
+    brandColors,
+    visualIdentity,
+    style = 'modern',
+    mood = 'professional',
+    subject = 'concept',
+    avoidElements = [],
+    additionalInstructions,
+  } = config;
+
+  const parts: string[] = [];
+
+  // Main subject with brand context
+  parts.push(`Create a brand-consistent image for ${brandName}`);
+  parts.push(`Topic/concept: "${topic}"`);
+  parts.push('');
+
+  // Brand colors (MANDATORY)
+  parts.push('MANDATORY COLOR PALETTE:');
+  parts.push(`- Primary color: ${brandColors.primary}`);
+  if (brandColors.secondary) {
+    parts.push(`- Secondary color: ${brandColors.secondary}`);
+  }
+  if (brandColors.accent) {
+    parts.push(`- Accent color: ${brandColors.accent}`);
+  }
+  parts.push('These colors MUST be prominently featured in the image.');
+  parts.push('');
+
+  // Visual identity
+  if (visualIdentity) {
+    parts.push(`Brand visual identity: ${visualIdentity}`);
+    parts.push('');
+  }
+
+  // Style and mood
+  parts.push(`Style: ${STYLE_DESCRIPTIONS[style]}`);
+  parts.push(`Mood: ${MOOD_DESCRIPTIONS[mood]}`);
+
+  // Subject
+  if (subject === 'person') {
+    parts.push('\nInclude stylized human figure(s) or silhouette(s)');
+  }
+
+  // Standard avoidances for brand images
+  const standardAvoidances = ['text', 'logos', 'watermarks', 'stock photo feel', ...avoidElements];
+  parts.push(`\nAvoid: ${standardAvoidances.join(', ')}`);
+
+  // Additional instructions
+  if (additionalInstructions) {
+    parts.push(`\n${additionalInstructions}`);
+  }
+
+  // Quality
+  parts.push('\nQuality: High resolution, professional, suitable for web and print');
+
+  return parts.join('\n');
+}
+
+/**
+ * Build a prompt to generate image description from article content
+ */
+export function buildImageDescriptionPrompt(
+  articleTitle: string,
+  articleContent: string,
+  brandConfig?: {
+    name: string;
+    colors: string[];
+    style?: string;
+  }
+): string {
+  const parts: string[] = [
+    "Analyse cet article et génère un prompt détaillé pour créer une image d'illustration.",
+    '',
+    `Titre: ${articleTitle}`,
+    '',
+    'Contenu (extrait):',
+    articleContent.slice(0, 1500),
+    '',
+  ];
+
+  if (brandConfig) {
+    parts.push('Identité visuelle de la marque:');
+    parts.push(`- Nom: ${brandConfig.name}`);
+    parts.push(`- Couleurs: ${brandConfig.colors.join(', ')}`);
+    if (brandConfig.style) {
+      parts.push(`- Style: ${brandConfig.style}`);
+    }
+    parts.push('');
+  }
+
+  parts.push(`Génère un prompt en anglais pour DALL-E 3 qui:
+1. Capture l'essence du sujet de l'article
+2. Utilise un style visuel cohérent${brandConfig ? ' avec la marque' : ''}
+3. Évite tout texte ou logo
+4. Est adapté au format 16:9 (landscape)
+5. A une qualité professionnelle
+
+Format attendu: Un seul paragraphe descriptif, sans markdown ni formatage spécial.`);
+
+  return parts.join('\n');
+}
+
+/**
+ * Build prompt for generating multiple image variations
+ */
+export function buildImageVariationsPrompt(
+  basePrompt: string,
+  variationCount: number = 3
+): string[] {
+  const variations = [
+    // Original
+    basePrompt,
+    // More abstract
+    `${basePrompt}\n\nVariation: More abstract and conceptual interpretation, focus on shapes and symbolic elements.`,
+    // Warmer tones
+    `${basePrompt}\n\nVariation: Warmer color temperature, more inviting and human-centered composition.`,
+    // Minimalist
+    `${basePrompt}\n\nVariation: Ultra-minimalist approach, maximum negative space, essential elements only.`,
+  ];
+
+  return variations.slice(0, variationCount);
+}

--- a/packages/ai/src/prompts/index.ts
+++ b/packages/ai/src/prompts/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Prompt templates exports
+ * @package @kairn/ai
+ */
+
+// Blog article prompts
+export {
+  buildArticlePrompt,
+  buildOutlinePrompt,
+  buildSectionPrompt,
+  buildFaqPrompt,
+  buildMetaDescriptionPrompt,
+  buildTagsPrompt,
+  LENGTH_CONFIG,
+  TONE_DESCRIPTIONS,
+  DEFAULT_SYSTEM_PROMPT,
+  type ArticlePromptConfig,
+} from './blog-article.js';
+
+// Social post prompts
+export {
+  buildSocialPostPrompt,
+  buildMultiPlatformPrompt,
+  PLATFORM_CONFIG,
+  SOCIAL_TONE_DESCRIPTIONS,
+  SOCIAL_ANGLE_DESCRIPTIONS,
+  INSTAGRAM_FORMATS,
+  THREADS_FORMATS,
+  LINKEDIN_FORMATS,
+  type SocialPromptConfig,
+} from './social-post.js';
+
+// Image prompts
+export {
+  buildImagePrompt,
+  buildBrandedImagePrompt,
+  buildImageDescriptionPrompt,
+  buildImageVariationsPrompt,
+  STYLE_DESCRIPTIONS,
+  MOOD_DESCRIPTIONS,
+  type ImagePromptConfig,
+  type BrandedImageConfig,
+  type ImageStyle,
+  type ImageMood,
+  type ImageSubject,
+} from './image-prompt.js';

--- a/packages/ai/src/prompts/social-post.ts
+++ b/packages/ai/src/prompts/social-post.ts
@@ -1,0 +1,364 @@
+/**
+ * Social media post generation prompt templates
+ * @package @kairn/ai
+ */
+
+import type { SocialPlatform, SocialTone, SocialAngle, SocialFormat } from '../services/types.js';
+
+// ============================================
+// Platform Configuration
+// ============================================
+
+export const PLATFORM_CONFIG: Record<
+  SocialPlatform,
+  {
+    maxLength: number;
+    supportsHashtags: boolean;
+    supportsLinks: boolean;
+    mediaRequired: boolean;
+    characterName: string;
+  }
+> = {
+  facebook: {
+    maxLength: 2000,
+    supportsHashtags: true,
+    supportsLinks: true,
+    mediaRequired: false,
+    characterName: 'Facebook',
+  },
+  instagram: {
+    maxLength: 2200,
+    supportsHashtags: true,
+    supportsLinks: false,
+    mediaRequired: true,
+    characterName: 'Instagram',
+  },
+  linkedin: {
+    maxLength: 3000,
+    supportsHashtags: true,
+    supportsLinks: true,
+    mediaRequired: false,
+    characterName: 'LinkedIn',
+  },
+  twitter: {
+    maxLength: 280,
+    supportsHashtags: true,
+    supportsLinks: true,
+    mediaRequired: false,
+    characterName: 'X (Twitter)',
+  },
+  threads: {
+    maxLength: 500,
+    supportsHashtags: false,
+    supportsLinks: true,
+    mediaRequired: false,
+    characterName: 'Threads',
+  },
+};
+
+// ============================================
+// Tone Descriptions
+// ============================================
+
+export const SOCIAL_TONE_DESCRIPTIONS: Record<SocialTone, string> = {
+  informative: 'Informatif et factuel, partage de connaissances',
+  inspirational: 'Inspirant et motivant, éveille les émotions positives',
+  promotional: 'Promotionnel mais subtil, met en valeur sans être agressif',
+  educational: 'Éducatif et pédagogique, explique clairement',
+  personal: "Personnel et authentique, partage d'expérience",
+  entertaining: "Divertissant et engageant, capte l'attention",
+  thought_provoking: 'Qui fait réfléchir, questionne les certitudes',
+};
+
+// ============================================
+// Angle Descriptions
+// ============================================
+
+export const SOCIAL_ANGLE_DESCRIPTIONS: Record<SocialAngle, string> = {
+  benefits: 'Met en avant les bénéfices et avantages',
+  problem: "Part d'un problème ou d'une frustration",
+  story: 'Raconte une histoire ou anecdote',
+  expert: "Position d'expert, partage de savoir",
+  practical: 'Conseils pratiques et actionnables',
+  curiosity: 'Suscite la curiosité, intrigue',
+  controversy: 'Prend position, va à contre-courant',
+  social_proof: 'Témoignages, résultats, preuves',
+};
+
+// ============================================
+// Instagram Formats
+// ============================================
+
+export const INSTAGRAM_FORMATS: Partial<Record<SocialFormat, string>> = {
+  hook_reveal: `Format "Hook & Reveal":
+- Ligne 1: Accroche choc ou contre-intuitive
+- Ligne 2-3: Développement court
+- Ligne 4: Révélation ou conseil actionnable
+- Emojis stratégiques (2-3 max)`,
+
+  visual_list: `Format "Liste Visuelle":
+- Titre accrocheur
+- 3-5 points numérotés avec emojis
+- Chaque point = 1 ligne
+- Call-to-action final`,
+
+  micro_storytelling: `Format "Micro-Storytelling":
+- Situation initiale (1 ligne)
+- Tension/problème (1 ligne)
+- Résolution/leçon (1-2 lignes)
+- Question pour engager`,
+
+  rhetorical_question: `Format "Question Rhétorique":
+- Question d'ouverture percutante
+- Réponse développée en 2-3 lignes
+- Perspective ou conseil
+- Question finale pour engagement`,
+
+  quote_reflection: `Format "Citation & Réflexion":
+- Citation inspirante avec guillemets
+- Interprétation personnelle (2-3 lignes)
+- Application concrète
+- Invitation à réflexion`,
+
+  myth_reality: `Format "Mythe vs Réalité":
+- "On croit souvent que..." (mythe)
+- "En réalité..." (vérité)
+- Explication courte
+- Prise de conscience finale`,
+};
+
+// ============================================
+// Threads Formats
+// ============================================
+
+export const THREADS_FORMATS: Partial<Record<SocialFormat, string>> = {
+  raw_thought: `Format "Pensée Brute":
+- Pensée spontanée et authentique
+- Ton conversationnel
+- Pas de structure forcée
+- Invitation au dialogue`,
+
+  observation: `Format "Observation":
+- Observation du quotidien professionnel
+- Ton réflexif
+- Question implicite ou explicite`,
+
+  open_question: `Format "Question Ouverte":
+- Question sans réponse évidente
+- Ouvre le débat
+- Encourage les réponses diverses`,
+
+  micro_confession: `Format "Micro-Confession":
+- Aveu personnel ou professionnel
+- Vulnérabilité mesurée
+- Leçon apprise`,
+
+  poetic_fragment: `Format "Fragment Poétique":
+- Expression métaphorique
+- Évocateur et imagé
+- Court et percutant`,
+
+  counter_intuitive: `Format "Contre-Intuitif":
+- Affirmation surprenante
+- Explication rapide
+- Invite à reconsidérer`,
+};
+
+// ============================================
+// LinkedIn Formats
+// ============================================
+
+export const LINKEDIN_FORMATS: Partial<Record<SocialFormat, string>> = {
+  observation_pro: `Format "Observation Pro":
+- Observation du monde professionnel
+- Analyse courte (2-3 lignes)
+- Conclusion ou question`,
+
+  counter_intuitive: `Format "Contre-Intuition":
+- Affirmation qui va à contre-courant
+- Arguments en 3-4 points
+- Conclusion nuancée`,
+
+  visual_list: `Format "Liste à Puces":
+- Introduction accrocheuse (1 ligne)
+- 5-7 points courts
+- Conclusion avec call-to-action`,
+
+  micro_storytelling: `Format "Storytelling Court":
+- Situation de départ
+- Challenge rencontré
+- Solution trouvée
+- Leçon partagée`,
+
+  rhetorical_question: `Format "Question Provocante":
+- Question qui challenge
+- Réponse argumentée
+- Invitation au débat`,
+
+  social_proof: `Format "Témoignage Terrain":
+- Expérience vécue
+- Résultat concret
+- Apprentissage applicable`,
+};
+
+// ============================================
+// Prompt Configuration
+// ============================================
+
+export interface SocialPromptConfig {
+  sourceContent: string;
+  sourceTitle?: string;
+  platform: SocialPlatform;
+  tone?: SocialTone;
+  angle?: SocialAngle;
+  format?: SocialFormat;
+  includeHashtags?: boolean;
+  includeEmojis?: boolean;
+  includeCallToAction?: boolean;
+  maxLength?: number;
+  language?: 'fr' | 'en';
+  link?: string;
+  authenticityLevel?: 1 | 2 | 3 | 4 | 5;
+  expertiseLevel?: 1 | 2 | 3 | 4 | 5;
+}
+
+// ============================================
+// Prompt Builders
+// ============================================
+
+/**
+ * Build social post generation prompt
+ */
+export function buildSocialPostPrompt(config: SocialPromptConfig): string {
+  const {
+    sourceContent,
+    sourceTitle,
+    platform,
+    tone = 'informative',
+    angle = 'benefits',
+    format,
+    includeHashtags = true,
+    includeEmojis = true,
+    includeCallToAction = true,
+    maxLength,
+    language = 'fr',
+    link,
+    authenticityLevel,
+    expertiseLevel,
+  } = config;
+
+  const platformConfig = PLATFORM_CONFIG[platform];
+  const effectiveMaxLength = maxLength ?? platformConfig.maxLength;
+
+  const parts: string[] = [
+    `Crée un post ${platformConfig.characterName} à partir du contenu suivant :`,
+    '',
+    `${sourceTitle ? `Titre: ${sourceTitle}\n` : ''}Contenu:`,
+    sourceContent.slice(0, 2000),
+    '',
+  ];
+
+  // Platform specifications
+  parts.push('Spécifications de la plateforme :');
+  parts.push(`- Longueur max : ${effectiveMaxLength} caractères`);
+  parts.push(`- Ton : ${SOCIAL_TONE_DESCRIPTIONS[tone]}`);
+  parts.push(`- Angle : ${SOCIAL_ANGLE_DESCRIPTIONS[angle]}`);
+
+  if (format) {
+    const formatDescription = getFormatDescription(platform, format);
+    if (formatDescription) {
+      parts.push(`\nFormat demandé :\n${formatDescription}`);
+    }
+  }
+
+  // Options
+  parts.push('\nOptions :');
+  parts.push(
+    `- Hashtags : ${includeHashtags && platformConfig.supportsHashtags ? 'Oui (3-5 pertinents)' : 'Non'}`
+  );
+  parts.push(`- Emojis : ${includeEmojis ? 'Oui (avec parcimonie)' : 'Non'}`);
+  parts.push(`- Call-to-action : ${includeCallToAction ? 'Oui' : 'Non'}`);
+  parts.push(`- Langue : ${language === 'fr' ? 'Français' : 'Anglais'}`);
+
+  if (link && platformConfig.supportsLinks) {
+    parts.push(`- Lien à inclure : ${link}`);
+  }
+
+  if (authenticityLevel) {
+    parts.push(
+      `- Niveau d'authenticité : ${authenticityLevel}/5 (${authenticityLevel <= 2 ? 'formel' : authenticityLevel >= 4 ? 'très personnel' : 'équilibré'})`
+    );
+  }
+
+  if (expertiseLevel) {
+    parts.push(
+      `- Niveau d'expertise affiché : ${expertiseLevel}/5 (${expertiseLevel <= 2 ? 'accessible' : expertiseLevel >= 4 ? 'expert' : 'intermédiaire'})`
+    );
+  }
+
+  parts.push('\nGénère uniquement le post, prêt à être publié, sans explications.');
+
+  return parts.join('\n');
+}
+
+/**
+ * Get format description for a platform
+ */
+function getFormatDescription(platform: SocialPlatform, format: SocialFormat): string | null {
+  switch (platform) {
+    case 'instagram':
+      return INSTAGRAM_FORMATS[format] || null;
+    case 'threads':
+      return THREADS_FORMATS[format] || null;
+    case 'linkedin':
+      return LINKEDIN_FORMATS[format] || null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build prompt for multi-platform generation
+ */
+export function buildMultiPlatformPrompt(
+  sourceContent: string,
+  sourceTitle: string | undefined,
+  platforms: SocialPlatform[],
+  options: Partial<SocialPromptConfig> = {}
+): string {
+  const parts: string[] = [
+    `Adapte le contenu suivant pour plusieurs réseaux sociaux :`,
+    '',
+    `${sourceTitle ? `Titre: ${sourceTitle}\n` : ''}Contenu:`,
+    sourceContent.slice(0, 2000),
+    '',
+    'Plateformes demandées :',
+  ];
+
+  for (const platform of platforms) {
+    const config = PLATFORM_CONFIG[platform];
+    parts.push(`- ${config.characterName} (max ${config.maxLength} car.)`);
+  }
+
+  parts.push('\nRègles générales :');
+  parts.push('- Adapter le ton à chaque plateforme');
+  parts.push('- Respecter les limites de caractères');
+  parts.push('- Messages cohérents mais différenciés');
+
+  if (options.includeHashtags !== false) {
+    parts.push('- Inclure des hashtags pertinents (sauf Threads)');
+  }
+
+  parts.push(`\nFormat de sortie JSON :
+{
+  "posts": {
+    "facebook": "Contenu du post Facebook...",
+    "instagram": "Contenu du post Instagram...",
+    "linkedin": "Contenu du post LinkedIn...",
+    "twitter": "Contenu du post Twitter...",
+    "threads": "Contenu du post Threads..."
+  }
+}`);
+
+  return parts.join('\n');
+}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1,0 +1,244 @@
+/**
+ * Anthropic (Claude) AI Provider implementation
+ * @package @kairn/ai
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type {
+  Message,
+  MessageCreateParamsNonStreaming,
+} from '@anthropic-ai/sdk/resources/messages';
+
+import {
+  AIProvider,
+  AnthropicProviderConfig,
+  GenerateTextOptions,
+  TextGenerationResult,
+  AIProviderError,
+  AITimeoutError,
+  AIRateLimitError,
+  AIAuthenticationError,
+} from './types.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+const DEFAULT_MAX_TOKENS = 8192;
+const DEFAULT_TIMEOUT_MS = 120000; // 2 minutes
+
+export class AnthropicProvider implements AIProvider {
+  readonly name = 'anthropic';
+  readonly defaultTextModel: string;
+  private client: Anthropic | null = null;
+  private readonly config: AnthropicProviderConfig;
+
+  constructor(config: AnthropicProviderConfig) {
+    this.config = config;
+    this.defaultTextModel = config.model || DEFAULT_MODEL;
+  }
+
+  /**
+   * Lazily initialize the Anthropic client
+   */
+  private async getClient(): Promise<Anthropic> {
+    if (this.client) {
+      return this.client;
+    }
+
+    try {
+      // Dynamic import to avoid requiring the SDK when not used
+      const { default: AnthropicSDK } = await import('@anthropic-ai/sdk');
+      this.client = new AnthropicSDK({
+        apiKey: this.config.apiKey,
+        ...(this.config.baseUrl && { baseURL: this.config.baseUrl }),
+      });
+      return this.client;
+    } catch (error) {
+      throw new AIProviderError(
+        'Failed to initialize Anthropic SDK. Make sure @anthropic-ai/sdk is installed.',
+        this.name,
+        'SDK_INIT_ERROR'
+      );
+    }
+  }
+
+  isConfigured(): boolean {
+    return !!this.config.apiKey;
+  }
+
+  async generateText(
+    prompt: string,
+    options: GenerateTextOptions = {}
+  ): Promise<TextGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.isConfigured()) {
+      throw new AIAuthenticationError(this.name);
+    }
+
+    const client = await this.getClient();
+
+    const maxTokens = options.maxTokens ?? this.config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    const params: MessageCreateParamsNonStreaming = {
+      model: this.defaultTextModel,
+      max_tokens: maxTokens,
+      messages: [{ role: 'user', content: prompt }],
+      ...(options.systemPrompt && { system: options.systemPrompt }),
+      ...(options.temperature !== undefined && { temperature: options.temperature }),
+      ...(options.stopSequences && { stop_sequences: options.stopSequences }),
+    };
+
+    try {
+      const response = await this.withTimeout(client.messages.create(params), timeoutMs);
+
+      return this.parseResponse(response, startTime);
+    } catch (error) {
+      throw this.handleError(error, startTime);
+    }
+  }
+
+  async generateFromMessages(
+    messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+    options: GenerateTextOptions = {}
+  ): Promise<TextGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.isConfigured()) {
+      throw new AIAuthenticationError(this.name);
+    }
+
+    const client = await this.getClient();
+
+    const maxTokens = options.maxTokens ?? this.config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    const params: MessageCreateParamsNonStreaming = {
+      model: this.defaultTextModel,
+      max_tokens: maxTokens,
+      messages: messages.map(m => ({
+        role: m.role,
+        content: m.content,
+      })),
+      ...(options.systemPrompt && { system: options.systemPrompt }),
+      ...(options.temperature !== undefined && { temperature: options.temperature }),
+      ...(options.stopSequences && { stop_sequences: options.stopSequences }),
+    };
+
+    try {
+      const response = await this.withTimeout(client.messages.create(params), timeoutMs);
+
+      return this.parseResponse(response, startTime);
+    } catch (error) {
+      throw this.handleError(error, startTime);
+    }
+  }
+
+  private parseResponse(response: Message, startTime: number): TextGenerationResult {
+    const content = response.content
+      .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+      .map(block => block.text)
+      .join('');
+
+    let stopReason: TextGenerationResult['stopReason'] = 'end_turn';
+    if (response.stop_reason === 'max_tokens') {
+      stopReason = 'max_tokens';
+    } else if (response.stop_reason === 'stop_sequence') {
+      stopReason = 'stop_sequence';
+    }
+
+    return {
+      content,
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+      totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+      model: response.model,
+      stopReason,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new AITimeoutError(this.name, timeoutMs));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      clearTimeout(timeoutId!);
+    }
+  }
+
+  private handleError(error: unknown, _startTime: number): AIProviderError {
+    if (error instanceof AIProviderError) {
+      return error;
+    }
+
+    // Handle Anthropic SDK errors
+    if (error && typeof error === 'object' && 'status' in error) {
+      const err = error as { status: number; message?: string; error?: { type?: string } };
+
+      if (err.status === 401) {
+        return new AIAuthenticationError(this.name);
+      }
+
+      if (err.status === 429) {
+        return new AIRateLimitError(this.name);
+      }
+
+      const isRetriable = err.status >= 500 || err.status === 408;
+      return new AIProviderError(
+        err.message || 'Unknown Anthropic error',
+        this.name,
+        err.error?.type || 'UNKNOWN',
+        err.status,
+        isRetriable
+      );
+    }
+
+    // Handle network errors
+    if (error instanceof Error) {
+      const message = error.message.toLowerCase();
+      const isRetriable =
+        message.includes('econnreset') ||
+        message.includes('etimedout') ||
+        message.includes('network');
+
+      return new AIProviderError(error.message, this.name, 'NETWORK_ERROR', undefined, isRetriable);
+    }
+
+    return new AIProviderError('Unknown error occurred', this.name, 'UNKNOWN', undefined, false);
+  }
+}
+
+/**
+ * Create an Anthropic provider with configuration
+ */
+export function createAnthropicProvider(config: AnthropicProviderConfig): AnthropicProvider {
+  return new AnthropicProvider(config);
+}
+
+/**
+ * Create an Anthropic provider from environment variables
+ */
+export function createAnthropicProviderFromEnv(): AnthropicProvider {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    throw new AIProviderError(
+      'ANTHROPIC_API_KEY environment variable is not set',
+      'anthropic',
+      'CONFIG_ERROR'
+    );
+  }
+
+  return new AnthropicProvider({
+    apiKey,
+    model: process.env.ANTHROPIC_MODEL,
+    baseUrl: process.env.ANTHROPIC_BASE_URL,
+  });
+}

--- a/packages/ai/src/providers/index.ts
+++ b/packages/ai/src/providers/index.ts
@@ -1,0 +1,37 @@
+/**
+ * AI Providers exports
+ * @package @kairn/ai
+ */
+
+// Types
+export type {
+  AIProvider,
+  GenerateTextOptions,
+  GenerateImageOptions,
+  TextGenerationResult,
+  ImageGenerationResult,
+  AnthropicProviderConfig,
+  OpenAIProviderConfig,
+  RetryOptions,
+} from './types.js';
+
+// Error classes
+export {
+  AIProviderError,
+  AITimeoutError,
+  AIRateLimitError,
+  AIAuthenticationError,
+} from './types.js';
+
+// Zod schemas
+export { GenerateTextOptionsSchema, GenerateImageOptionsSchema } from './types.js';
+
+// Anthropic provider
+export {
+  AnthropicProvider,
+  createAnthropicProvider,
+  createAnthropicProviderFromEnv,
+} from './anthropic.js';
+
+// OpenAI provider
+export { OpenAIProvider, createOpenAIProvider, createOpenAIProviderFromEnv } from './openai.js';

--- a/packages/ai/src/providers/openai.ts
+++ b/packages/ai/src/providers/openai.ts
@@ -1,0 +1,311 @@
+/**
+ * OpenAI (GPT + DALL-E) AI Provider implementation
+ * @package @kairn/ai
+ */
+
+import type OpenAI from 'openai';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+
+import {
+  AIProvider,
+  OpenAIProviderConfig,
+  GenerateTextOptions,
+  GenerateImageOptions,
+  TextGenerationResult,
+  ImageGenerationResult,
+  AIProviderError,
+  AITimeoutError,
+  AIRateLimitError,
+  AIAuthenticationError,
+} from './types.js';
+
+const DEFAULT_TEXT_MODEL = 'gpt-4o';
+const DEFAULT_IMAGE_MODEL = 'dall-e-3';
+const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_TIMEOUT_MS = 120000; // 2 minutes
+
+export class OpenAIProvider implements AIProvider {
+  readonly name = 'openai';
+  readonly defaultTextModel: string;
+  readonly defaultImageModel: string;
+  private client: OpenAI | null = null;
+  private readonly config: OpenAIProviderConfig;
+
+  constructor(config: OpenAIProviderConfig) {
+    this.config = config;
+    this.defaultTextModel = config.textModel || DEFAULT_TEXT_MODEL;
+    this.defaultImageModel = config.imageModel || DEFAULT_IMAGE_MODEL;
+  }
+
+  /**
+   * Lazily initialize the OpenAI client
+   */
+  private async getClient(): Promise<OpenAI> {
+    if (this.client) {
+      return this.client;
+    }
+
+    try {
+      // Dynamic import to avoid requiring the SDK when not used
+      const { default: OpenAISDK } = await import('openai');
+      this.client = new OpenAISDK({
+        apiKey: this.config.apiKey,
+        ...(this.config.organization && { organization: this.config.organization }),
+        ...(this.config.baseUrl && { baseURL: this.config.baseUrl }),
+      });
+      return this.client;
+    } catch (error) {
+      throw new AIProviderError(
+        'Failed to initialize OpenAI SDK. Make sure openai is installed.',
+        this.name,
+        'SDK_INIT_ERROR'
+      );
+    }
+  }
+
+  isConfigured(): boolean {
+    return !!this.config.apiKey;
+  }
+
+  async generateText(
+    prompt: string,
+    options: GenerateTextOptions = {}
+  ): Promise<TextGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.isConfigured()) {
+      throw new AIAuthenticationError(this.name);
+    }
+
+    const client = await this.getClient();
+
+    const maxTokens = options.maxTokens ?? this.config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    const messages: ChatCompletionMessageParam[] = [];
+
+    if (options.systemPrompt) {
+      messages.push({ role: 'system', content: options.systemPrompt });
+    }
+    messages.push({ role: 'user', content: prompt });
+
+    try {
+      const response = await this.withTimeout(
+        client.chat.completions.create({
+          model: this.defaultTextModel,
+          messages,
+          max_tokens: maxTokens,
+          ...(options.temperature !== undefined && { temperature: options.temperature }),
+          ...(options.stopSequences && { stop: options.stopSequences }),
+        }),
+        timeoutMs
+      );
+
+      return this.parseTextResponse(response, startTime);
+    } catch (error) {
+      throw this.handleError(error, startTime);
+    }
+  }
+
+  async generateFromMessages(
+    messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+    options: GenerateTextOptions = {}
+  ): Promise<TextGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.isConfigured()) {
+      throw new AIAuthenticationError(this.name);
+    }
+
+    const client = await this.getClient();
+
+    const maxTokens = options.maxTokens ?? this.config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    const chatMessages: ChatCompletionMessageParam[] = [];
+
+    if (options.systemPrompt) {
+      chatMessages.push({ role: 'system', content: options.systemPrompt });
+    }
+
+    chatMessages.push(
+      ...messages.map(m => ({
+        role: m.role,
+        content: m.content,
+      }))
+    );
+
+    try {
+      const response = await this.withTimeout(
+        client.chat.completions.create({
+          model: this.defaultTextModel,
+          messages: chatMessages,
+          max_tokens: maxTokens,
+          ...(options.temperature !== undefined && { temperature: options.temperature }),
+          ...(options.stopSequences && { stop: options.stopSequences }),
+        }),
+        timeoutMs
+      );
+
+      return this.parseTextResponse(response, startTime);
+    } catch (error) {
+      throw this.handleError(error, startTime);
+    }
+  }
+
+  async generateImage(
+    prompt: string,
+    options: GenerateImageOptions = {}
+  ): Promise<ImageGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.isConfigured()) {
+      throw new AIAuthenticationError(this.name);
+    }
+
+    const client = await this.getClient();
+
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const count = options.count ?? 1;
+
+    try {
+      const response = await this.withTimeout(
+        client.images.generate({
+          model: this.defaultImageModel,
+          prompt,
+          n: count,
+          size: options.size ?? '1792x1024',
+          quality: options.quality ?? 'hd',
+          style: options.style ?? 'vivid',
+          response_format: 'url',
+        }),
+        timeoutMs
+      );
+
+      return {
+        images: (response.data || []).map(img => ({
+          url: img.url,
+          revisedPrompt: img.revised_prompt,
+        })),
+        model: this.defaultImageModel,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (error) {
+      throw this.handleError(error, startTime);
+    }
+  }
+
+  private parseTextResponse(
+    response: OpenAI.Chat.Completions.ChatCompletion,
+    startTime: number
+  ): TextGenerationResult {
+    const choice = response.choices[0];
+    const content = choice?.message?.content || '';
+
+    let stopReason: TextGenerationResult['stopReason'] = 'end_turn';
+    if (choice?.finish_reason === 'length') {
+      stopReason = 'max_tokens';
+    } else if (choice?.finish_reason === 'stop') {
+      stopReason = 'end_turn';
+    }
+
+    const usage = response.usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+
+    return {
+      content,
+      inputTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      totalTokens: usage.total_tokens,
+      model: response.model,
+      stopReason,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new AITimeoutError(this.name, timeoutMs));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      clearTimeout(timeoutId!);
+    }
+  }
+
+  private handleError(error: unknown, _startTime: number): AIProviderError {
+    if (error instanceof AIProviderError) {
+      return error;
+    }
+
+    // Handle OpenAI SDK errors
+    if (error && typeof error === 'object' && 'status' in error) {
+      const err = error as { status: number; message?: string; code?: string };
+
+      if (err.status === 401) {
+        return new AIAuthenticationError(this.name);
+      }
+
+      if (err.status === 429) {
+        return new AIRateLimitError(this.name);
+      }
+
+      const isRetriable = err.status >= 500 || err.status === 408;
+      return new AIProviderError(
+        err.message || 'Unknown OpenAI error',
+        this.name,
+        err.code || 'UNKNOWN',
+        err.status,
+        isRetriable
+      );
+    }
+
+    // Handle network errors
+    if (error instanceof Error) {
+      const message = error.message.toLowerCase();
+      const isRetriable =
+        message.includes('econnreset') ||
+        message.includes('etimedout') ||
+        message.includes('network');
+
+      return new AIProviderError(error.message, this.name, 'NETWORK_ERROR', undefined, isRetriable);
+    }
+
+    return new AIProviderError('Unknown error occurred', this.name, 'UNKNOWN', undefined, false);
+  }
+}
+
+/**
+ * Create an OpenAI provider with configuration
+ */
+export function createOpenAIProvider(config: OpenAIProviderConfig): OpenAIProvider {
+  return new OpenAIProvider(config);
+}
+
+/**
+ * Create an OpenAI provider from environment variables
+ */
+export function createOpenAIProviderFromEnv(): OpenAIProvider {
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  if (!apiKey) {
+    throw new AIProviderError(
+      'OPENAI_API_KEY environment variable is not set',
+      'openai',
+      'CONFIG_ERROR'
+    );
+  }
+
+  return new OpenAIProvider({
+    apiKey,
+    textModel: process.env.OPENAI_TEXT_MODEL,
+    imageModel: process.env.OPENAI_IMAGE_MODEL,
+    organization: process.env.OPENAI_ORGANIZATION,
+    baseUrl: process.env.OPENAI_BASE_URL,
+  });
+}

--- a/packages/ai/src/providers/types.ts
+++ b/packages/ai/src/providers/types.ts
@@ -1,0 +1,234 @@
+/**
+ * Types for AI Provider abstraction
+ * @package @kairn/ai
+ */
+
+import { z } from 'zod';
+
+// ============================================
+// Generation Options
+// ============================================
+
+export interface GenerateTextOptions {
+  /** Maximum tokens to generate */
+  maxTokens?: number;
+  /** Temperature for generation (0-1) */
+  temperature?: number;
+  /** System prompt to set the AI behavior */
+  systemPrompt?: string;
+  /** Stop sequences to end generation */
+  stopSequences?: string[];
+  /** Timeout in milliseconds */
+  timeoutMs?: number;
+}
+
+export interface GenerateImageOptions {
+  /** Image size */
+  size?: '1024x1024' | '1792x1024' | '1024x1792';
+  /** Quality level */
+  quality?: 'standard' | 'hd';
+  /** Style of the image */
+  style?: 'vivid' | 'natural';
+  /** Number of images to generate */
+  count?: number;
+  /** Timeout in milliseconds */
+  timeoutMs?: number;
+}
+
+// ============================================
+// Generation Results
+// ============================================
+
+export interface TextGenerationResult {
+  /** Generated text content */
+  content: string;
+  /** Tokens used for input */
+  inputTokens: number;
+  /** Tokens used for output */
+  outputTokens: number;
+  /** Total tokens used */
+  totalTokens: number;
+  /** Model used for generation */
+  model: string;
+  /** Stop reason */
+  stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'timeout' | 'error';
+  /** Generation duration in milliseconds */
+  durationMs: number;
+}
+
+export interface ImageGenerationResult {
+  /** Array of generated image URLs or base64 data */
+  images: Array<{
+    url?: string;
+    base64?: string;
+    revisedPrompt?: string;
+  }>;
+  /** Model used for generation */
+  model: string;
+  /** Generation duration in milliseconds */
+  durationMs: number;
+}
+
+// ============================================
+// Provider Interface
+// ============================================
+
+export interface AIProvider {
+  /** Provider name for identification */
+  readonly name: string;
+
+  /** Default model for text generation */
+  readonly defaultTextModel: string;
+
+  /** Default model for image generation (if supported) */
+  readonly defaultImageModel?: string;
+
+  /**
+   * Generate text from a prompt
+   * @param prompt The user prompt
+   * @param options Generation options
+   * @returns Promise with generation result
+   */
+  generateText(prompt: string, options?: GenerateTextOptions): Promise<TextGenerationResult>;
+
+  /**
+   * Generate text from messages (chat format)
+   * @param messages Array of messages
+   * @param options Generation options
+   * @returns Promise with generation result
+   */
+  generateFromMessages?(
+    messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+    options?: GenerateTextOptions
+  ): Promise<TextGenerationResult>;
+
+  /**
+   * Generate images from a prompt (optional, not all providers support this)
+   * @param prompt The image generation prompt
+   * @param options Image generation options
+   * @returns Promise with image generation result
+   */
+  generateImage?(prompt: string, options?: GenerateImageOptions): Promise<ImageGenerationResult>;
+
+  /**
+   * Check if the provider is properly configured
+   */
+  isConfigured(): boolean;
+}
+
+// ============================================
+// Provider Configuration
+// ============================================
+
+export interface AnthropicProviderConfig {
+  /** Anthropic API key */
+  apiKey: string;
+  /** Model to use (default: claude-sonnet-4-5-20250929) */
+  model?: string;
+  /** Base URL for API (optional, for proxies) */
+  baseUrl?: string;
+  /** Default max tokens */
+  defaultMaxTokens?: number;
+  /** Default timeout in milliseconds */
+  defaultTimeoutMs?: number;
+}
+
+export interface OpenAIProviderConfig {
+  /** OpenAI API key */
+  apiKey: string;
+  /** Model to use for text (default: gpt-4o) */
+  textModel?: string;
+  /** Model to use for images (default: dall-e-3) */
+  imageModel?: string;
+  /** Organization ID (optional) */
+  organization?: string;
+  /** Base URL for API (optional, for proxies) */
+  baseUrl?: string;
+  /** Default max tokens */
+  defaultMaxTokens?: number;
+  /** Default timeout in milliseconds */
+  defaultTimeoutMs?: number;
+}
+
+// ============================================
+// Retry Configuration
+// ============================================
+
+export interface RetryOptions {
+  /** Maximum number of retries (default: 3) */
+  maxRetries?: number;
+  /** Initial delay between retries in ms (default: 1000) */
+  initialDelayMs?: number;
+  /** Backoff multiplier (default: 2) */
+  backoffMultiplier?: number;
+  /** Maximum delay between retries in ms (default: 30000) */
+  maxDelayMs?: number;
+  /** Custom function to determine if an error is retriable */
+  isRetriable?: (error: unknown) => boolean;
+  /** Callback called on each retry attempt */
+  onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
+}
+
+// ============================================
+// Zod Schemas for Validation
+// ============================================
+
+export const GenerateTextOptionsSchema = z.object({
+  maxTokens: z.number().positive().optional(),
+  temperature: z.number().min(0).max(1).optional(),
+  systemPrompt: z.string().optional(),
+  stopSequences: z.array(z.string()).optional(),
+  timeoutMs: z.number().positive().optional(),
+});
+
+export const GenerateImageOptionsSchema = z.object({
+  size: z.enum(['1024x1024', '1792x1024', '1024x1792']).optional(),
+  quality: z.enum(['standard', 'hd']).optional(),
+  style: z.enum(['vivid', 'natural']).optional(),
+  count: z.number().min(1).max(4).optional(),
+  timeoutMs: z.number().positive().optional(),
+});
+
+// ============================================
+// Error Types
+// ============================================
+
+export class AIProviderError extends Error {
+  constructor(
+    message: string,
+    public readonly provider: string,
+    public readonly code: string,
+    public readonly statusCode?: number,
+    public readonly isRetriable: boolean = false
+  ) {
+    super(message);
+    this.name = 'AIProviderError';
+  }
+}
+
+export class AITimeoutError extends AIProviderError {
+  constructor(provider: string, timeoutMs: number) {
+    super(`AI request timed out after ${timeoutMs}ms`, provider, 'TIMEOUT', undefined, true);
+    this.name = 'AITimeoutError';
+  }
+}
+
+export class AIRateLimitError extends AIProviderError {
+  constructor(provider: string, retryAfter?: number) {
+    super(
+      `Rate limit exceeded${retryAfter ? `, retry after ${retryAfter}s` : ''}`,
+      provider,
+      'RATE_LIMIT',
+      429,
+      true
+    );
+    this.name = 'AIRateLimitError';
+  }
+}
+
+export class AIAuthenticationError extends AIProviderError {
+  constructor(provider: string) {
+    super(`Authentication failed for ${provider}`, provider, 'AUTH_ERROR', 401, false);
+    this.name = 'AIAuthenticationError';
+  }
+}

--- a/packages/ai/src/services/content-generator.ts
+++ b/packages/ai/src/services/content-generator.ts
@@ -1,0 +1,369 @@
+/**
+ * Content Generation Service
+ * @package @kairn/ai
+ */
+
+import {
+  buildArticlePrompt,
+  buildOutlinePrompt,
+  buildSectionPrompt,
+  buildFaqPrompt,
+  buildMetaDescriptionPrompt,
+  buildTagsPrompt,
+  DEFAULT_SYSTEM_PROMPT,
+  LENGTH_CONFIG,
+} from '../prompts/blog-article.js';
+import type { AIProvider, RetryOptions } from '../providers/types.js';
+import {
+  extractXmlBlock,
+  parseJsonSafe,
+  parseList,
+  parseFaq,
+  cleanMarkdown,
+  validateXmlTags,
+} from '../utils/parsing.js';
+import { withRetry } from '../utils/retry.js';
+
+import type { ArticleGenerationOptions, GeneratedArticle, ArticleOutline } from './types.js';
+
+// ============================================
+// Content Generator Service
+// ============================================
+
+export class ContentGenerator {
+  private provider: AIProvider;
+  private defaultSystemPrompt: string;
+  private retryOptions: RetryOptions;
+
+  constructor(
+    provider: AIProvider,
+    options: {
+      systemPrompt?: string;
+      retryOptions?: RetryOptions;
+    } = {}
+  ) {
+    this.provider = provider;
+    this.defaultSystemPrompt = options.systemPrompt || DEFAULT_SYSTEM_PROMPT;
+    this.retryOptions = options.retryOptions || {
+      maxRetries: 2,
+      initialDelayMs: 1000,
+      backoffMultiplier: 2,
+    };
+  }
+
+  /**
+   * Generate a complete article in a single call
+   */
+  async generateFullArticle(options: ArticleGenerationOptions): Promise<GeneratedArticle> {
+    const { length = 'medium', customSystemPrompt } = options;
+    const lengthConfig = LENGTH_CONFIG[length];
+
+    const prompt = buildArticlePrompt(options);
+    const systemPrompt = customSystemPrompt || this.defaultSystemPrompt;
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          systemPrompt,
+          maxTokens: lengthConfig.maxTokens,
+          temperature: 0.7,
+        }),
+      this.retryOptions
+    );
+
+    return this.parseArticleResponse(result.content, result);
+  }
+
+  /**
+   * Generate article outline first, then content
+   */
+  async generateOutline(options: ArticleGenerationOptions): Promise<ArticleOutline> {
+    const prompt = buildOutlinePrompt(options);
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          maxTokens: 2000,
+          temperature: 0.7,
+        }),
+      this.retryOptions
+    );
+
+    const outline = parseJsonSafe<ArticleOutline>(result.content);
+
+    if (!outline) {
+      throw new Error('Failed to parse article outline');
+    }
+
+    return outline;
+  }
+
+  /**
+   * Generate article from existing outline, section by section
+   */
+  async generateFromOutline(
+    outline: ArticleOutline,
+    options: Omit<ArticleGenerationOptions, 'topic'> & { topic?: string }
+  ): Promise<GeneratedArticle> {
+    const topic = options.topic || outline.title;
+    const { tone = 'professional', customSystemPrompt } = options;
+    const systemPrompt = customSystemPrompt || this.defaultSystemPrompt;
+
+    const sections: string[] = [];
+    let totalTokens = 0;
+    const startTime = Date.now();
+
+    // Generate introduction
+    const introResult = await withRetry(
+      () =>
+        this.provider.generateText(
+          `Rédige l'introduction de l'article "${outline.title}".\n\nRésumé attendu : ${outline.introduction}\n\nTon : ${tone}\n\nL'introduction doit :\n- Accrocher le lecteur\n- Présenter le sujet\n- Annoncer ce qui sera couvert\n- Faire 100-150 mots`,
+          {
+            systemPrompt,
+            maxTokens: 1000,
+            temperature: 0.7,
+          }
+        ),
+      this.retryOptions
+    );
+    sections.push(introResult.content);
+    totalTokens += introResult.totalTokens;
+
+    // Generate each section
+    for (const section of outline.sections) {
+      const sectionResult = await withRetry(
+        () =>
+          this.provider.generateText(
+            buildSectionPrompt(section.heading, section.keyPoints, {
+              articleTopic: topic,
+              previousSections: sections.slice(-2), // Last 2 sections for context
+              tone,
+            }),
+            {
+              systemPrompt,
+              maxTokens: 2000,
+              temperature: 0.7,
+            }
+          ),
+        this.retryOptions
+      );
+
+      sections.push(`## ${section.heading}\n\n${sectionResult.content}`);
+      totalTokens += sectionResult.totalTokens;
+
+      // Generate subsections if any
+      if (section.subsections) {
+        for (const subsection of section.subsections) {
+          const subResult = await withRetry(
+            () =>
+              this.provider.generateText(
+                buildSectionPrompt(subsection.heading, subsection.keyPoints, {
+                  articleTopic: topic,
+                  previousSections: sections.slice(-1),
+                  tone,
+                }),
+                {
+                  systemPrompt,
+                  maxTokens: 1500,
+                  temperature: 0.7,
+                }
+              ),
+            this.retryOptions
+          );
+
+          sections.push(`### ${subsection.heading}\n\n${subResult.content}`);
+          totalTokens += subResult.totalTokens;
+        }
+      }
+    }
+
+    // Generate conclusion
+    const conclusionResult = await withRetry(
+      () =>
+        this.provider.generateText(
+          `Rédige la conclusion de l'article "${outline.title}".\n\nRésumé attendu : ${outline.conclusion}\n\nLa conclusion doit :\n- Récapituler les points clés\n- Apporter une réflexion finale\n- Inviter à l'action ou à la réflexion\n- Faire 100-150 mots`,
+          {
+            systemPrompt,
+            maxTokens: 1000,
+            temperature: 0.7,
+          }
+        ),
+      this.retryOptions
+    );
+    sections.push(`## Conclusion\n\n${conclusionResult.content}`);
+    totalTokens += conclusionResult.totalTokens;
+
+    // Assemble content
+    const fullContent = sections.join('\n\n');
+
+    // Generate metadata
+    const [description, tags, faqItems] = await Promise.all([
+      this.generateMetaDescription(outline.title, fullContent, options.seoQuery),
+      this.generateTags(fullContent),
+      this.generateFaq(fullContent, topic),
+    ]);
+
+    totalTokens += description.tokens + tags.tokens + faqItems.tokens;
+
+    return {
+      title: outline.title,
+      description: description.content,
+      content: cleanMarkdown(`# ${outline.title}\n\n${fullContent}`),
+      category: options.category,
+      tags: tags.content,
+      faq: faqItems.content,
+      metadata: {
+        tokensUsed: totalTokens,
+        durationMs: Date.now() - startTime,
+        model: this.provider.defaultTextModel,
+      },
+    };
+  }
+
+  /**
+   * Generate FAQ from article content
+   */
+  async generateFaq(
+    articleContent: string,
+    topic: string,
+    count: number = 5
+  ): Promise<{ content: Array<{ question: string; answer: string }>; tokens: number }> {
+    const prompt = buildFaqPrompt(articleContent, topic, count);
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          maxTokens: 2000,
+          temperature: 0.5,
+        }),
+      this.retryOptions
+    );
+
+    const faq = parseFaq(result.content);
+
+    return {
+      content: faq.length > 0 ? faq : [],
+      tokens: result.totalTokens,
+    };
+  }
+
+  /**
+   * Generate meta description from article
+   */
+  async generateMetaDescription(
+    title: string,
+    content: string,
+    seoQuery?: string
+  ): Promise<{ content: string; tokens: number }> {
+    const prompt = buildMetaDescriptionPrompt(title, content, seoQuery);
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          maxTokens: 200,
+          temperature: 0.3,
+        }),
+      this.retryOptions
+    );
+
+    // Clean up the description
+    let description = result.content.replace(/^["']|["']$/g, '').trim();
+
+    // Ensure it's within limits
+    if (description.length > 160) {
+      description = description.slice(0, 157) + '...';
+    }
+
+    return {
+      content: description,
+      tokens: result.totalTokens,
+    };
+  }
+
+  /**
+   * Generate tags from article content
+   */
+  async generateTags(
+    content: string,
+    existingTags?: string[]
+  ): Promise<{ content: string[]; tokens: number }> {
+    const prompt = buildTagsPrompt(content, existingTags);
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          maxTokens: 200,
+          temperature: 0.3,
+        }),
+      this.retryOptions
+    );
+
+    const tags = parseList(result.content)
+      .map(tag => tag.toLowerCase().trim())
+      .filter(tag => tag.length > 0 && tag.length <= 50)
+      .slice(0, 10);
+
+    return {
+      content: tags,
+      tokens: result.totalTokens,
+    };
+  }
+
+  /**
+   * Parse article response from XML-formatted AI output
+   */
+  private parseArticleResponse(
+    response: string,
+    rawResult: { totalTokens: number; durationMs: number; model: string }
+  ): GeneratedArticle {
+    // Validate required tags
+    const validation = validateXmlTags(response, ['TITLE', 'DESCRIPTION', 'CONTENT']);
+
+    if (!validation.valid) {
+      throw new Error(`Missing required XML tags in response: ${validation.missing.join(', ')}`);
+    }
+
+    // Extract fields
+    const title = extractXmlBlock(response, 'TITLE') || '';
+    const description = extractXmlBlock(response, 'DESCRIPTION') || '';
+    const content = extractXmlBlock(response, 'CONTENT') || '';
+    const tagsRaw = extractXmlBlock(response, 'TAGS') || '';
+    const faqRaw = extractXmlBlock(response, 'FAQ') || '';
+    const imagePrompt = extractXmlBlock(response, 'IMAGE_PROMPT') || undefined;
+    const category = extractXmlBlock(response, 'CATEGORY') || undefined;
+
+    // Parse tags
+    const tags = parseList(tagsRaw);
+
+    // Parse FAQ
+    const faq = parseFaq(faqRaw);
+
+    return {
+      title: title.trim(),
+      description: description.trim(),
+      content: cleanMarkdown(content),
+      category,
+      tags,
+      faq,
+      imagePrompt,
+      metadata: {
+        tokensUsed: rawResult.totalTokens,
+        durationMs: rawResult.durationMs,
+        model: rawResult.model,
+      },
+    };
+  }
+}
+
+/**
+ * Create a content generator with the given provider
+ */
+export function createContentGenerator(
+  provider: AIProvider,
+  options?: {
+    systemPrompt?: string;
+    retryOptions?: RetryOptions;
+  }
+): ContentGenerator {
+  return new ContentGenerator(provider, options);
+}

--- a/packages/ai/src/services/image-generator.ts
+++ b/packages/ai/src/services/image-generator.ts
@@ -1,0 +1,245 @@
+/**
+ * Image Generation Service
+ * @package @kairn/ai
+ */
+
+import {
+  buildImagePrompt,
+  buildBrandedImagePrompt,
+  buildImageDescriptionPrompt,
+  buildImageVariationsPrompt,
+  type ImagePromptConfig,
+  type BrandedImageConfig,
+} from '../prompts/image-prompt.js';
+import type { AIProvider, RetryOptions } from '../providers/types.js';
+import { withRetry } from '../utils/retry.js';
+
+import type { GeneratedImage, ImageGenerationOptions } from './types.js';
+
+// ============================================
+// Image Generator Service
+// ============================================
+
+export class ImageGenerator {
+  private textProvider: AIProvider;
+  private imageProvider: AIProvider;
+  private retryOptions: RetryOptions;
+
+  /**
+   * Create an image generator
+   * @param textProvider Provider for text generation (prompt creation)
+   * @param imageProvider Provider for image generation (must support generateImage)
+   */
+  constructor(
+    textProvider: AIProvider,
+    imageProvider: AIProvider,
+    options: {
+      retryOptions?: RetryOptions;
+    } = {}
+  ) {
+    this.textProvider = textProvider;
+    this.imageProvider = imageProvider;
+    this.retryOptions = options.retryOptions || {
+      maxRetries: 2,
+      initialDelayMs: 2000,
+      backoffMultiplier: 2,
+    };
+
+    if (!this.imageProvider.generateImage) {
+      throw new Error(
+        `Image provider "${this.imageProvider.name}" does not support image generation`
+      );
+    }
+  }
+
+  /**
+   * Generate images from a prompt configuration
+   */
+  async generateFromConfig(
+    config: ImagePromptConfig,
+    options: Omit<ImageGenerationOptions, 'prompt'> = {}
+  ): Promise<GeneratedImage[]> {
+    const prompt = buildImagePrompt(config);
+    return this.generate({ ...options, prompt });
+  }
+
+  /**
+   * Generate branded images with brand guidelines
+   */
+  async generateBranded(
+    config: BrandedImageConfig,
+    options: Omit<ImageGenerationOptions, 'prompt'> = {}
+  ): Promise<GeneratedImage[]> {
+    const prompt = buildBrandedImagePrompt(config);
+    return this.generate({ ...options, prompt });
+  }
+
+  /**
+   * Generate images from article content
+   * First generates a prompt from the article, then generates images
+   */
+  async generateFromArticle(
+    articleTitle: string,
+    articleContent: string,
+    brandConfig?: {
+      name: string;
+      colors: string[];
+      style?: string;
+    },
+    options: Omit<ImageGenerationOptions, 'prompt'> = {}
+  ): Promise<{
+    images: GeneratedImage[];
+    generatedPrompt: string;
+    metadata: { promptTokens: number };
+  }> {
+    // First, generate the image prompt from the article
+    const promptGenerationPrompt = buildImageDescriptionPrompt(
+      articleTitle,
+      articleContent,
+      brandConfig
+    );
+
+    const promptResult = await withRetry(
+      () =>
+        this.textProvider.generateText(promptGenerationPrompt, {
+          maxTokens: 500,
+          temperature: 0.7,
+        }),
+      this.retryOptions
+    );
+
+    const generatedPrompt = promptResult.content.trim();
+
+    // Generate images using the generated prompt
+    const images = await this.generate({
+      ...options,
+      prompt: generatedPrompt,
+    });
+
+    return {
+      images,
+      generatedPrompt,
+      metadata: {
+        promptTokens: promptResult.totalTokens,
+      },
+    };
+  }
+
+  /**
+   * Generate multiple image variations
+   */
+  async generateVariations(
+    baseConfig: ImagePromptConfig,
+    count: number = 3,
+    options: Omit<ImageGenerationOptions, 'prompt' | 'count'> = {}
+  ): Promise<GeneratedImage[]> {
+    const basePrompt = buildImagePrompt(baseConfig);
+    const prompts = buildImageVariationsPrompt(basePrompt, count);
+
+    const results: GeneratedImage[] = [];
+
+    // Generate each variation
+    for (const prompt of prompts) {
+      const images = await this.generate({
+        ...options,
+        prompt,
+        count: 1,
+      });
+      results.push(...images);
+    }
+
+    return results;
+  }
+
+  /**
+   * Core image generation method
+   */
+  async generate(options: ImageGenerationOptions): Promise<GeneratedImage[]> {
+    const { prompt, count = 1, size, quality, style } = options;
+
+    if (!this.imageProvider.generateImage) {
+      throw new Error('Image provider does not support image generation');
+    }
+
+    const startTime = Date.now();
+
+    const result = await withRetry(
+      () =>
+        this.imageProvider.generateImage!(prompt, {
+          count,
+          size,
+          quality,
+          style,
+        }),
+      this.retryOptions
+    );
+
+    return result.images.map(img => ({
+      url: img.url,
+      base64: img.base64,
+      revisedPrompt: img.revisedPrompt,
+      metadata: {
+        durationMs: Date.now() - startTime,
+        model: result.model,
+      },
+    }));
+  }
+
+  /**
+   * Enhance a basic prompt with more details
+   */
+  async enhancePrompt(basicPrompt: string): Promise<string> {
+    const enhancementPrompt = `Enhance this image generation prompt to be more detailed and visually descriptive:
+
+"${basicPrompt}"
+
+Add:
+- Specific visual details (lighting, composition, textures)
+- Color descriptions
+- Atmosphere and mood
+- Technical quality instructions
+
+Return only the enhanced prompt, no explanations.`;
+
+    const result = await withRetry(
+      () =>
+        this.textProvider.generateText(enhancementPrompt, {
+          maxTokens: 500,
+          temperature: 0.5,
+        }),
+      this.retryOptions
+    );
+
+    return result.content.trim();
+  }
+}
+
+/**
+ * Create an image generator with the given providers
+ */
+export function createImageGenerator(
+  textProvider: AIProvider,
+  imageProvider: AIProvider,
+  options?: {
+    retryOptions?: RetryOptions;
+  }
+): ImageGenerator {
+  return new ImageGenerator(textProvider, imageProvider, options);
+}
+
+/**
+ * Create an image generator with a single provider that supports both text and images
+ */
+export function createImageGeneratorSingleProvider(
+  provider: AIProvider,
+  options?: {
+    retryOptions?: RetryOptions;
+  }
+): ImageGenerator {
+  if (!provider.generateImage) {
+    throw new Error(
+      `Provider "${provider.name}" does not support image generation. Use createImageGenerator with separate text and image providers.`
+    );
+  }
+  return new ImageGenerator(provider, provider, options);
+}

--- a/packages/ai/src/services/index.ts
+++ b/packages/ai/src/services/index.ts
@@ -1,0 +1,49 @@
+/**
+ * AI Services exports
+ * @package @kairn/ai
+ */
+
+// Types
+export type {
+  ArticleTone,
+  ArticleLength,
+  ArticleCategory,
+  ArticleGenerationOptions,
+  GeneratedArticle,
+  ArticleOutline,
+  SocialPlatform,
+  SocialTone,
+  SocialAngle,
+  SocialFormat,
+  SocialPostGenerationOptions,
+  GeneratedSocialPost,
+  MultiPlatformPosts,
+  ImageGenerationOptions,
+  GeneratedImage,
+  ImprovementType,
+  TextImprovementOptions,
+  ImprovedText,
+} from './types.js';
+
+// Zod schemas
+export {
+  ArticleGenerationOptionsSchema,
+  SocialPostGenerationOptionsSchema,
+  TextImprovementOptionsSchema,
+} from './types.js';
+
+// Content Generator
+export { ContentGenerator, createContentGenerator } from './content-generator.js';
+
+// Social Generator
+export { SocialGenerator, createSocialGenerator } from './social-generator.js';
+
+// Image Generator
+export {
+  ImageGenerator,
+  createImageGenerator,
+  createImageGeneratorSingleProvider,
+} from './image-generator.js';
+
+// Text Improver
+export { TextImprover, createTextImprover } from './text-improver.js';

--- a/packages/ai/src/services/social-generator.ts
+++ b/packages/ai/src/services/social-generator.ts
@@ -1,0 +1,305 @@
+/**
+ * Social Media Post Generation Service
+ * @package @kairn/ai
+ */
+
+import {
+  buildSocialPostPrompt,
+  buildMultiPlatformPrompt,
+  PLATFORM_CONFIG,
+} from '../prompts/social-post.js';
+import type { AIProvider, RetryOptions } from '../providers/types.js';
+import { parseJsonSafe } from '../utils/parsing.js';
+import { withRetry } from '../utils/retry.js';
+
+import type {
+  SocialPlatform,
+  SocialPostGenerationOptions,
+  GeneratedSocialPost,
+  MultiPlatformPosts,
+} from './types.js';
+
+// ============================================
+// Social Generator Service
+// ============================================
+
+export class SocialGenerator {
+  private provider: AIProvider;
+  private retryOptions: RetryOptions;
+
+  constructor(
+    provider: AIProvider,
+    options: {
+      retryOptions?: RetryOptions;
+    } = {}
+  ) {
+    this.provider = provider;
+    this.retryOptions = options.retryOptions || {
+      maxRetries: 2,
+      initialDelayMs: 1000,
+      backoffMultiplier: 2,
+    };
+  }
+
+  /**
+   * Generate a post for a specific platform
+   */
+  async generateForPlatform(options: SocialPostGenerationOptions): Promise<GeneratedSocialPost> {
+    const prompt = buildSocialPostPrompt(options);
+    const platformConfig = PLATFORM_CONFIG[options.platform];
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          maxTokens: 1000,
+          temperature: 0.7,
+        }),
+      this.retryOptions
+    );
+
+    // Clean up the response
+    let content = result.content.trim();
+
+    // Remove any markdown code block markers if present
+    content = content
+      .replace(/^```[\w]*\n?/, '')
+      .replace(/\n?```$/, '')
+      .trim();
+
+    // Truncate if needed
+    if (content.length > platformConfig.maxLength) {
+      content = this.truncatePreservingWords(content, platformConfig.maxLength);
+    }
+
+    // Extract hashtags
+    const hashtags = this.extractHashtags(content);
+
+    return {
+      content,
+      platform: options.platform,
+      characterCount: content.length,
+      hashtags,
+      metadata: {
+        tokensUsed: result.totalTokens,
+        durationMs: result.durationMs,
+        model: result.model,
+      },
+    };
+  }
+
+  /**
+   * Generate posts for multiple platforms at once
+   */
+  async generateForPlatforms(
+    sourceContent: string,
+    sourceTitle: string | undefined,
+    platforms: SocialPlatform[],
+    options: Partial<
+      Omit<SocialPostGenerationOptions, 'sourceContent' | 'sourceTitle' | 'platform'>
+    > = {}
+  ): Promise<MultiPlatformPosts> {
+    const startTime = Date.now();
+
+    const prompt = buildMultiPlatformPrompt(sourceContent, sourceTitle, platforms, options);
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          maxTokens: 3000,
+          temperature: 0.7,
+        }),
+      this.retryOptions
+    );
+
+    // Parse the JSON response
+    const parsed = parseJsonSafe<{ posts: Record<string, string> }>(result.content);
+
+    if (!parsed || !parsed.posts) {
+      // Fallback: generate individually if JSON parsing fails
+      return this.generateIndividually(sourceContent, sourceTitle, platforms, options);
+    }
+
+    // Validate and clean each post
+    const posts: Partial<Record<SocialPlatform, string>> = {};
+
+    for (const platform of platforms) {
+      const postContent = parsed.posts[platform];
+      if (postContent) {
+        const config = PLATFORM_CONFIG[platform];
+        let content = postContent.trim();
+
+        // Truncate if needed
+        if (content.length > config.maxLength) {
+          content = this.truncatePreservingWords(content, config.maxLength);
+        }
+
+        posts[platform] = content;
+      }
+    }
+
+    return {
+      posts,
+      metadata: {
+        tokensUsed: result.totalTokens,
+        durationMs: Date.now() - startTime,
+        model: result.model,
+      },
+    };
+  }
+
+  /**
+   * Generate posts individually (fallback or for more control)
+   */
+  private async generateIndividually(
+    sourceContent: string,
+    sourceTitle: string | undefined,
+    platforms: SocialPlatform[],
+    options: Partial<
+      Omit<SocialPostGenerationOptions, 'sourceContent' | 'sourceTitle' | 'platform'>
+    >
+  ): Promise<MultiPlatformPosts> {
+    const startTime = Date.now();
+    let totalTokens = 0;
+    const posts: Partial<Record<SocialPlatform, string>> = {};
+
+    // Generate in parallel for efficiency
+    const results = await Promise.all(
+      platforms.map(async platform => {
+        const result = await this.generateForPlatform({
+          sourceContent,
+          sourceTitle,
+          platform,
+          ...options,
+        });
+        return { platform, result };
+      })
+    );
+
+    for (const { platform, result } of results) {
+      posts[platform] = result.content;
+      totalTokens += result.metadata.tokensUsed;
+    }
+
+    return {
+      posts,
+      metadata: {
+        tokensUsed: totalTokens,
+        durationMs: Date.now() - startTime,
+        model: this.provider.defaultTextModel,
+      },
+    };
+  }
+
+  /**
+   * Platform-specific generation methods
+   */
+  async generateForFacebook(
+    content: string,
+    title?: string,
+    options?: Partial<SocialPostGenerationOptions>
+  ): Promise<GeneratedSocialPost> {
+    return this.generateForPlatform({
+      sourceContent: content,
+      sourceTitle: title,
+      platform: 'facebook',
+      ...options,
+    });
+  }
+
+  async generateForInstagram(
+    content: string,
+    title?: string,
+    options?: Partial<SocialPostGenerationOptions>
+  ): Promise<GeneratedSocialPost> {
+    return this.generateForPlatform({
+      sourceContent: content,
+      sourceTitle: title,
+      platform: 'instagram',
+      includeHashtags: true,
+      includeEmojis: true,
+      ...options,
+    });
+  }
+
+  async generateForLinkedIn(
+    content: string,
+    title?: string,
+    options?: Partial<SocialPostGenerationOptions>
+  ): Promise<GeneratedSocialPost> {
+    return this.generateForPlatform({
+      sourceContent: content,
+      sourceTitle: title,
+      platform: 'linkedin',
+      tone: 'informative',
+      ...options,
+    });
+  }
+
+  async generateForTwitter(
+    content: string,
+    title?: string,
+    options?: Partial<SocialPostGenerationOptions>
+  ): Promise<GeneratedSocialPost> {
+    return this.generateForPlatform({
+      sourceContent: content,
+      sourceTitle: title,
+      platform: 'twitter',
+      includeHashtags: true,
+      ...options,
+    });
+  }
+
+  async generateForThreads(
+    content: string,
+    title?: string,
+    options?: Partial<SocialPostGenerationOptions>
+  ): Promise<GeneratedSocialPost> {
+    return this.generateForPlatform({
+      sourceContent: content,
+      sourceTitle: title,
+      platform: 'threads',
+      includeHashtags: false, // Threads doesn't support hashtags well
+      ...options,
+    });
+  }
+
+  /**
+   * Extract hashtags from post content
+   */
+  private extractHashtags(content: string): string[] {
+    const hashtagRegex = /#[\w\u00C0-\u024F]+/g;
+    const matches = content.match(hashtagRegex);
+    return matches ? [...new Set(matches)] : [];
+  }
+
+  /**
+   * Truncate content while preserving whole words
+   */
+  private truncatePreservingWords(content: string, maxLength: number): string {
+    if (content.length <= maxLength) {
+      return content;
+    }
+
+    // Find the last space before the limit
+    const truncated = content.slice(0, maxLength);
+    const lastSpace = truncated.lastIndexOf(' ');
+
+    if (lastSpace > maxLength * 0.8) {
+      return truncated.slice(0, lastSpace) + '...';
+    }
+
+    return truncated.slice(0, maxLength - 3) + '...';
+  }
+}
+
+/**
+ * Create a social generator with the given provider
+ */
+export function createSocialGenerator(
+  provider: AIProvider,
+  options?: {
+    retryOptions?: RetryOptions;
+  }
+): SocialGenerator {
+  return new SocialGenerator(provider, options);
+}

--- a/packages/ai/src/services/text-improver.ts
+++ b/packages/ai/src/services/text-improver.ts
@@ -1,0 +1,243 @@
+/**
+ * Text Improvement Service
+ * @package @kairn/ai
+ */
+
+import { TONE_DESCRIPTIONS } from '../prompts/blog-article.js';
+import type { AIProvider, RetryOptions } from '../providers/types.js';
+import { withRetry } from '../utils/retry.js';
+
+import type {
+  TextImprovementOptions,
+  ImprovedText,
+  ImprovementType,
+  ArticleTone,
+} from './types.js';
+
+// ============================================
+// Improvement Type Descriptions
+// ============================================
+
+const IMPROVEMENT_DESCRIPTIONS: Record<ImprovementType, string> = {
+  clarity:
+    'Améliore la clarté du texte en simplifiant les phrases complexes et en rendant les idées plus accessibles',
+  conciseness:
+    'Réduit la longueur tout en préservant le sens, élimine les redondances et les mots superflus',
+  engagement:
+    'Rend le texte plus engageant et captivant, ajoute des accroches et des transitions dynamiques',
+  seo: 'Optimise pour le référencement naturel en intégrant naturellement les mots-clés et en améliorant la structure',
+  tone: 'Ajuste le ton selon les instructions tout en préservant le message',
+  grammar: 'Corrige les erreurs grammaticales, orthographiques et de ponctuation',
+  structure:
+    "Améliore l'organisation et la structure du texte avec des paragraphes et transitions logiques",
+  readability: 'Améliore la lisibilité avec des paragraphes courts, des listes et du texte aéré',
+};
+
+// ============================================
+// Text Improver Service
+// ============================================
+
+export class TextImprover {
+  private provider: AIProvider;
+  private retryOptions: RetryOptions;
+  private defaultSystemPrompt: string;
+
+  constructor(
+    provider: AIProvider,
+    options: {
+      systemPrompt?: string;
+      retryOptions?: RetryOptions;
+    } = {}
+  ) {
+    this.provider = provider;
+    this.retryOptions = options.retryOptions || {
+      maxRetries: 2,
+      initialDelayMs: 1000,
+      backoffMultiplier: 2,
+    };
+    this.defaultSystemPrompt =
+      options.systemPrompt ||
+      `Tu es un rédacteur expert spécialisé dans l'amélioration de texte.
+
+Règles d'amélioration :
+1. Préserve le sens et les informations clés du texte original
+2. Améliore la clarté et la fluidité
+3. Corrige les erreurs grammaticales et de style
+4. Utilise le Markdown approprié (gras pour les concepts clés, italique pour les nuances)
+5. Structure les paragraphes de manière aérée (3-4 lignes max)
+6. Pas de retours à la ligne à l'intérieur des paragraphes
+7. Réponds uniquement avec le texte amélioré, sans commentaires ni explications`;
+  }
+
+  /**
+   * Improve text based on options
+   */
+  async improve(options: TextImprovementOptions): Promise<ImprovedText> {
+    const {
+      text,
+      type = 'clarity',
+      instructions,
+      targetTone,
+      preserveMarkdown = true,
+      language = 'fr',
+    } = options;
+
+    const prompt = this.buildImprovementPrompt(
+      text,
+      type,
+      instructions,
+      targetTone,
+      preserveMarkdown,
+      language
+    );
+
+    const result = await withRetry(
+      () =>
+        this.provider.generateText(prompt, {
+          systemPrompt: this.defaultSystemPrompt,
+          maxTokens: Math.max(text.length * 2, 2000),
+          temperature: 0.3,
+        }),
+      this.retryOptions
+    );
+
+    // Clean up the response
+    let improvedContent = result.content.trim();
+
+    // Remove any wrapper quotes or markdown code blocks
+    improvedContent = improvedContent
+      .replace(/^```[\w]*\n?/, '')
+      .replace(/\n?```$/, '')
+      .replace(/^["']|["']$/g, '')
+      .trim();
+
+    return {
+      content: improvedContent,
+      metadata: {
+        tokensUsed: result.totalTokens,
+        durationMs: result.durationMs,
+        model: result.model,
+      },
+    };
+  }
+
+  /**
+   * Quick improvement methods for common use cases
+   */
+  async improveClarity(text: string, language?: 'fr' | 'en'): Promise<ImprovedText> {
+    return this.improve({ text, type: 'clarity', language });
+  }
+
+  async improveConciseness(text: string, language?: 'fr' | 'en'): Promise<ImprovedText> {
+    return this.improve({ text, type: 'conciseness', language });
+  }
+
+  async improveEngagement(text: string, language?: 'fr' | 'en'): Promise<ImprovedText> {
+    return this.improve({ text, type: 'engagement', language });
+  }
+
+  async improveSeo(
+    text: string,
+    keywords?: string[],
+    language?: 'fr' | 'en'
+  ): Promise<ImprovedText> {
+    const instructions = keywords?.length
+      ? `Intègre naturellement ces mots-clés : ${keywords.join(', ')}`
+      : undefined;
+    return this.improve({ text, type: 'seo', instructions, language });
+  }
+
+  async improveGrammar(text: string, language?: 'fr' | 'en'): Promise<ImprovedText> {
+    return this.improve({ text, type: 'grammar', language });
+  }
+
+  async improveReadability(text: string, language?: 'fr' | 'en'): Promise<ImprovedText> {
+    return this.improve({ text, type: 'readability', language });
+  }
+
+  async changeTone(
+    text: string,
+    targetTone: ArticleTone,
+    language?: 'fr' | 'en'
+  ): Promise<ImprovedText> {
+    return this.improve({ text, type: 'tone', targetTone, language });
+  }
+
+  /**
+   * Custom improvement with specific instructions
+   */
+  async improveWithInstructions(
+    text: string,
+    instructions: string,
+    language?: 'fr' | 'en'
+  ): Promise<ImprovedText> {
+    return this.improve({ text, instructions, language });
+  }
+
+  /**
+   * Build the improvement prompt
+   */
+  private buildImprovementPrompt(
+    text: string,
+    type: ImprovementType,
+    instructions?: string,
+    targetTone?: ArticleTone,
+    preserveMarkdown?: boolean,
+    language?: 'fr' | 'en'
+  ): string {
+    const parts: string[] = [];
+
+    // Main instruction
+    parts.push('Améliore le texte suivant :');
+    parts.push('');
+    parts.push('---');
+    parts.push(text);
+    parts.push('---');
+    parts.push('');
+
+    // Improvement type
+    parts.push(`Type d'amélioration demandé : ${type}`);
+    parts.push(IMPROVEMENT_DESCRIPTIONS[type]);
+    parts.push('');
+
+    // Additional instructions
+    if (instructions) {
+      parts.push(`Instructions spécifiques : ${instructions}`);
+      parts.push('');
+    }
+
+    // Target tone
+    if (targetTone) {
+      parts.push(`Ton cible : ${TONE_DESCRIPTIONS[targetTone]}`);
+      parts.push('');
+    }
+
+    // Markdown handling
+    if (preserveMarkdown) {
+      parts.push('Préserve le formatage Markdown existant (titres, listes, gras, italique).');
+    } else {
+      parts.push('Tu peux ajouter ou modifier le formatage Markdown si nécessaire.');
+    }
+
+    // Language
+    parts.push(`\nLangue : ${language === 'fr' ? 'Français' : 'Anglais'}`);
+
+    // Final instruction
+    parts.push('\nRéponds uniquement avec le texte amélioré, sans commentaires ni explications.');
+
+    return parts.join('\n');
+  }
+}
+
+/**
+ * Create a text improver with the given provider
+ */
+export function createTextImprover(
+  provider: AIProvider,
+  options?: {
+    systemPrompt?: string;
+    retryOptions?: RetryOptions;
+  }
+): TextImprover {
+  return new TextImprover(provider, options);
+}

--- a/packages/ai/src/services/types.ts
+++ b/packages/ai/src/services/types.ts
@@ -1,0 +1,395 @@
+/**
+ * Types for AI Services
+ * @package @kairn/ai
+ */
+
+import { z } from 'zod';
+
+// ============================================
+// Content Generation Types
+// ============================================
+
+export type ArticleTone =
+  | 'professional'
+  | 'casual'
+  | 'educational'
+  | 'inspirational'
+  | 'analytical'
+  | 'poetic'
+  | 'introspective'
+  | 'narrative'
+  | 'conversational'
+  | 'provocative'
+  | 'humorous'
+  | 'scientific'
+  | 'practical';
+
+export type ArticleLength = 'short' | 'medium' | 'long';
+
+export type ArticleCategory = string;
+
+export interface ArticleGenerationOptions {
+  /** Main topic of the article */
+  topic: string;
+  /** Article category (optional) */
+  category?: ArticleCategory;
+  /** Target length */
+  length?: ArticleLength;
+  /** Primary tone */
+  tone?: ArticleTone;
+  /** Multiple tones to blend */
+  tones?: ArticleTone[];
+  /** SEO keywords to include */
+  keywords?: string[];
+  /** Target audience description */
+  targetAudience?: string;
+  /** Target SEO query */
+  seoQuery?: string;
+  /** Search intent to address */
+  searchIntent?: string;
+  /** Content language */
+  language?: 'fr' | 'en';
+  /** Custom system prompt to override default */
+  customSystemPrompt?: string;
+}
+
+export interface GeneratedArticle {
+  /** Article title */
+  title: string;
+  /** Meta description for SEO */
+  description: string;
+  /** Full article content in Markdown */
+  content: string;
+  /** Article category */
+  category?: string;
+  /** SEO tags */
+  tags: string[];
+  /** FAQ items */
+  faq: Array<{ question: string; answer: string }>;
+  /** Prompt for image generation */
+  imagePrompt?: string;
+  /** Generation metadata */
+  metadata: {
+    tokensUsed: number;
+    durationMs: number;
+    model: string;
+  };
+}
+
+export interface ArticleOutline {
+  /** Proposed title */
+  title: string;
+  /** Introduction summary */
+  introduction: string;
+  /** Article sections */
+  sections: Array<{
+    heading: string;
+    level: 2 | 3;
+    keyPoints: string[];
+    subsections?: Array<{
+      heading: string;
+      level: 3;
+      keyPoints: string[];
+    }>;
+  }>;
+  /** Conclusion summary */
+  conclusion: string;
+}
+
+// ============================================
+// Social Media Types
+// ============================================
+
+export type SocialPlatform = 'facebook' | 'instagram' | 'linkedin' | 'twitter' | 'threads';
+
+export type SocialTone =
+  | 'informative'
+  | 'inspirational'
+  | 'promotional'
+  | 'educational'
+  | 'personal'
+  | 'entertaining'
+  | 'thought_provoking';
+
+export type SocialAngle =
+  | 'benefits'
+  | 'problem'
+  | 'story'
+  | 'expert'
+  | 'practical'
+  | 'curiosity'
+  | 'controversy'
+  | 'social_proof';
+
+export type SocialFormat =
+  | 'hook_reveal'
+  | 'visual_list'
+  | 'micro_storytelling'
+  | 'rhetorical_question'
+  | 'quote_reflection'
+  | 'myth_reality'
+  | 'raw_thought'
+  | 'observation'
+  | 'open_question'
+  | 'micro_confession'
+  | 'poetic_fragment'
+  | 'counter_intuitive'
+  | 'observation_pro'
+  | 'social_proof';
+
+export interface SocialPostGenerationOptions {
+  /** Source content to transform */
+  sourceContent: string;
+  /** Source content title (optional) */
+  sourceTitle?: string;
+  /** Target platform */
+  platform: SocialPlatform;
+  /** Tone of the post */
+  tone?: SocialTone;
+  /** Angle/approach */
+  angle?: SocialAngle;
+  /** Specific format (platform-dependent) */
+  format?: SocialFormat;
+  /** Include hashtags */
+  includeHashtags?: boolean;
+  /** Include emojis */
+  includeEmojis?: boolean;
+  /** Include call-to-action */
+  includeCallToAction?: boolean;
+  /** Maximum length override */
+  maxLength?: number;
+  /** Content language */
+  language?: 'fr' | 'en';
+  /** Link to include */
+  link?: string;
+  /** Authenticity level (1-5) */
+  authenticityLevel?: 1 | 2 | 3 | 4 | 5;
+  /** Expertise level (1-5) */
+  expertiseLevel?: 1 | 2 | 3 | 4 | 5;
+}
+
+export interface GeneratedSocialPost {
+  /** Post content */
+  content: string;
+  /** Target platform */
+  platform: SocialPlatform;
+  /** Character count */
+  characterCount: number;
+  /** Extracted hashtags */
+  hashtags: string[];
+  /** Generation metadata */
+  metadata: {
+    tokensUsed: number;
+    durationMs: number;
+    model: string;
+  };
+}
+
+export interface MultiPlatformPosts {
+  /** Posts keyed by platform */
+  posts: Partial<Record<SocialPlatform, string>>;
+  /** Generation metadata */
+  metadata: {
+    tokensUsed: number;
+    durationMs: number;
+    model: string;
+  };
+}
+
+// ============================================
+// Image Generation Types
+// ============================================
+
+export interface ImageGenerationOptions {
+  /** Image prompt */
+  prompt: string;
+  /** Number of images to generate */
+  count?: number;
+  /** Image size */
+  size?: '1024x1024' | '1792x1024' | '1024x1792';
+  /** Quality level */
+  quality?: 'standard' | 'hd';
+  /** Style */
+  style?: 'vivid' | 'natural';
+}
+
+export interface GeneratedImage {
+  /** Image URL or base64 data */
+  url?: string;
+  base64?: string;
+  /** Revised prompt (if modified by the model) */
+  revisedPrompt?: string;
+  /** Generation metadata */
+  metadata: {
+    durationMs: number;
+    model: string;
+  };
+}
+
+// ============================================
+// Text Improvement Types
+// ============================================
+
+export type ImprovementType =
+  | 'clarity'
+  | 'conciseness'
+  | 'engagement'
+  | 'seo'
+  | 'tone'
+  | 'grammar'
+  | 'structure'
+  | 'readability';
+
+export interface TextImprovementOptions {
+  /** Text to improve */
+  text: string;
+  /** Type of improvement */
+  type?: ImprovementType;
+  /** Custom improvement instructions */
+  instructions?: string;
+  /** Target tone (optional) */
+  targetTone?: ArticleTone;
+  /** Preserve markdown formatting */
+  preserveMarkdown?: boolean;
+  /** Content language */
+  language?: 'fr' | 'en';
+}
+
+export interface ImprovedText {
+  /** Improved text */
+  content: string;
+  /** List of changes made */
+  changes?: string[];
+  /** Generation metadata */
+  metadata: {
+    tokensUsed: number;
+    durationMs: number;
+    model: string;
+  };
+}
+
+// ============================================
+// Zod Schemas
+// ============================================
+
+export const ArticleGenerationOptionsSchema = z.object({
+  topic: z.string().min(1),
+  category: z.string().optional(),
+  length: z.enum(['short', 'medium', 'long']).optional(),
+  tone: z
+    .enum([
+      'professional',
+      'casual',
+      'educational',
+      'inspirational',
+      'analytical',
+      'poetic',
+      'introspective',
+      'narrative',
+      'conversational',
+      'provocative',
+      'humorous',
+      'scientific',
+      'practical',
+    ])
+    .optional(),
+  tones: z
+    .array(
+      z.enum([
+        'professional',
+        'casual',
+        'educational',
+        'inspirational',
+        'analytical',
+        'poetic',
+        'introspective',
+        'narrative',
+        'conversational',
+        'provocative',
+        'humorous',
+        'scientific',
+        'practical',
+      ])
+    )
+    .optional(),
+  keywords: z.array(z.string()).optional(),
+  targetAudience: z.string().optional(),
+  seoQuery: z.string().optional(),
+  searchIntent: z.string().optional(),
+  language: z.enum(['fr', 'en']).optional(),
+  customSystemPrompt: z.string().optional(),
+});
+
+export const SocialPostGenerationOptionsSchema = z.object({
+  sourceContent: z.string().min(1),
+  sourceTitle: z.string().optional(),
+  platform: z.enum(['facebook', 'instagram', 'linkedin', 'twitter', 'threads']),
+  tone: z
+    .enum([
+      'informative',
+      'inspirational',
+      'promotional',
+      'educational',
+      'personal',
+      'entertaining',
+      'thought_provoking',
+    ])
+    .optional(),
+  angle: z
+    .enum([
+      'benefits',
+      'problem',
+      'story',
+      'expert',
+      'practical',
+      'curiosity',
+      'controversy',
+      'social_proof',
+    ])
+    .optional(),
+  format: z.string().optional(),
+  includeHashtags: z.boolean().optional(),
+  includeEmojis: z.boolean().optional(),
+  includeCallToAction: z.boolean().optional(),
+  maxLength: z.number().positive().optional(),
+  language: z.enum(['fr', 'en']).optional(),
+  link: z.string().url().optional(),
+  authenticityLevel: z.number().min(1).max(5).optional(),
+  expertiseLevel: z.number().min(1).max(5).optional(),
+});
+
+export const TextImprovementOptionsSchema = z.object({
+  text: z.string().min(1),
+  type: z
+    .enum([
+      'clarity',
+      'conciseness',
+      'engagement',
+      'seo',
+      'tone',
+      'grammar',
+      'structure',
+      'readability',
+    ])
+    .optional(),
+  instructions: z.string().optional(),
+  targetTone: z
+    .enum([
+      'professional',
+      'casual',
+      'educational',
+      'inspirational',
+      'analytical',
+      'poetic',
+      'introspective',
+      'narrative',
+      'conversational',
+      'provocative',
+      'humorous',
+      'scientific',
+      'practical',
+    ])
+    .optional(),
+  preserveMarkdown: z.boolean().optional(),
+  language: z.enum(['fr', 'en']).optional(),
+});

--- a/packages/ai/src/utils/index.ts
+++ b/packages/ai/src/utils/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Utility exports
+ * @package @kairn/ai
+ */
+
+export {
+  withRetry,
+  createRetryable,
+  isRetriableError,
+  sleep,
+  calculateDelay,
+  type RetryConfig,
+} from './retry.js';
+
+export {
+  parseJsonSafe,
+  extractXmlBlock,
+  extractAllXmlBlocks,
+  validateXmlTags,
+  parseList,
+  parseFaq,
+  cleanMarkdown,
+} from './parsing.js';

--- a/packages/ai/src/utils/parsing.ts
+++ b/packages/ai/src/utils/parsing.ts
@@ -1,0 +1,306 @@
+/**
+ * Robust JSON and XML parsing utilities for AI responses
+ * @package @kairn/ai
+ */
+
+/**
+ * Attempt to parse JSON from AI response, with error recovery
+ *
+ * Handles common issues:
+ * - Markdown code blocks
+ * - Truncated JSON
+ * - Missing closing brackets
+ * - Extra text before/after JSON
+ *
+ * @param text Raw text from AI response
+ * @returns Parsed JSON object or null if parsing fails
+ */
+export function parseJsonSafe<T = unknown>(text: string): T | null {
+  if (!text || typeof text !== 'string') {
+    return null;
+  }
+
+  // Try direct parse first
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    // Continue with recovery attempts
+  }
+
+  // Remove markdown code blocks
+  const cleaned = text
+    .replace(/```json\s*/gi, '')
+    .replace(/```\s*/g, '')
+    .trim();
+
+  // Try parsing cleaned text
+  try {
+    return JSON.parse(cleaned) as T;
+  } catch {
+    // Continue with more recovery
+  }
+
+  // Find JSON-like structure (object or array)
+  const objectMatch = cleaned.match(/\{[\s\S]*\}/);
+  const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
+
+  const jsonText = objectMatch?.[0] || arrayMatch?.[0];
+  if (jsonText) {
+    try {
+      return JSON.parse(jsonText) as T;
+    } catch {
+      // Try to fix truncated JSON
+      const fixed = fixTruncatedJson(jsonText);
+      if (fixed) {
+        try {
+          return JSON.parse(fixed) as T;
+        } catch {
+          // Give up
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Attempt to fix truncated JSON by adding missing closing brackets
+ */
+function fixTruncatedJson(json: string): string | null {
+  let fixed = json.trim();
+
+  // Count brackets
+  let braceCount = 0;
+  let bracketCount = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < fixed.length; i++) {
+    const char = fixed[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (!inString) {
+      if (char === '{') braceCount++;
+      else if (char === '}') braceCount--;
+      else if (char === '[') bracketCount++;
+      else if (char === ']') bracketCount--;
+    }
+  }
+
+  // If we're in a string, try to close it
+  if (inString) {
+    fixed += '"';
+  }
+
+  // Remove trailing comma if present
+  fixed = fixed.replace(/,\s*$/, '');
+
+  // Add missing closing brackets
+  while (bracketCount > 0) {
+    fixed += ']';
+    bracketCount--;
+  }
+
+  while (braceCount > 0) {
+    fixed += '}';
+    braceCount--;
+  }
+
+  return fixed;
+}
+
+/**
+ * Extract content from XML-like tags
+ *
+ * @param text Text containing XML tags
+ * @param tagName Name of the tag to extract
+ * @returns Content between tags or null if not found
+ *
+ * @example
+ * ```typescript
+ * const title = extractXmlBlock(response, "TITLE");
+ * // From: <TITLE>My Article Title</TITLE>
+ * // Returns: "My Article Title"
+ * ```
+ */
+export function extractXmlBlock(text: string, tagName: string): string | null {
+  const regex = new RegExp(`<${tagName}>([\\s\\S]*?)<\\/${tagName}>`, 'i');
+  const match = text.match(regex);
+  return match && match[1] ? match[1].trim() : null;
+}
+
+/**
+ * Extract multiple instances of an XML block
+ *
+ * @param text Text containing XML tags
+ * @param tagName Name of the tag to extract
+ * @returns Array of content strings
+ */
+export function extractAllXmlBlocks(text: string, tagName: string): string[] {
+  const regex = new RegExp(`<${tagName}>([\\s\\S]*?)<\\/${tagName}>`, 'gi');
+  const matches = [...text.matchAll(regex)];
+  return matches.map(match => (match[1] ?? '').trim()).filter(Boolean);
+}
+
+/**
+ * Check if all required XML tags are present and complete
+ *
+ * @param text Text to validate
+ * @param requiredTags Array of required tag names
+ * @returns Object with validation result and missing tags
+ */
+export function validateXmlTags(
+  text: string,
+  requiredTags: string[]
+): { valid: boolean; missing: string[] } {
+  const missing: string[] = [];
+
+  for (const tag of requiredTags) {
+    if (!extractXmlBlock(text, tag)) {
+      missing.push(tag);
+    }
+  }
+
+  return {
+    valid: missing.length === 0,
+    missing,
+  };
+}
+
+/**
+ * Parse a list from AI response (handles various formats)
+ *
+ * Supports:
+ * - JSON arrays
+ * - Comma-separated values
+ * - Numbered lists
+ * - Bullet point lists
+ * - Line-separated values
+ *
+ * @param text Raw text containing a list
+ * @returns Array of strings
+ */
+export function parseList(text: string): string[] {
+  if (!text) return [];
+
+  // Try JSON array first
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (Array.isArray(parsed)) {
+      return (parsed as unknown[]).map(String).filter(Boolean);
+    }
+  } catch {
+    // Continue with other formats
+  }
+
+  // Remove common list wrappers
+  const cleaned = text
+    .replace(/^\s*\[/, '')
+    .replace(/\]\s*$/, '')
+    .trim();
+
+  // Check if it looks like comma-separated
+  if (cleaned.includes(',') && !cleaned.includes('\n')) {
+    return cleaned
+      .split(',')
+      .map(s => s.trim().replace(/^["']|["']$/g, ''))
+      .filter(Boolean);
+  }
+
+  // Handle numbered or bulleted lists
+  return cleaned
+    .split(/\n/)
+    .map(line =>
+      line
+        .replace(/^\s*[-•*]\s*/, '') // Remove bullets
+        .replace(/^\s*\d+[.)]\s*/, '') // Remove numbers
+        .replace(/^["']|["']$/g, '') // Remove quotes
+        .trim()
+    )
+    .filter(Boolean);
+}
+
+/**
+ * Parse FAQ format from AI response
+ *
+ * @param text Text containing FAQ items
+ * @returns Array of question/answer pairs
+ */
+export function parseFaq(text: string): Array<{ question: string; answer: string }> {
+  // Try JSON first
+  const json = parseJsonSafe<Array<{ question: string; answer: string }>>(text);
+  if (json && Array.isArray(json)) {
+    return json.filter(
+      item => typeof item === 'object' && item !== null && 'question' in item && 'answer' in item
+    );
+  }
+
+  // Try XML-like format
+  const faqBlocks = extractAllXmlBlocks(text, 'FAQ_ITEM');
+  if (faqBlocks.length > 0) {
+    return faqBlocks
+      .map(block => ({
+        question: extractXmlBlock(block, 'QUESTION') || '',
+        answer: extractXmlBlock(block, 'ANSWER') || '',
+      }))
+      .filter(item => item.question && item.answer);
+  }
+
+  // Try pattern matching (Q: ... A: ...)
+  const qaPattern = /(?:Q(?:uestion)?[:.]?\s*)?(.+?)\n+(?:A(?:nswer)?[:.]?\s*)(.+?)(?=\n+Q|$)/gis;
+  const matches = [...text.matchAll(qaPattern)];
+  if (matches.length > 0) {
+    return matches
+      .map(match => ({
+        question: (match[1] ?? '').trim(),
+        answer: (match[2] ?? '').trim(),
+      }))
+      .filter(item => item.question && item.answer);
+  }
+
+  return [];
+}
+
+/**
+ * Clean markdown content from AI response
+ *
+ * Normalizes:
+ * - Line breaks within paragraphs
+ * - Whitespace
+ * - Code block markers
+ *
+ * @param text Raw markdown text
+ * @returns Cleaned markdown
+ */
+export function cleanMarkdown(text: string): string {
+  if (!text) return '';
+
+  return (
+    text
+      // Remove any XML tags that might have leaked through
+      .replace(/<[A-Z_]+>|<\/[A-Z_]+>/g, '')
+      // Normalize line endings
+      .replace(/\r\n/g, '\n')
+      // Fix paragraphs with internal line breaks (but preserve intentional ones)
+      .replace(/([^\n])\n([^\n#>*\-\d])/g, '$1 $2')
+      // Remove excessive blank lines
+      .replace(/\n{3,}/g, '\n\n')
+      // Trim
+      .trim()
+  );
+}

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -1,0 +1,164 @@
+/**
+ * Retry utilities with exponential backoff
+ * @package @kairn/ai
+ */
+
+import { AIProviderError } from '../providers/types.js';
+
+export interface RetryConfig {
+  /** Maximum number of retries (default: 3) */
+  maxRetries?: number;
+  /** Initial delay between retries in ms (default: 1000) */
+  initialDelayMs?: number;
+  /** Backoff multiplier (default: 2) */
+  backoffMultiplier?: number;
+  /** Maximum delay between retries in ms (default: 30000) */
+  maxDelayMs?: number;
+  /** Custom function to determine if an error is retriable */
+  isRetriable?: (error: unknown) => boolean;
+  /** Callback called on each retry attempt */
+  onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
+}
+
+const DEFAULT_RETRY_CONFIG: Required<Omit<RetryConfig, 'onRetry' | 'isRetriable'>> = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  backoffMultiplier: 2,
+  maxDelayMs: 30000,
+};
+
+/**
+ * Default function to determine if an error is retriable
+ */
+export function isRetriableError(error: unknown): boolean {
+  // Check AIProviderError
+  if (error instanceof AIProviderError) {
+    return error.isRetriable;
+  }
+
+  // Check standard Error message
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    return (
+      message.includes('econnreset') ||
+      message.includes('etimedout') ||
+      message.includes('rate_limit') ||
+      message.includes('overloaded') ||
+      message.includes('502') ||
+      message.includes('503') ||
+      message.includes('504') ||
+      message.includes('network')
+    );
+  }
+
+  // Check HTTP-like errors
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status: number }).status;
+    return status >= 500 || status === 408 || status === 429;
+  }
+
+  return false;
+}
+
+/**
+ * Sleep for a given number of milliseconds
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Calculate delay for a given retry attempt with exponential backoff
+ */
+export function calculateDelay(
+  attempt: number,
+  initialDelayMs: number,
+  backoffMultiplier: number,
+  maxDelayMs: number
+): number {
+  const delay = initialDelayMs * Math.pow(backoffMultiplier, attempt - 1);
+  // Add jitter to prevent thundering herd
+  const jitter = Math.random() * 0.1 * delay;
+  return Math.min(delay + jitter, maxDelayMs);
+}
+
+/**
+ * Execute a function with retry logic and exponential backoff
+ *
+ * @param fn Function to execute
+ * @param config Retry configuration
+ * @returns Result of the function
+ * @throws Last error if all retries fail
+ *
+ * @example
+ * ```typescript
+ * const result = await withRetry(
+ *   () => provider.generateText(prompt),
+ *   {
+ *     maxRetries: 3,
+ *     onRetry: (attempt, error, delay) => {
+ *       console.log(`Retry ${attempt} after ${delay}ms: ${error}`);
+ *     }
+ *   }
+ * );
+ * ```
+ */
+export async function withRetry<T>(fn: () => Promise<T>, config: RetryConfig = {}): Promise<T> {
+  const {
+    maxRetries = DEFAULT_RETRY_CONFIG.maxRetries,
+    initialDelayMs = DEFAULT_RETRY_CONFIG.initialDelayMs,
+    backoffMultiplier = DEFAULT_RETRY_CONFIG.backoffMultiplier,
+    maxDelayMs = DEFAULT_RETRY_CONFIG.maxDelayMs,
+    isRetriable = isRetriableError,
+    onRetry,
+  } = config;
+
+  let lastError: unknown;
+  let attempt = 0;
+
+  while (attempt <= maxRetries) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      attempt++;
+
+      if (attempt > maxRetries || !isRetriable(error)) {
+        throw error;
+      }
+
+      const delay = calculateDelay(attempt, initialDelayMs, backoffMultiplier, maxDelayMs);
+
+      if (onRetry) {
+        onRetry(attempt, error, delay);
+      }
+
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Create a retryable version of an async function
+ *
+ * @param fn Function to wrap
+ * @param config Retry configuration
+ * @returns Wrapped function with retry logic
+ *
+ * @example
+ * ```typescript
+ * const generateWithRetry = createRetryable(
+ *   (prompt: string) => provider.generateText(prompt),
+ *   { maxRetries: 3 }
+ * );
+ * const result = await generateWithRetry("Hello");
+ * ```
+ */
+export function createRetryable<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
+  config: RetryConfig = {}
+): (...args: TArgs) => Promise<TResult> {
+  return (...args: TArgs) => withRetry(() => fn(...args), config);
+}

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "@kairn/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,37 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
+  packages/ai:
+    dependencies:
+      '@kairn/config':
+        specifier: workspace:*
+        version: link:../config
+      '@kairn/core':
+        specifier: workspace:*
+        version: link:../core
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+    devDependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.26.0
+        version: 0.26.1
+      '@kairn/eslint-config':
+        specifier: workspace:*
+        version: link:../../tooling/eslint-config
+      '@kairn/typescript-config':
+        specifier: workspace:*
+        version: link:../../tooling/typescript-config
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      openai:
+        specifier: ^4.52.0
+        version: 4.104.0(ws@8.18.3)(zod@3.25.76)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   packages/analytics:
     dependencies:
       ua-parser-js:
@@ -566,6 +597,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/sdk@0.26.1':
+    resolution: {integrity: sha512-HeMJP1bDFfQPQS3XTJAmfXkFBdZ88wvfkE05+vsoA9zGn5dHqEaHOPsqkazf/i0gXYg2XlLxxZrf6rUAarSqzw==}
 
   '@anthropic-ai/sdk@0.71.2':
     resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
@@ -1504,6 +1538,12 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
 
@@ -1754,6 +1794,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1771,6 +1815,10 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1862,6 +1910,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   autoprefixer@10.4.22:
     resolution: {integrity: sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==}
@@ -2089,6 +2140,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2258,6 +2313,10 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -2514,6 +2573,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
@@ -2596,6 +2659,17 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
 
   frac@1.1.2:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
@@ -2817,6 +2891,9 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -3375,6 +3452,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -3474,8 +3559,22 @@ packages:
     resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -3557,6 +3656,18 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   openai@6.16.0:
     resolution: {integrity: sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==}
@@ -4349,6 +4460,9 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -4483,6 +4597,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -4608,8 +4725,15 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@8.0.0:
     resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
@@ -4626,6 +4750,9 @@ packages:
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4737,6 +4864,18 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/sdk@0.26.1':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@anthropic-ai/sdk@0.71.2(zod@3.25.76)':
     dependencies:
@@ -5416,6 +5555,15 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 20.19.30
+      form-data: 4.0.5
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
@@ -5691,6 +5839,10 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -5700,6 +5852,10 @@ snapshots:
   adler-32@1.3.1: {}
 
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv@6.12.6:
     dependencies:
@@ -5813,6 +5969,8 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
 
   autoprefixer@10.4.22(postcss@8.5.6):
     dependencies:
@@ -6040,6 +6198,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0: {}
@@ -6184,6 +6346,8 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.4: {}
+
+  delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
 
@@ -6607,6 +6771,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
@@ -6692,6 +6858,21 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
 
   frac@1.1.2: {}
 
@@ -7023,6 +7204,10 @@ snapshots:
       - supports-color
 
   human-signals@5.0.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -7833,6 +8018,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mimic-fn@2.1.0: {}
 
   mimic-fn@4.0.0: {}
@@ -7932,7 +8123,13 @@ snapshots:
 
   node-addon-api@8.5.0: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
 
@@ -8017,6 +8214,21 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@4.104.0(ws@8.18.3)(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
 
   openai@6.16.0(ws@8.18.3)(zod@3.25.76):
     optionalDependencies:
@@ -8977,6 +9189,8 @@ snapshots:
     dependencies:
       tldts: 7.0.19
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -9119,6 +9333,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -9307,7 +9523,11 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
   web-vitals@5.1.0: {}
+
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.0: {}
 
@@ -9319,6 +9539,11 @@ snapshots:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
This commit creates the @kairn/ai package that abstracts AI services
(Anthropic Claude, OpenAI GPT/DALL-E) for the Kairn platform.

Key features:
- Provider abstraction layer (Anthropic, OpenAI) with unified interface
- Content generation service for blog articles (full, outline-based)
- Social media post generation for multiple platforms
- Image generation service with brand support
- Text improvement service with multiple improvement types
- Robust utilities: retry with exponential backoff, JSON/XML parsing
- Comprehensive prompt templates for articles, social posts, and images

The package supports:
- Multiple generation strategies (single-call, multi-step, sectional)
- Platform-specific social formats (Instagram, LinkedIn, Threads, etc.)
- Branded image generation with color palette support
- Configurable retry logic with error recovery
- Full TypeScript support with Zod validation schemas