### PR TITLE
feat(social): implement phase 5 mutualization - complete @kairn/social package

### DIFF
--- a/packages/social/.eslintrc.json
+++ b/packages/social/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["@kairn/eslint-config"],
+  "parserOptions": {
+    "project": true
+  },
+  "rules": {
+    "no-console": "off"
+  },
+  "ignorePatterns": ["dist/"]
+}

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -2,7 +2,7 @@
   "name": "@kairn/social",
   "version": "0.0.1",
   "private": true,
-  "description": "Module réseaux sociaux pour les sites Kairn",
+  "description": "Social media integration module for Kairn sites - OAuth and publishing",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -17,6 +17,10 @@
     "./posting": {
       "types": "./dist/posting/index.d.ts",
       "import": "./dist/posting/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
     }
   },
   "scripts": {
@@ -30,7 +34,21 @@
     "@kairn/core": "workspace:*"
   },
   "devDependencies": {
+    "@kairn/eslint-config": "workspace:*",
     "@kairn/typescript-config": "workspace:*",
+    "@types/node": "^20.10.0",
     "typescript": "^5.4.0"
-  }
+  },
+  "keywords": [
+    "social-media",
+    "oauth",
+    "facebook",
+    "instagram",
+    "linkedin",
+    "twitter",
+    "threads",
+    "publishing"
+  ],
+  "author": "Kairn Team",
+  "license": "UNLICENSED"
 }

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -1,22 +1,72 @@
 /**
  * @kairn/social - Social Media Integration Module
- * 
- * This module provides social media integration for Kairn sites.
- * Features will be added progressively:
- * - OAuth integration for social platforms
- * - Social post publishing
- * - Analytics integration
+ *
+ * Provides OAuth authentication and post publishing for social media platforms:
+ * - Facebook (Pages)
+ * - Instagram (Business/Creator)
+ * - LinkedIn (Personal & Organization)
+ * - Twitter/X
+ * - Threads
+ *
+ * @example OAuth Flow
+ * ```typescript
+ * import { facebook, generateStateToken } from '@kairn/social/oauth';
+ *
+ * // Generate state for CSRF protection
+ * const state = generateStateToken();
+ *
+ * // Get authorization URL
+ * const authUrl = facebook.getAuthorizationUrl(redirectUri, state);
+ *
+ * // After callback, exchange code for tokens
+ * const tokens = await facebook.exchangeCodeForToken(code, redirectUri);
+ * ```
+ *
+ * @example Publishing
+ * ```typescript
+ * import { getPublisher } from '@kairn/social/posting';
+ *
+ * const publisher = getPublisher('FACEBOOK');
+ * const result = await publisher.publish({
+ *   content: 'Hello, world!',
+ *   mediaUrls: [],
+ *   hashtags: ['hello'],
+ *   linkUrl: 'https://example.com',
+ *   accessToken: 'your-access-token',
+ *   accountMetadata: { pageId: 'your-page-id' },
+ * });
+ * ```
  */
 
+// Version
 export const VERSION = '0.0.1';
 
-// Placeholder exports - actual features to be implemented
-export interface SocialConfig {
-  enabled: boolean;
-  platforms: string[];
-}
+// Core types
+export * from './types';
 
-export const defaultSocialConfig: SocialConfig = {
-  enabled: false,
-  platforms: [],
-};
+// Re-export modules for convenient access
+export * as oauth from './oauth';
+export * as posting from './posting';
+export * as utils from './utils';
+
+// Convenience re-exports from oauth
+export {
+  encryptToken,
+  decryptToken,
+  isEncryptedToken,
+  generateEncryptionKey,
+  generateStateToken,
+  TokenManager,
+  type TokenStorage,
+  type TokenManagerConfig,
+} from './oauth';
+
+// Convenience re-exports from posting
+export {
+  getPublisher,
+  PostScheduler,
+  MultiPublisher,
+  type PostStorage,
+  type SchedulerConfig,
+  type MultiPublisherConfig,
+} from './posting';

--- a/packages/social/src/oauth/facebook.ts
+++ b/packages/social/src/oauth/facebook.ts
@@ -1,0 +1,427 @@
+/**
+ * @kairn/social - Facebook OAuth Provider
+ *
+ * Handles OAuth 2.0 authentication with Facebook for Page publishing
+ * and Instagram Business account access.
+ *
+ * @see https://developers.facebook.com/docs/facebook-login/guides/access-tokens
+ */
+
+import type { SocialAccountMetadata } from '../types';
+
+import type { OAuthProvider, OAuthTokens, ConfigCheckResult, FacebookPageInfo } from './types';
+
+// ===========================================
+// Configuration
+// ===========================================
+
+export interface FacebookOAuthConfig {
+  appId?: string;
+  appSecret?: string;
+  graphApiVersion?: string;
+}
+
+const DEFAULT_GRAPH_API_VERSION = 'v18.0';
+
+function getConfig(config?: FacebookOAuthConfig) {
+  return {
+    appId: config?.appId || process.env.FACEBOOK_APP_ID,
+    appSecret: config?.appSecret || process.env.FACEBOOK_APP_SECRET,
+    graphApiVersion: config?.graphApiVersion || DEFAULT_GRAPH_API_VERSION,
+  };
+}
+
+function getGraphApiBase(version: string) {
+  return `https://graph.facebook.com/${version}`;
+}
+
+/**
+ * Scopes for Facebook and Instagram Business
+ */
+export const FACEBOOK_SCOPES = [
+  'pages_manage_posts',
+  'pages_read_engagement',
+  'pages_show_list',
+  'instagram_basic',
+  'instagram_content_publish',
+  'instagram_manage_insights',
+  'business_management',
+];
+
+// ===========================================
+// Types
+// ===========================================
+
+interface FacebookTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+}
+
+interface FacebookPage {
+  id: string;
+  name: string;
+  access_token: string;
+  category?: string;
+  instagram_business_account?: {
+    id: string;
+    username?: string;
+  };
+}
+
+interface FacebookPagesResponse {
+  data: FacebookPage[];
+  paging?: {
+    cursors: {
+      before: string;
+      after: string;
+    };
+    next?: string;
+  };
+}
+
+interface FacebookUser {
+  id: string;
+  name: string;
+  email?: string;
+}
+
+interface InstagramAccount {
+  id: string;
+  username: string;
+  profile_picture_url?: string;
+  followers_count?: number;
+}
+
+// ===========================================
+// Facebook OAuth Provider
+// ===========================================
+
+/**
+ * Check if Facebook OAuth is configured
+ */
+export function checkFacebookConfig(config?: FacebookOAuthConfig): ConfigCheckResult {
+  const { appId, appSecret } = getConfig(config);
+
+  if (!appId) {
+    return { valid: false, error: 'FACEBOOK_APP_ID not configured' };
+  }
+  if (!appSecret) {
+    return { valid: false, error: 'FACEBOOK_APP_SECRET not configured' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Generate Facebook OAuth authorization URL
+ */
+export function getAuthorizationUrl(
+  redirectUri: string,
+  state: string,
+  config?: FacebookOAuthConfig
+): string {
+  const { appId, graphApiVersion } = getConfig(config);
+  const configCheck = checkFacebookConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    client_id: appId!,
+    redirect_uri: redirectUri,
+    state,
+    scope: FACEBOOK_SCOPES.join(','),
+    response_type: 'code',
+    auth_type: 'rerequest',
+  });
+
+  return `https://www.facebook.com/${graphApiVersion}/dialog/oauth?${params.toString()}`;
+}
+
+/**
+ * Exchange authorization code for access token
+ */
+export async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+  config?: FacebookOAuthConfig
+): Promise<OAuthTokens> {
+  const { appId, appSecret, graphApiVersion } = getConfig(config);
+  const configCheck = checkFacebookConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    client_id: appId!,
+    client_secret: appSecret!,
+    redirect_uri: redirectUri,
+    code,
+  });
+
+  const response = await fetch(
+    `${getGraphApiBase(graphApiVersion)}/oauth/access_token?${params.toString()}`
+  );
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error?: { message?: string } };
+    throw new Error(`Facebook OAuth error: ${error.error?.message || 'Token exchange failed'}`);
+  }
+
+  const data = (await response.json()) as FacebookTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresIn: data.expires_in,
+    tokenType: data.token_type,
+  };
+}
+
+/**
+ * Exchange short-lived token for long-lived token (60 days)
+ */
+export async function exchangeForLongLivedToken(
+  shortLivedToken: string,
+  config?: FacebookOAuthConfig
+): Promise<OAuthTokens> {
+  const { appId, appSecret, graphApiVersion } = getConfig(config);
+  const configCheck = checkFacebookConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    grant_type: 'fb_exchange_token',
+    client_id: appId!,
+    client_secret: appSecret!,
+    fb_exchange_token: shortLivedToken,
+  });
+
+  const response = await fetch(
+    `${getGraphApiBase(graphApiVersion)}/oauth/access_token?${params.toString()}`
+  );
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error?: { message?: string } };
+    throw new Error(
+      `Long-lived token exchange error: ${error.error?.message || 'Exchange failed'}`
+    );
+  }
+
+  const data = (await response.json()) as FacebookTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresIn: data.expires_in || 5184000, // 60 days default
+  };
+}
+
+/**
+ * Get Facebook user information
+ */
+export async function getFacebookUser(
+  accessToken: string,
+  config?: FacebookOAuthConfig
+): Promise<FacebookUser> {
+  const { graphApiVersion } = getConfig(config);
+
+  const response = await fetch(
+    `${getGraphApiBase(graphApiVersion)}/me?fields=id,name,email&access_token=${accessToken}`
+  );
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error?: { message?: string } };
+    throw new Error(`User fetch error: ${error.error?.message || 'Request failed'}`);
+  }
+
+  return (await response.json()) as FacebookUser;
+}
+
+/**
+ * Get user's Facebook Pages
+ */
+export async function getFacebookPages(
+  accessToken: string,
+  config?: FacebookOAuthConfig
+): Promise<FacebookPageInfo[]> {
+  const { graphApiVersion } = getConfig(config);
+
+  const response = await fetch(
+    `${getGraphApiBase(graphApiVersion)}/me/accounts?fields=id,name,access_token,category,instagram_business_account{id,username}&access_token=${accessToken}`
+  );
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error?: { message?: string } };
+    throw new Error(`Pages fetch error: ${error.error?.message || 'Request failed'}`);
+  }
+
+  const data = (await response.json()) as FacebookPagesResponse;
+
+  return data.data.map(page => ({
+    pageId: page.id,
+    pageName: page.name,
+    pageAccessToken: page.access_token,
+    category: page.category,
+    instagramAccount: page.instagram_business_account
+      ? {
+          id: page.instagram_business_account.id,
+          username: page.instagram_business_account.username || '',
+        }
+      : undefined,
+  }));
+}
+
+/**
+ * Get Instagram Business account details
+ */
+export async function getInstagramAccount(
+  accessToken: string,
+  instagramAccountId: string,
+  config?: FacebookOAuthConfig
+): Promise<InstagramAccount> {
+  const { graphApiVersion } = getConfig(config);
+
+  const response = await fetch(
+    `${getGraphApiBase(graphApiVersion)}/${instagramAccountId}?fields=id,username,profile_picture_url,followers_count&access_token=${accessToken}`
+  );
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error?: { message?: string } };
+    throw new Error(`Instagram account fetch error: ${error.error?.message || 'Request failed'}`);
+  }
+
+  return (await response.json()) as InstagramAccount;
+}
+
+/**
+ * Debug/validate a token
+ */
+export async function debugToken(
+  accessToken: string,
+  config?: FacebookOAuthConfig
+): Promise<{
+  isValid: boolean;
+  expiresAt?: Date;
+  scopes?: string[];
+  userId?: string;
+  appId?: string;
+}> {
+  const { appId, appSecret, graphApiVersion } = getConfig(config);
+  const configCheck = checkFacebookConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const response = await fetch(
+    `${getGraphApiBase(graphApiVersion)}/debug_token?input_token=${accessToken}&access_token=${appId}|${appSecret}`
+  );
+
+  if (!response.ok) {
+    return { isValid: false };
+  }
+
+  const data = (await response.json()) as {
+    data: {
+      is_valid: boolean;
+      expires_at?: number;
+      scopes?: string[];
+      user_id?: string;
+      app_id?: string;
+    };
+  };
+  const tokenData = data.data;
+
+  return {
+    isValid: tokenData.is_valid,
+    expiresAt: tokenData.expires_at ? new Date(tokenData.expires_at * 1000) : undefined,
+    scopes: tokenData.scopes,
+    userId: tokenData.user_id,
+    appId: tokenData.app_id,
+  };
+}
+
+/**
+ * Refresh Page Access Token
+ * Note: Page tokens from long-lived user tokens don't expire
+ */
+export async function refreshPageToken(
+  userAccessToken: string,
+  pageId: string,
+  config?: FacebookOAuthConfig
+): Promise<string> {
+  const pages = await getFacebookPages(userAccessToken, config);
+  const page = pages.find(p => p.pageId === pageId);
+
+  if (!page) {
+    throw new Error(`Page ${pageId} not found or access revoked`);
+  }
+
+  return page.pageAccessToken;
+}
+
+/**
+ * Build account metadata from Facebook/Instagram info
+ */
+export function buildAccountMetadata(
+  page: FacebookPageInfo,
+  instagramInfo?: InstagramAccount
+): SocialAccountMetadata {
+  const metadata: SocialAccountMetadata = {
+    pageId: page.pageId,
+    pageName: page.pageName,
+  };
+
+  if (page.instagramAccount && instagramInfo) {
+    metadata.igUserId = instagramInfo.id;
+    metadata.igUsername = instagramInfo.username;
+    metadata.linkedFacebookPageId = page.pageId;
+    metadata.avatarUrl = instagramInfo.profile_picture_url;
+  }
+
+  return metadata;
+}
+
+/**
+ * Calculate token expiry date
+ */
+export function calculateTokenExpiry(expiresIn: number): Date {
+  return new Date(Date.now() + expiresIn * 1000);
+}
+
+// ===========================================
+// Provider class for standardized interface
+// ===========================================
+
+export class FacebookOAuthProvider implements OAuthProvider {
+  readonly name = 'Facebook';
+  private config?: FacebookOAuthConfig;
+
+  constructor(config?: FacebookOAuthConfig) {
+    this.config = config;
+  }
+
+  checkConfig(): ConfigCheckResult {
+    return checkFacebookConfig(this.config);
+  }
+
+  getAuthorizationUrl(redirectUri: string, state: string): string {
+    return getAuthorizationUrl(redirectUri, state, this.config);
+  }
+
+  async exchangeCodeForToken(code: string, redirectUri: string): Promise<OAuthTokens> {
+    return exchangeCodeForToken(code, redirectUri, this.config);
+  }
+
+  calculateTokenExpiry(expiresIn: number): Date {
+    return calculateTokenExpiry(expiresIn);
+  }
+
+  async validateToken(accessToken: string): Promise<boolean> {
+    const result = await debugToken(accessToken, this.config);
+    return result.isValid;
+  }
+}

--- a/packages/social/src/oauth/index.ts
+++ b/packages/social/src/oauth/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @kairn/social/oauth - OAuth Module
+ *
+ * OAuth 2.0 implementations for social media platforms.
+ */
+
+// Types
+export * from './types';
+
+// Facebook
+export * as facebook from './facebook';
+export { FacebookOAuthProvider, FACEBOOK_SCOPES } from './facebook';
+
+// Instagram (uses Facebook OAuth)
+export * as instagram from './instagram';
+export { InstagramOAuthProvider, INSTAGRAM_SCOPES } from './instagram';
+
+// LinkedIn
+export * as linkedin from './linkedin';
+export { LinkedInOAuthProvider, LINKEDIN_SCOPES } from './linkedin';
+
+// Twitter (with PKCE)
+export * as twitter from './twitter';
+export {
+  TwitterOAuthProvider,
+  TWITTER_SCOPES,
+  TWITTER_MINIMAL_SCOPES,
+  generateCodeVerifier,
+  generateCodeChallenge,
+} from './twitter';
+
+// Threads
+export * as threads from './threads';
+export { ThreadsOAuthProvider, THREADS_SCOPES, THREADS_MINIMAL_SCOPES } from './threads';
+
+// Token Manager
+export {
+  TokenManager,
+  shouldRefreshToken,
+  refreshPlatformToken,
+  type TokenManagerConfig,
+  type TokenStorage,
+} from './token-manager';
+
+// Crypto utilities (re-exported for convenience)
+export {
+  encryptToken,
+  decryptToken,
+  isEncryptedToken,
+  generateEncryptionKey,
+  testEncryption,
+  generateStateToken,
+} from '../utils/crypto';

--- a/packages/social/src/oauth/instagram.ts
+++ b/packages/social/src/oauth/instagram.ts
@@ -1,0 +1,355 @@
+/**
+ * @kairn/social - Instagram OAuth Provider
+ *
+ * Instagram Business/Creator accounts are managed through Facebook Graph API.
+ * Authentication goes through Facebook OAuth, then accesses the Instagram Business
+ * account linked to a Facebook Page.
+ *
+ * Prerequisites:
+ * - Instagram account must be Business or Creator type
+ * - Instagram account must be linked to a Facebook Page
+ * - User must have admin permissions on the Page
+ *
+ * @see https://developers.facebook.com/docs/instagram-api/getting-started
+ */
+
+import type { SocialAccountMetadata } from '../types';
+
+import {
+  checkFacebookConfig,
+  getAuthorizationUrl as getFacebookAuthUrl,
+  exchangeCodeForToken as exchangeFacebookCode,
+  exchangeForLongLivedToken,
+  getFacebookPages,
+  getInstagramAccount as getFacebookInstagramAccount,
+  type FacebookOAuthConfig,
+} from './facebook';
+import type {
+  OAuthProvider,
+  OAuthTokens,
+  ConfigCheckResult,
+  InstagramBusinessAccount,
+  FacebookPageInfo,
+} from './types';
+
+// ===========================================
+// Configuration
+// ===========================================
+
+const DEFAULT_GRAPH_API_VERSION = 'v18.0';
+
+function getGraphApiBase(version = DEFAULT_GRAPH_API_VERSION) {
+  return `https://graph.facebook.com/${version}`;
+}
+
+/**
+ * Instagram-specific scopes (subset of Facebook scopes)
+ */
+export const INSTAGRAM_SCOPES = [
+  'instagram_basic',
+  'instagram_content_publish',
+  'instagram_manage_insights',
+  'pages_show_list',
+  'pages_read_engagement',
+  'business_management',
+];
+
+// ===========================================
+// Instagram OAuth Functions
+// ===========================================
+
+/**
+ * Check if Instagram OAuth is configured (uses Facebook config)
+ */
+export const checkInstagramConfig = checkFacebookConfig;
+
+/**
+ * Generate authorization URL (uses Facebook OAuth flow)
+ */
+export function getAuthorizationUrl(
+  redirectUri: string,
+  state: string,
+  config?: FacebookOAuthConfig
+): string {
+  return getFacebookAuthUrl(redirectUri, state, config);
+}
+
+/**
+ * Exchange authorization code for token (same as Facebook)
+ */
+export async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+  config?: FacebookOAuthConfig
+): Promise<OAuthTokens> {
+  return exchangeFacebookCode(code, redirectUri, config);
+}
+
+/**
+ * Get all Instagram Business accounts linked to Facebook Pages
+ */
+export async function getInstagramAccounts(
+  accessToken: string,
+  config?: FacebookOAuthConfig
+): Promise<InstagramBusinessAccount[]> {
+  const pages = await getFacebookPages(accessToken, config);
+  const instagramAccounts: InstagramBusinessAccount[] = [];
+
+  for (const page of pages) {
+    if (page.instagramAccount) {
+      try {
+        const igDetails = await getFacebookInstagramAccount(
+          page.pageAccessToken,
+          page.instagramAccount.id,
+          config
+        );
+
+        instagramAccounts.push({
+          id: igDetails.id,
+          username: igDetails.username,
+          profilePictureUrl: igDetails.profile_picture_url,
+          followersCount: igDetails.followers_count,
+          linkedPageId: page.pageId,
+          linkedPageName: page.pageName,
+        });
+      } catch (error) {
+        // Skip if we can't access the Instagram account
+        console.warn(
+          `[Instagram] Cannot access Instagram account for page ${page.pageName}:`,
+          error
+        );
+      }
+    }
+  }
+
+  return instagramAccounts;
+}
+
+/**
+ * Get Instagram Business account details
+ */
+export async function getInstagramAccountDetails(
+  accessToken: string,
+  instagramAccountId: string,
+  config?: FacebookOAuthConfig
+): Promise<InstagramBusinessAccount | null> {
+  const graphApiBase = getGraphApiBase(config?.graphApiVersion);
+
+  try {
+    const response = await fetch(
+      `${graphApiBase}/${instagramAccountId}?fields=id,username,name,profile_picture_url,followers_count,media_count,biography,website&access_token=${accessToken}`
+    );
+
+    if (!response.ok) {
+      const error = (await response.json()) as { error?: { message?: string } };
+      throw new Error(error.error?.message || 'Request failed');
+    }
+
+    const data = (await response.json()) as {
+      id: string;
+      username: string;
+      name?: string;
+      profile_picture_url?: string;
+      followers_count?: number;
+      media_count?: number;
+      biography?: string;
+      website?: string;
+    };
+
+    // Get linked page info
+    const pagesResponse = await fetch(
+      `${graphApiBase}/${instagramAccountId}?fields=instagram_business_account{id},id,name&access_token=${accessToken}`
+    );
+
+    let linkedPageId = '';
+    let linkedPageName = '';
+
+    if (pagesResponse.ok) {
+      const pageData = (await pagesResponse.json()) as { id?: string; name?: string };
+      linkedPageId = pageData.id || '';
+      linkedPageName = pageData.name || '';
+    }
+
+    return {
+      id: data.id,
+      username: data.username,
+      name: data.name,
+      profilePictureUrl: data.profile_picture_url,
+      followersCount: data.followers_count,
+      mediaCount: data.media_count,
+      biography: data.biography,
+      website: data.website,
+      linkedPageId,
+      linkedPageName,
+    };
+  } catch (error) {
+    console.error('[Instagram] Account details fetch error:', error);
+    return null;
+  }
+}
+
+/**
+ * Check Instagram permissions on an account
+ */
+export async function checkInstagramPermissions(
+  accessToken: string,
+  instagramAccountId: string,
+  config?: FacebookOAuthConfig
+): Promise<{
+  canPublish: boolean;
+  canReadInsights: boolean;
+  missingPermissions: string[];
+}> {
+  const graphApiBase = getGraphApiBase(config?.graphApiVersion);
+  const missingPermissions: string[] = [];
+  let canPublish = false;
+  let canReadInsights = false;
+
+  try {
+    // Test publish access
+    const publishTestResponse = await fetch(
+      `${graphApiBase}/${instagramAccountId}/media?access_token=${accessToken}`,
+      { method: 'GET' }
+    );
+
+    if (publishTestResponse.ok) {
+      canPublish = true;
+    } else {
+      missingPermissions.push('instagram_content_publish');
+    }
+
+    // Test insights access
+    const insightsResponse = await fetch(
+      `${graphApiBase}/${instagramAccountId}/insights?metric=impressions,reach&period=day&access_token=${accessToken}`
+    );
+
+    if (insightsResponse.ok) {
+      canReadInsights = true;
+    } else {
+      missingPermissions.push('instagram_manage_insights');
+    }
+  } catch {
+    missingPermissions.push('instagram_content_publish', 'instagram_manage_insights');
+  }
+
+  return {
+    canPublish,
+    canReadInsights,
+    missingPermissions,
+  };
+}
+
+/**
+ * Get Page Access Token for Instagram publishing
+ */
+export async function getPageTokenForInstagram(
+  userAccessToken: string,
+  linkedPageId: string,
+  config?: FacebookOAuthConfig
+): Promise<string | null> {
+  const pages = await getFacebookPages(userAccessToken, config);
+  const page = pages.find(p => p.pageId === linkedPageId);
+  return page?.pageAccessToken || null;
+}
+
+/**
+ * Build account metadata for Instagram
+ */
+export function buildAccountMetadata(
+  account: InstagramBusinessAccount,
+  _page: FacebookPageInfo
+): SocialAccountMetadata {
+  return {
+    igUserId: account.id,
+    igUsername: account.username,
+    linkedFacebookPageId: account.linkedPageId,
+    pageName: account.linkedPageName,
+    avatarUrl: account.profilePictureUrl,
+  };
+}
+
+/**
+ * Validate Instagram token
+ */
+export async function validateInstagramToken(
+  accessToken: string,
+  instagramAccountId: string,
+  config?: FacebookOAuthConfig
+): Promise<boolean> {
+  const graphApiBase = getGraphApiBase(config?.graphApiVersion);
+
+  try {
+    const response = await fetch(
+      `${graphApiBase}/${instagramAccountId}?fields=id&access_token=${accessToken}`
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensure valid token for Instagram publishing
+ */
+export async function ensureValidToken(
+  userAccessToken: string,
+  pageId: string,
+  config?: FacebookOAuthConfig
+): Promise<string> {
+  const pageToken = await getPageTokenForInstagram(userAccessToken, pageId, config);
+
+  if (!pageToken) {
+    throw new Error('Cannot retrieve page token for Instagram');
+  }
+
+  return pageToken;
+}
+
+/**
+ * Calculate token expiry
+ * Note: Page Access Tokens don't expire if User Token is long-lived
+ */
+export function calculateTokenExpiry(expiresIn?: number): Date | null {
+  if (!expiresIn) {
+    return null; // Page tokens don't expire
+  }
+  return new Date(Date.now() + expiresIn * 1000);
+}
+
+// ===========================================
+// Provider class for standardized interface
+// ===========================================
+
+export class InstagramOAuthProvider implements OAuthProvider {
+  readonly name = 'Instagram';
+  private config?: FacebookOAuthConfig;
+
+  constructor(config?: FacebookOAuthConfig) {
+    this.config = config;
+  }
+
+  checkConfig(): ConfigCheckResult {
+    return checkInstagramConfig(this.config);
+  }
+
+  getAuthorizationUrl(redirectUri: string, state: string): string {
+    return getAuthorizationUrl(redirectUri, state, this.config);
+  }
+
+  async exchangeCodeForToken(code: string, redirectUri: string): Promise<OAuthTokens> {
+    return exchangeCodeForToken(code, redirectUri, this.config);
+  }
+
+  calculateTokenExpiry(expiresIn: number): Date {
+    return calculateTokenExpiry(expiresIn) || new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+  }
+
+  validateToken(accessToken: string): Promise<boolean> {
+    // For Instagram, we need the account ID to validate
+    // This basic check just verifies the token format
+    return Promise.resolve(accessToken.length > 0);
+  }
+}
+
+// Re-export long-lived token exchange for convenience
+export { exchangeForLongLivedToken };

--- a/packages/social/src/oauth/linkedin.ts
+++ b/packages/social/src/oauth/linkedin.ts
@@ -1,0 +1,381 @@
+/**
+ * @kairn/social - LinkedIn OAuth Provider
+ *
+ * Handles OAuth 2.0 authentication with LinkedIn for publishing to:
+ * - User personal profiles
+ * - Organization/Company pages
+ *
+ * Required scopes:
+ * - openid: OpenID Connect
+ * - profile: Basic profile info
+ * - w_member_social: Post on behalf of member
+ * - r_organization_social: Read org info (requires Marketing Developer Platform)
+ * - w_organization_social: Post on behalf of org (requires Marketing Developer Platform)
+ *
+ * @see https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow
+ */
+
+import type { SocialAccountMetadata } from '../types';
+
+import type { OAuthProvider, OAuthTokens, ConfigCheckResult, LinkedInAccountInfo } from './types';
+
+// ===========================================
+// Configuration
+// ===========================================
+
+export interface LinkedInOAuthConfig {
+  clientId?: string;
+  clientSecret?: string;
+}
+
+const LINKEDIN_AUTH_BASE = 'https://www.linkedin.com/oauth/v2';
+
+function getConfig(config?: LinkedInOAuthConfig) {
+  return {
+    clientId: config?.clientId || process.env.LINKEDIN_CLIENT_ID,
+    clientSecret: config?.clientSecret || process.env.LINKEDIN_CLIENT_SECRET,
+  };
+}
+
+/**
+ * LinkedIn OAuth scopes
+ *
+ * Required LinkedIn Products:
+ * - "Share on LinkedIn": w_member_social
+ * - "Sign In with LinkedIn using OpenID Connect": openid, profile, email
+ */
+export const LINKEDIN_SCOPES = [
+  'openid',
+  'profile',
+  'w_member_social',
+  // Organization scopes (require Marketing Developer Platform)
+  // 'r_organization_social',
+  // 'w_organization_social',
+];
+
+// ===========================================
+// Types
+// ===========================================
+
+interface LinkedInTokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+  refresh_token_expires_in?: number;
+  scope: string;
+  token_type: string;
+}
+
+interface LinkedInUserInfo {
+  sub: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  picture?: string;
+  email?: string;
+  email_verified?: boolean;
+}
+
+// ===========================================
+// LinkedIn OAuth Functions
+// ===========================================
+
+/**
+ * Check if LinkedIn OAuth is configured
+ */
+export function checkLinkedInConfig(config?: LinkedInOAuthConfig): ConfigCheckResult {
+  const { clientId, clientSecret } = getConfig(config);
+
+  if (!clientId) {
+    return { valid: false, error: 'LINKEDIN_CLIENT_ID not configured' };
+  }
+  if (!clientSecret) {
+    return { valid: false, error: 'LINKEDIN_CLIENT_SECRET not configured' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Generate LinkedIn OAuth authorization URL
+ */
+export function getAuthorizationUrl(
+  redirectUri: string,
+  state: string,
+  config?: LinkedInOAuthConfig
+): string {
+  const { clientId } = getConfig(config);
+  const configCheck = checkLinkedInConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId!,
+    redirect_uri: redirectUri,
+    state,
+    scope: LINKEDIN_SCOPES.join(' '),
+  });
+
+  return `${LINKEDIN_AUTH_BASE}/authorization?${params.toString()}`;
+}
+
+/**
+ * Exchange authorization code for access token
+ */
+export async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+  config?: LinkedInOAuthConfig
+): Promise<OAuthTokens> {
+  const { clientId, clientSecret } = getConfig(config);
+  const configCheck = checkLinkedInConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+    client_id: clientId!,
+    client_secret: clientSecret!,
+  });
+
+  const response = await fetch(`${LINKEDIN_AUTH_BASE}/accessToken`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error_description?: string; error?: string };
+    throw new Error(
+      `LinkedIn OAuth error: ${error.error_description || error.error || 'Token exchange failed'}`
+    );
+  }
+
+  const data = (await response.json()) as LinkedInTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresIn: data.expires_in,
+    refreshToken: data.refresh_token,
+    scope: data.scope,
+  };
+}
+
+/**
+ * Refresh an access token
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  config?: LinkedInOAuthConfig
+): Promise<OAuthTokens> {
+  const { clientId, clientSecret } = getConfig(config);
+  const configCheck = checkLinkedInConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: clientId!,
+    client_secret: clientSecret!,
+  });
+
+  const response = await fetch(`${LINKEDIN_AUTH_BASE}/accessToken`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error_description?: string; error?: string };
+    throw new Error(
+      `LinkedIn refresh token error: ${error.error_description || error.error || 'Refresh failed'}`
+    );
+  }
+
+  const data = (await response.json()) as LinkedInTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresIn: data.expires_in,
+    refreshToken: data.refresh_token,
+  };
+}
+
+/**
+ * Get user info via OpenID Connect
+ * @see https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2
+ */
+export async function getUserInfo(accessToken: string): Promise<LinkedInUserInfo> {
+  const response = await fetch('https://api.linkedin.com/v2/userinfo', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'LinkedIn-Version': '202401',
+      'X-Restli-Protocol-Version': '2.0.0',
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMessage = 'Request failed';
+    try {
+      const errorJson = JSON.parse(errorText) as { message?: string; error_description?: string };
+      errorMessage = errorJson.message || errorJson.error_description || errorText;
+    } catch {
+      errorMessage = errorText || `HTTP ${response.status}`;
+    }
+    throw new Error(`LinkedIn profile fetch error: ${errorMessage}`);
+  }
+
+  return (await response.json()) as LinkedInUserInfo;
+}
+
+/**
+ * Get complete LinkedIn account info
+ */
+export async function getLinkedInAccountInfo(accessToken: string): Promise<LinkedInAccountInfo> {
+  const userInfo = await getUserInfo(accessToken);
+
+  return {
+    personId: userInfo.sub,
+    firstName: userInfo.given_name,
+    lastName: userInfo.family_name,
+    fullName: userInfo.name,
+    email: userInfo.email,
+    profilePictureUrl: userInfo.picture,
+  };
+}
+
+/**
+ * Introspect a token (if app supports it)
+ */
+export async function introspectToken(
+  accessToken: string,
+  config?: LinkedInOAuthConfig
+): Promise<{
+  active: boolean;
+  expiresAt?: Date;
+  scope?: string;
+  clientId?: string;
+}> {
+  const { clientId, clientSecret } = getConfig(config);
+  const configCheck = checkLinkedInConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  try {
+    const params = new URLSearchParams({
+      token: accessToken,
+      client_id: clientId!,
+      client_secret: clientSecret!,
+    });
+
+    const response = await fetch(`${LINKEDIN_AUTH_BASE}/introspectToken`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params.toString(),
+    });
+
+    if (!response.ok) {
+      return { active: false };
+    }
+
+    const data = (await response.json()) as {
+      active: boolean;
+      exp?: number;
+      scope?: string;
+      client_id?: string;
+    };
+
+    return {
+      active: data.active,
+      expiresAt: data.exp ? new Date(data.exp * 1000) : undefined,
+      scope: data.scope,
+      clientId: data.client_id,
+    };
+  } catch {
+    return { active: true }; // Assume active on error
+  }
+}
+
+/**
+ * Build account metadata from LinkedIn info
+ */
+export function buildAccountMetadata(info: LinkedInAccountInfo): SocialAccountMetadata {
+  return {
+    personId: info.personId,
+    profileUrl: `https://www.linkedin.com/in/${info.personId}`,
+    avatarUrl: info.profilePictureUrl,
+  };
+}
+
+/**
+ * Calculate token expiry date
+ */
+export function calculateTokenExpiry(expiresIn: number): Date {
+  return new Date(Date.now() + expiresIn * 1000);
+}
+
+/**
+ * Check if token should be refreshed (expires in less than 7 days)
+ */
+export function shouldRefreshToken(tokenExpiry: Date | null): boolean {
+  if (!tokenExpiry) return true;
+
+  const sevenDaysFromNow = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  return tokenExpiry < sevenDaysFromNow;
+}
+
+// ===========================================
+// Provider class for standardized interface
+// ===========================================
+
+export class LinkedInOAuthProvider implements OAuthProvider {
+  readonly name = 'LinkedIn';
+  private config?: LinkedInOAuthConfig;
+
+  constructor(config?: LinkedInOAuthConfig) {
+    this.config = config;
+  }
+
+  checkConfig(): ConfigCheckResult {
+    return checkLinkedInConfig(this.config);
+  }
+
+  getAuthorizationUrl(redirectUri: string, state: string): string {
+    return getAuthorizationUrl(redirectUri, state, this.config);
+  }
+
+  async exchangeCodeForToken(code: string, redirectUri: string): Promise<OAuthTokens> {
+    return exchangeCodeForToken(code, redirectUri, this.config);
+  }
+
+  async refreshToken(refreshToken: string): Promise<OAuthTokens> {
+    return refreshAccessToken(refreshToken, this.config);
+  }
+
+  calculateTokenExpiry(expiresIn: number): Date {
+    return calculateTokenExpiry(expiresIn);
+  }
+
+  async validateToken(accessToken: string): Promise<boolean> {
+    const result = await introspectToken(accessToken, this.config);
+    return result.active;
+  }
+}

--- a/packages/social/src/oauth/threads.ts
+++ b/packages/social/src/oauth/threads.ts
@@ -1,0 +1,375 @@
+/**
+ * @kairn/social - Threads OAuth Provider
+ *
+ * Handles OAuth 2.0 authentication with Threads for publishing content.
+ *
+ * Required scopes:
+ * - threads_basic: Basic profile access
+ * - threads_content_publish: Publish on Threads
+ * - threads_manage_insights: Read statistics (optional)
+ * - threads_manage_replies: Manage replies (optional)
+ *
+ * @see https://developers.facebook.com/docs/threads/overview
+ */
+
+import type { SocialAccountMetadata } from '../types';
+
+import type { OAuthProvider, OAuthTokens, ConfigCheckResult, ThreadsAccountInfo } from './types';
+
+// ===========================================
+// Configuration
+// ===========================================
+
+export interface ThreadsOAuthConfig {
+  appId?: string;
+  appSecret?: string;
+  apiVersion?: string;
+}
+
+const THREADS_API_VERSION = 'v1.0';
+const THREADS_API_BASE = 'https://graph.threads.net';
+const THREADS_AUTH_BASE = 'https://threads.net';
+
+function getConfig(config?: ThreadsOAuthConfig) {
+  return {
+    appId: config?.appId || process.env.THREADS_APP_ID || process.env.FACEBOOK_APP_ID,
+    appSecret:
+      config?.appSecret || process.env.THREADS_APP_SECRET || process.env.FACEBOOK_APP_SECRET,
+    apiVersion: config?.apiVersion || THREADS_API_VERSION,
+  };
+}
+
+/**
+ * Threads OAuth scopes
+ */
+export const THREADS_SCOPES = [
+  'threads_basic',
+  'threads_content_publish',
+  'threads_manage_insights',
+  'threads_manage_replies',
+];
+
+/**
+ * Minimal scopes (publish only)
+ */
+export const THREADS_MINIMAL_SCOPES = ['threads_basic', 'threads_content_publish'];
+
+// ===========================================
+// Types
+// ===========================================
+
+interface ThreadsTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+}
+
+interface ThreadsLongLivedTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+interface ThreadsUser {
+  id: string;
+  username: string;
+  name?: string;
+  threads_profile_picture_url?: string;
+  threads_biography?: string;
+}
+
+// ===========================================
+// Threads OAuth Functions
+// ===========================================
+
+/**
+ * Check if Threads OAuth is configured
+ */
+export function checkThreadsConfig(config?: ThreadsOAuthConfig): ConfigCheckResult {
+  const { appId, appSecret } = getConfig(config);
+
+  if (!appId) {
+    return { valid: false, error: 'THREADS_APP_ID (or FACEBOOK_APP_ID) not configured' };
+  }
+  if (!appSecret) {
+    return { valid: false, error: 'THREADS_APP_SECRET (or FACEBOOK_APP_SECRET) not configured' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Generate Threads OAuth authorization URL
+ */
+export function getAuthorizationUrl(
+  redirectUri: string,
+  state: string,
+  config?: ThreadsOAuthConfig
+): string {
+  const { appId } = getConfig(config);
+  const configCheck = checkThreadsConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    client_id: appId!,
+    redirect_uri: redirectUri,
+    state,
+    scope: THREADS_SCOPES.join(','),
+    response_type: 'code',
+  });
+
+  return `${THREADS_AUTH_BASE}/oauth/authorize?${params.toString()}`;
+}
+
+/**
+ * Exchange authorization code for short-lived access token
+ */
+export async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+  config?: ThreadsOAuthConfig
+): Promise<OAuthTokens> {
+  const { appId, appSecret } = getConfig(config);
+  const configCheck = checkThreadsConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    client_id: appId!,
+    client_secret: appSecret!,
+    redirect_uri: redirectUri,
+    code,
+    grant_type: 'authorization_code',
+  });
+
+  const response = await fetch(`${THREADS_API_BASE}/oauth/access_token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as {
+      error_message?: string;
+      error?: { message?: string };
+    };
+    throw new Error(
+      `Threads OAuth error: ${error.error_message || error.error?.message || 'Token exchange failed'}`
+    );
+  }
+
+  const data = (await response.json()) as ThreadsTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresIn: data.expires_in,
+  };
+}
+
+/**
+ * Exchange short-lived token for long-lived token (60 days)
+ */
+export async function exchangeForLongLivedToken(
+  shortLivedToken: string,
+  config?: ThreadsOAuthConfig
+): Promise<OAuthTokens> {
+  const { appSecret } = getConfig(config);
+  const configCheck = checkThreadsConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    grant_type: 'th_exchange_token',
+    client_secret: appSecret!,
+    access_token: shortLivedToken,
+  });
+
+  const response = await fetch(`${THREADS_API_BASE}/access_token?${params.toString()}`);
+
+  if (!response.ok) {
+    const error = (await response.json()) as {
+      error_message?: string;
+      error?: { message?: string };
+    };
+    throw new Error(
+      `Threads long-lived token exchange error: ${error.error_message || error.error?.message || 'Exchange failed'}`
+    );
+  }
+
+  const data = (await response.json()) as ThreadsLongLivedTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresIn: data.expires_in || 5184000, // 60 days default
+  };
+}
+
+/**
+ * Refresh a long-lived token (before expiration)
+ */
+export async function refreshLongLivedToken(
+  longLivedToken: string,
+  config?: ThreadsOAuthConfig
+): Promise<OAuthTokens> {
+  const configCheck = checkThreadsConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    grant_type: 'th_refresh_token',
+    access_token: longLivedToken,
+  });
+
+  const response = await fetch(`${THREADS_API_BASE}/refresh_access_token?${params.toString()}`);
+
+  if (!response.ok) {
+    const error = (await response.json()) as {
+      error_message?: string;
+      error?: { message?: string };
+    };
+    throw new Error(
+      `Threads token refresh error: ${error.error_message || error.error?.message || 'Refresh failed'}`
+    );
+  }
+
+  const data = (await response.json()) as ThreadsLongLivedTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresIn: data.expires_in || 5184000,
+  };
+}
+
+/**
+ * Get Threads profile info
+ */
+export async function getThreadsUser(
+  accessToken: string,
+  config?: ThreadsOAuthConfig
+): Promise<ThreadsUser> {
+  const { apiVersion } = getConfig(config);
+  const fields = 'id,username,name,threads_profile_picture_url,threads_biography';
+
+  const response = await fetch(
+    `${THREADS_API_BASE}/${apiVersion}/me?fields=${fields}&access_token=${accessToken}`
+  );
+
+  if (!response.ok) {
+    const error = (await response.json()) as {
+      error_message?: string;
+      error?: { message?: string };
+    };
+    throw new Error(
+      `Threads profile fetch error: ${error.error_message || error.error?.message || 'Request failed'}`
+    );
+  }
+
+  return (await response.json()) as ThreadsUser;
+}
+
+/**
+ * Validate a Threads token
+ */
+export async function validateToken(
+  accessToken: string,
+  config?: ThreadsOAuthConfig
+): Promise<boolean> {
+  const { apiVersion } = getConfig(config);
+
+  try {
+    const response = await fetch(
+      `${THREADS_API_BASE}/${apiVersion}/me?fields=id&access_token=${accessToken}`
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build account metadata from Threads user
+ */
+export function buildAccountMetadata(user: ThreadsUser): SocialAccountMetadata {
+  return {
+    threadsUserId: user.id,
+    threadsUsername: user.username,
+    avatarUrl: user.threads_profile_picture_url,
+  };
+}
+
+/**
+ * Convert user data to account info
+ */
+export function toAccountInfo(user: ThreadsUser): ThreadsAccountInfo {
+  return {
+    userId: user.id,
+    username: user.username,
+    name: user.name,
+    profilePictureUrl: user.threads_profile_picture_url,
+    biography: user.threads_biography,
+  };
+}
+
+/**
+ * Calculate token expiry date
+ */
+export function calculateTokenExpiry(expiresIn: number): Date {
+  return new Date(Date.now() + expiresIn * 1000);
+}
+
+/**
+ * Check if token should be refreshed (expires in less than 7 days)
+ */
+export function shouldRefreshToken(tokenExpiry: Date | null): boolean {
+  if (!tokenExpiry) return true;
+
+  const sevenDaysFromNow = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  return tokenExpiry < sevenDaysFromNow;
+}
+
+// ===========================================
+// Provider class for standardized interface
+// ===========================================
+
+export class ThreadsOAuthProvider implements OAuthProvider {
+  readonly name = 'Threads';
+  private config?: ThreadsOAuthConfig;
+
+  constructor(config?: ThreadsOAuthConfig) {
+    this.config = config;
+  }
+
+  checkConfig(): ConfigCheckResult {
+    return checkThreadsConfig(this.config);
+  }
+
+  getAuthorizationUrl(redirectUri: string, state: string): string {
+    return getAuthorizationUrl(redirectUri, state, this.config);
+  }
+
+  async exchangeCodeForToken(code: string, redirectUri: string): Promise<OAuthTokens> {
+    return exchangeCodeForToken(code, redirectUri, this.config);
+  }
+
+  async refreshToken(token: string): Promise<OAuthTokens> {
+    return refreshLongLivedToken(token, this.config);
+  }
+
+  calculateTokenExpiry(expiresIn: number): Date {
+    return calculateTokenExpiry(expiresIn);
+  }
+
+  async validateToken(accessToken: string): Promise<boolean> {
+    return validateToken(accessToken, this.config);
+  }
+}

--- a/packages/social/src/oauth/token-manager.ts
+++ b/packages/social/src/oauth/token-manager.ts
@@ -1,0 +1,407 @@
+/**
+ * @kairn/social - Token Manager
+ *
+ * Service for managing OAuth token lifecycle:
+ * - Token encryption/decryption for secure storage
+ * - Automatic token refresh before expiration
+ * - Token validation
+ *
+ * Strategies per platform:
+ * - Facebook: Page Access Tokens don't expire when derived from long-lived tokens
+ * - Instagram: Uses Facebook Page Access Tokens (don't expire)
+ * - LinkedIn: Tokens expire after 60 days, refresh token available
+ * - Twitter: Tokens expire after 2 hours, refresh token available
+ * - Threads: Tokens expire after 60 days, can be refreshed
+ */
+
+import type { SocialPlatform, SocialAccountFull } from '../types';
+import { encryptToken, decryptToken, isEncryptedToken } from '../utils/crypto';
+
+import * as linkedin from './linkedin';
+import * as threads from './threads';
+import * as twitter from './twitter';
+import type { OAuthTokens, TokenRefreshResult, TokenRefreshBatchResult } from './types';
+
+// Refresh threshold (7 days before expiration)
+const REFRESH_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Maximum refresh attempts
+const MAX_REFRESH_ATTEMPTS = 3;
+
+// Delay between retry attempts (ms)
+const RETRY_DELAY_MS = 1000;
+
+/**
+ * Token manager configuration
+ */
+export interface TokenManagerConfig {
+  /** Encryption key (64-char hex) */
+  encryptionKey?: string;
+  /** Refresh threshold in milliseconds */
+  refreshThresholdMs?: number;
+  /** Maximum refresh attempts */
+  maxRefreshAttempts?: number;
+}
+
+/**
+ * Token storage interface
+ * Implement this to integrate with your database
+ */
+export interface TokenStorage {
+  /** Get an account by ID */
+  getAccount(accountId: string): Promise<SocialAccountFull | null>;
+
+  /** Get all active accounts */
+  getAllActiveAccounts(): Promise<SocialAccountFull[]>;
+
+  /** Get accounts needing token refresh */
+  getAccountsNeedingRefresh(thresholdDate: Date): Promise<SocialAccountFull[]>;
+
+  /** Update account tokens */
+  updateAccountTokens(
+    accountId: string,
+    data: {
+      accessToken: string;
+      refreshToken?: string | null;
+      tokenExpiry?: Date | null;
+    }
+  ): Promise<void>;
+
+  /** Mark account as inactive (needs reconnection) */
+  markAccountInactive(accountId: string): Promise<void>;
+}
+
+/**
+ * Check if a token should be refreshed
+ */
+export function shouldRefreshToken(
+  tokenExpiry: Date | null,
+  thresholdMs = REFRESH_THRESHOLD_MS
+): boolean {
+  if (!tokenExpiry) {
+    // No expiration = no refresh needed (Facebook/Instagram Page Tokens)
+    return false;
+  }
+
+  const expiryTime = tokenExpiry.getTime();
+  const refreshThreshold = Date.now() + thresholdMs;
+
+  return expiryTime < refreshThreshold;
+}
+
+/**
+ * Refresh token for a specific platform
+ */
+export async function refreshPlatformToken(
+  platform: SocialPlatform,
+  refreshToken: string
+): Promise<OAuthTokens> {
+  switch (platform) {
+    case 'LINKEDIN':
+      return linkedin.refreshAccessToken(refreshToken);
+
+    case 'TWITTER':
+      return twitter.refreshAccessToken(refreshToken);
+
+    case 'THREADS':
+      return threads.refreshLongLivedToken(refreshToken);
+
+    case 'FACEBOOK':
+    case 'INSTAGRAM':
+      // Page Access Tokens don't expire
+      throw new Error(`${platform as string} tokens don't require refresh`);
+
+    default: {
+      const unknownPlatform: string = platform;
+      throw new Error(`Platform ${unknownPlatform} not supported for token refresh`);
+    }
+  }
+}
+
+/**
+ * Token Manager class
+ */
+export class TokenManager {
+  private storage: TokenStorage;
+  private config: Required<Omit<TokenManagerConfig, 'encryptionKey'>> & {
+    encryptionKey?: string;
+  };
+
+  constructor(storage: TokenStorage, config?: TokenManagerConfig) {
+    this.storage = storage;
+    this.config = {
+      encryptionKey: config?.encryptionKey,
+      refreshThresholdMs: config?.refreshThresholdMs || REFRESH_THRESHOLD_MS,
+      maxRefreshAttempts: config?.maxRefreshAttempts || MAX_REFRESH_ATTEMPTS,
+    };
+  }
+
+  /**
+   * Encrypt a token for storage
+   */
+  encrypt(token: string): string {
+    return encryptToken(token, { encryptionKey: this.config.encryptionKey });
+  }
+
+  /**
+   * Decrypt a token from storage
+   */
+  decrypt(encryptedToken: string): string {
+    return decryptToken(encryptedToken, { encryptionKey: this.config.encryptionKey });
+  }
+
+  /**
+   * Check if a token is encrypted
+   */
+  isEncrypted(token: string): boolean {
+    return isEncryptedToken(token);
+  }
+
+  /**
+   * Get decrypted access token for an account
+   */
+  async getAccessToken(accountId: string): Promise<string | null> {
+    const account = await this.storage.getAccount(accountId);
+    if (!account?.accessToken) return null;
+
+    try {
+      return this.decrypt(account.accessToken);
+    } catch {
+      // Token might not be encrypted (legacy)
+      return account.accessToken;
+    }
+  }
+
+  /**
+   * Refresh token for a single account
+   */
+  async refreshAccountToken(account: SocialAccountFull): Promise<TokenRefreshResult> {
+    const { id, platform, refreshToken } = account;
+
+    // Facebook and Instagram Page tokens don't expire
+    if (platform === 'FACEBOOK' || platform === 'INSTAGRAM') {
+      return {
+        accountId: id,
+        platform,
+        success: true,
+        message: 'Page tokens do not expire',
+      };
+    }
+
+    if (!refreshToken) {
+      return {
+        accountId: id,
+        platform,
+        success: false,
+        message: 'No refresh token available. Reconnection required.',
+      };
+    }
+
+    try {
+      // Decrypt refresh token
+      let decryptedRefreshToken: string;
+      try {
+        decryptedRefreshToken = this.decrypt(refreshToken);
+      } catch {
+        decryptedRefreshToken = refreshToken;
+      }
+
+      // Refresh the token
+      const newTokens = await refreshPlatformToken(platform, decryptedRefreshToken);
+
+      // Calculate new expiry
+      let newExpiry: Date | undefined;
+      if (newTokens.expiresIn) {
+        if (platform === 'LINKEDIN') {
+          newExpiry = linkedin.calculateTokenExpiry(newTokens.expiresIn);
+        } else if (platform === 'TWITTER') {
+          newExpiry = twitter.calculateTokenExpiry(newTokens.expiresIn);
+        } else if (platform === 'THREADS') {
+          newExpiry = threads.calculateTokenExpiry(newTokens.expiresIn);
+        } else {
+          newExpiry = new Date(Date.now() + newTokens.expiresIn * 1000);
+        }
+      }
+
+      // Update storage
+      await this.storage.updateAccountTokens(id, {
+        accessToken: this.encrypt(newTokens.accessToken),
+        refreshToken: newTokens.refreshToken
+          ? this.encrypt(newTokens.refreshToken)
+          : account.refreshToken,
+        tokenExpiry: newExpiry,
+      });
+
+      return {
+        accountId: id,
+        platform,
+        success: true,
+        message: 'Token refreshed successfully',
+        newExpiry,
+        newAccessToken: newTokens.accessToken,
+        newRefreshToken: newTokens.refreshToken,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        accountId: id,
+        platform,
+        success: false,
+        message: `Refresh failed: ${message}`,
+      };
+    }
+  }
+
+  /**
+   * Refresh all expiring tokens
+   */
+  async refreshAllExpiringTokens(): Promise<TokenRefreshBatchResult> {
+    const thresholdDate = new Date(Date.now() + this.config.refreshThresholdMs);
+    const accounts = await this.storage.getAccountsNeedingRefresh(thresholdDate);
+
+    const results: TokenRefreshResult[] = [];
+    let refreshed = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const account of accounts) {
+      // Skip platforms that don't expire
+      if (account.platform === 'FACEBOOK' || account.platform === 'INSTAGRAM') {
+        skipped++;
+        continue;
+      }
+
+      let lastError: string | null = null;
+      let success = false;
+
+      // Retry with backoff
+      for (let attempt = 1; attempt <= this.config.maxRefreshAttempts; attempt++) {
+        try {
+          const result = await this.refreshAccountToken(account);
+          results.push(result);
+
+          if (result.success) {
+            refreshed++;
+            success = true;
+            break;
+          } else {
+            lastError = result.message;
+          }
+        } catch (error) {
+          lastError = error instanceof Error ? error.message : 'Unknown error';
+        }
+
+        // Wait before retry
+        if (attempt < this.config.maxRefreshAttempts) {
+          await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS * attempt));
+        }
+      }
+
+      if (!success) {
+        failed++;
+        results.push({
+          accountId: account.id,
+          platform: account.platform,
+          success: false,
+          message: lastError || 'Failed after multiple attempts',
+        });
+
+        // Mark account as needing reconnection if refresh fails
+        await this.storage.markAccountInactive(account.id);
+      }
+    }
+
+    return {
+      total: accounts.length,
+      refreshed,
+      failed,
+      skipped,
+      results,
+    };
+  }
+
+  /**
+   * Validate account token
+   */
+  async validateAccountToken(accountId: string): Promise<{
+    valid: boolean;
+    needsRefresh: boolean;
+    expiresAt?: Date;
+    message?: string;
+  }> {
+    const account = await this.storage.getAccount(accountId);
+
+    if (!account) {
+      return { valid: false, needsRefresh: false, message: 'Account not found' };
+    }
+
+    const needsRefresh = shouldRefreshToken(account.tokenExpiry, this.config.refreshThresholdMs);
+
+    // For LinkedIn, verify with introspection API
+    if (account.platform === 'LINKEDIN' && account.accessToken) {
+      try {
+        const decryptedToken = this.decrypt(account.accessToken);
+        const introspection = await linkedin.introspectToken(decryptedToken);
+
+        return {
+          valid: introspection.active,
+          needsRefresh,
+          expiresAt: introspection.expiresAt || account.tokenExpiry || undefined,
+        };
+      } catch {
+        return {
+          valid: false,
+          needsRefresh: true,
+          message: 'Cannot verify token',
+        };
+      }
+    }
+
+    // For Twitter, validate with API
+    if (account.platform === 'TWITTER' && account.accessToken) {
+      try {
+        const decryptedToken = this.decrypt(account.accessToken);
+        const isValid = await twitter.validateToken(decryptedToken);
+
+        return {
+          valid: isValid,
+          needsRefresh,
+          expiresAt: account.tokenExpiry || undefined,
+        };
+      } catch {
+        return {
+          valid: false,
+          needsRefresh: true,
+          message: 'Cannot verify token',
+        };
+      }
+    }
+
+    // For Threads, validate with API
+    if (account.platform === 'THREADS' && account.accessToken) {
+      try {
+        const decryptedToken = this.decrypt(account.accessToken);
+        const isValid = await threads.validateToken(decryptedToken);
+
+        return {
+          valid: isValid,
+          needsRefresh,
+          expiresAt: account.tokenExpiry || undefined,
+        };
+      } catch {
+        return {
+          valid: false,
+          needsRefresh: true,
+          message: 'Cannot verify token',
+        };
+      }
+    }
+
+    // For Facebook/Instagram, assume valid (Page tokens don't expire)
+    return {
+      valid: true,
+      needsRefresh: false,
+      expiresAt: account.tokenExpiry || undefined,
+    };
+  }
+}

--- a/packages/social/src/oauth/twitter.ts
+++ b/packages/social/src/oauth/twitter.ts
@@ -1,0 +1,427 @@
+/**
+ * @kairn/social - Twitter/X OAuth Provider with PKCE
+ *
+ * Handles OAuth 2.0 authentication with Twitter using PKCE
+ * (Proof Key for Code Exchange) for security.
+ *
+ * Required scopes:
+ * - tweet.read: Read tweets
+ * - tweet.write: Publish tweets
+ * - users.read: Read user info
+ * - offline.access: Obtain refresh token
+ *
+ * @see https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code
+ */
+
+import { randomBytes, createHash } from 'crypto';
+
+import type { SocialAccountMetadata } from '../types';
+
+import type { OAuthProvider, OAuthTokens, ConfigCheckResult, TwitterAccountInfo } from './types';
+
+// ===========================================
+// Configuration
+// ===========================================
+
+export interface TwitterOAuthConfig {
+  clientId?: string;
+  clientSecret?: string;
+}
+
+const TWITTER_AUTH_BASE = 'https://twitter.com/i/oauth2';
+const TWITTER_API_BASE = 'https://api.twitter.com/2';
+
+function getConfig(config?: TwitterOAuthConfig) {
+  return {
+    clientId: config?.clientId || process.env.TWITTER_CLIENT_ID,
+    clientSecret: config?.clientSecret || process.env.TWITTER_CLIENT_SECRET,
+  };
+}
+
+/**
+ * Twitter OAuth scopes
+ */
+export const TWITTER_SCOPES = ['tweet.read', 'tweet.write', 'users.read', 'offline.access'];
+
+/**
+ * Minimal scopes (publish only)
+ */
+export const TWITTER_MINIMAL_SCOPES = ['tweet.write', 'users.read'];
+
+// ===========================================
+// Types
+// ===========================================
+
+interface TwitterTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope: string;
+}
+
+interface TwitterUser {
+  id: string;
+  name: string;
+  username: string;
+  profile_image_url?: string;
+  description?: string;
+}
+
+interface TwitterUserResponse {
+  data: TwitterUser;
+}
+
+// ===========================================
+// PKCE Helper Functions
+// ===========================================
+
+/**
+ * Generate a random code_verifier for PKCE
+ * The code_verifier must be between 43 and 128 characters
+ */
+export function generateCodeVerifier(): string {
+  return randomBytes(32)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+/**
+ * Generate the code_challenge from the code_verifier
+ * Uses SHA256 then base64url encodes
+ */
+export function generateCodeChallenge(codeVerifier: string): string {
+  return createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+// ===========================================
+// Twitter OAuth Functions
+// ===========================================
+
+/**
+ * Check if Twitter OAuth is configured
+ */
+export function checkTwitterConfig(config?: TwitterOAuthConfig): ConfigCheckResult {
+  const { clientId, clientSecret } = getConfig(config);
+
+  if (!clientId) {
+    return { valid: false, error: 'TWITTER_CLIENT_ID not configured' };
+  }
+  if (!clientSecret) {
+    return { valid: false, error: 'TWITTER_CLIENT_SECRET not configured' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Generate Twitter OAuth authorization URL with PKCE
+ *
+ * @param redirectUri - Callback URL after authorization
+ * @param state - CSRF protection token
+ * @param codeChallenge - PKCE challenge generated from code_verifier
+ */
+export function getAuthorizationUrl(
+  redirectUri: string,
+  state: string,
+  codeChallenge: string,
+  config?: TwitterOAuthConfig
+): string {
+  const { clientId } = getConfig(config);
+  const configCheck = checkTwitterConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId!,
+    redirect_uri: redirectUri,
+    state,
+    scope: TWITTER_SCOPES.join(' '),
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  });
+
+  return `${TWITTER_AUTH_BASE}/authorize?${params.toString()}`;
+}
+
+/**
+ * Generate authorization URL with automatic PKCE handling
+ * Returns both URL and code verifier
+ */
+export function getAuthorizationUrlWithPKCE(
+  redirectUri: string,
+  state: string,
+  config?: TwitterOAuthConfig
+): { url: string; codeVerifier: string } {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const url = getAuthorizationUrl(redirectUri, state, codeChallenge, config);
+
+  return { url, codeVerifier };
+}
+
+/**
+ * Exchange authorization code for access token
+ *
+ * @param code - Authorization code from callback
+ * @param redirectUri - Must match the one used for authorization
+ * @param codeVerifier - Original PKCE code verifier
+ */
+export async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+  codeVerifier: string,
+  config?: TwitterOAuthConfig
+): Promise<OAuthTokens> {
+  const { clientId, clientSecret } = getConfig(config);
+  const configCheck = checkTwitterConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  // Twitter uses Basic Auth for token exchange
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+  const params = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+    code_verifier: codeVerifier,
+  });
+
+  const response = await fetch(`${TWITTER_API_BASE}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${credentials}`,
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMessage = 'Token exchange failed';
+    try {
+      const errorJson = JSON.parse(errorText) as { error_description?: string; error?: string };
+      errorMessage = errorJson.error_description || errorJson.error || errorMessage;
+    } catch {
+      errorMessage = errorText || `HTTP ${response.status}`;
+    }
+    throw new Error(`Twitter OAuth error: ${errorMessage}`);
+  }
+
+  const data = (await response.json()) as TwitterTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+    scope: data.scope,
+  };
+}
+
+/**
+ * Refresh an access token
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  config?: TwitterOAuthConfig
+): Promise<OAuthTokens> {
+  const { clientId, clientSecret } = getConfig(config);
+  const configCheck = checkTwitterConfig(config);
+
+  if (!configCheck.valid) {
+    throw new Error(configCheck.error);
+  }
+
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+
+  const response = await fetch(`${TWITTER_API_BASE}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${credentials}`,
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMessage = 'Refresh failed';
+    try {
+      const errorJson = JSON.parse(errorText) as { error_description?: string; error?: string };
+      errorMessage = errorJson.error_description || errorJson.error || errorMessage;
+    } catch {
+      errorMessage = errorText || `HTTP ${response.status}`;
+    }
+    throw new Error(`Twitter refresh token error: ${errorMessage}`);
+  }
+
+  const data = (await response.json()) as TwitterTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+  };
+}
+
+/**
+ * Get authenticated Twitter user info
+ */
+export async function getTwitterUser(accessToken: string): Promise<TwitterUser> {
+  const response = await fetch(
+    `${TWITTER_API_BASE}/users/me?user.fields=id,name,username,profile_image_url,description`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMessage = 'Request failed';
+    try {
+      const errorJson = JSON.parse(errorText) as { detail?: string; title?: string };
+      errorMessage = errorJson.detail || errorJson.title || errorMessage;
+    } catch {
+      errorMessage = errorText || `HTTP ${response.status}`;
+    }
+    throw new Error(`Twitter profile fetch error: ${errorMessage}`);
+  }
+
+  const data = (await response.json()) as TwitterUserResponse;
+  return data.data;
+}
+
+/**
+ * Validate a token
+ */
+export async function validateToken(accessToken: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${TWITTER_API_BASE}/users/me`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get complete Twitter account info
+ */
+export async function getTwitterAccountInfo(accessToken: string): Promise<TwitterAccountInfo> {
+  const user = await getTwitterUser(accessToken);
+
+  return {
+    userId: user.id,
+    username: user.username,
+    name: user.name,
+    profilePictureUrl: user.profile_image_url,
+    description: user.description,
+  };
+}
+
+/**
+ * Build account metadata from Twitter user
+ */
+export function buildAccountMetadata(user: TwitterUser): SocialAccountMetadata {
+  return {
+    twitterUserId: user.id,
+    twitterUsername: user.username,
+    profileUrl: `https://twitter.com/${user.username}`,
+    avatarUrl: user.profile_image_url,
+  };
+}
+
+/**
+ * Convert user data to account info
+ */
+export function toAccountInfo(user: TwitterUser): TwitterAccountInfo {
+  return {
+    userId: user.id,
+    username: user.username,
+    name: user.name,
+    profilePictureUrl: user.profile_image_url,
+    description: user.description,
+  };
+}
+
+/**
+ * Calculate token expiry date
+ */
+export function calculateTokenExpiry(expiresIn: number): Date {
+  return new Date(Date.now() + expiresIn * 1000);
+}
+
+/**
+ * Check if token should be refreshed (expires in less than 5 minutes)
+ */
+export function shouldRefreshToken(tokenExpiry: Date | null): boolean {
+  if (!tokenExpiry) return true;
+
+  const fiveMinutesFromNow = new Date(Date.now() + 5 * 60 * 1000);
+  return tokenExpiry < fiveMinutesFromNow;
+}
+
+// ===========================================
+// Provider class for standardized interface
+// ===========================================
+
+export class TwitterOAuthProvider implements OAuthProvider {
+  readonly name = 'Twitter';
+  private config?: TwitterOAuthConfig;
+
+  constructor(config?: TwitterOAuthConfig) {
+    this.config = config;
+  }
+
+  checkConfig(): ConfigCheckResult {
+    return checkTwitterConfig(this.config);
+  }
+
+  /**
+   * Get authorization URL - requires code challenge for PKCE
+   * Use getAuthorizationUrlWithPKCE for automatic handling
+   */
+  getAuthorizationUrl(_redirectUri: string, _state: string): string {
+    throw new Error('Twitter requires PKCE. Use getAuthorizationUrlWithPKCE() instead.');
+  }
+
+  exchangeCodeForToken(_code: string, _redirectUri: string): Promise<OAuthTokens> {
+    throw new Error(
+      'Twitter requires code verifier for PKCE. Use exchangeCodeForToken(code, redirectUri, codeVerifier) instead.'
+    );
+  }
+
+  async refreshToken(refreshToken: string): Promise<OAuthTokens> {
+    return refreshAccessToken(refreshToken, this.config);
+  }
+
+  calculateTokenExpiry(expiresIn: number): Date {
+    return calculateTokenExpiry(expiresIn);
+  }
+
+  async validateToken(accessToken: string): Promise<boolean> {
+    return validateToken(accessToken);
+  }
+}

--- a/packages/social/src/oauth/types.ts
+++ b/packages/social/src/oauth/types.ts
@@ -1,0 +1,222 @@
+/**
+ * @kairn/social - OAuth Types
+ *
+ * Common types and interfaces for OAuth implementations across social platforms.
+ */
+
+import type { SocialAccountMetadata } from '../types';
+
+// ===========================================
+// OAuth Provider Interface
+// ===========================================
+
+/**
+ * OAuth tokens returned from token exchange
+ */
+export interface OAuthTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  expiresAt?: Date;
+  scope?: string | string[];
+  tokenType?: string;
+}
+
+/**
+ * Configuration check result
+ */
+export interface ConfigCheckResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * OAuth provider interface
+ * All platform-specific OAuth implementations should implement this interface.
+ */
+export interface OAuthProvider {
+  /** Platform name */
+  readonly name: string;
+
+  /**
+   * Check if the provider is properly configured
+   */
+  checkConfig(): ConfigCheckResult;
+
+  /**
+   * Generate the authorization URL for OAuth flow
+   * @param redirectUri - Callback URL after authorization
+   * @param state - CSRF protection token
+   */
+  getAuthorizationUrl(redirectUri: string, state: string): string;
+
+  /**
+   * Exchange authorization code for tokens
+   * @param code - Authorization code from callback
+   * @param redirectUri - Must match the one used in authorization
+   */
+  exchangeCodeForToken(code: string, redirectUri: string): Promise<OAuthTokens>;
+
+  /**
+   * Refresh an expired access token (optional)
+   * @param refreshToken - The refresh token
+   */
+  refreshToken?(refreshToken: string): Promise<OAuthTokens>;
+
+  /**
+   * Validate if a token is still valid
+   * @param accessToken - Token to validate
+   */
+  validateToken?(accessToken: string): Promise<boolean>;
+
+  /**
+   * Calculate token expiry date from expiresIn seconds
+   * @param expiresIn - Seconds until expiration
+   */
+  calculateTokenExpiry(expiresIn: number): Date;
+}
+
+// ===========================================
+// Token Management Types
+// ===========================================
+
+/**
+ * Result of a token refresh operation
+ */
+export interface TokenRefreshResult {
+  accountId: string;
+  platform: string;
+  success: boolean;
+  message: string;
+  newExpiry?: Date;
+  newAccessToken?: string;
+  newRefreshToken?: string;
+}
+
+/**
+ * Batch refresh result
+ */
+export interface TokenRefreshBatchResult {
+  total: number;
+  refreshed: number;
+  failed: number;
+  skipped: number;
+  results: TokenRefreshResult[];
+}
+
+/**
+ * Token validation result
+ */
+export interface TokenValidationResult {
+  valid: boolean;
+  needsRefresh: boolean;
+  expiresAt?: Date;
+  message?: string;
+}
+
+// ===========================================
+// Platform-specific Account Info Types
+// ===========================================
+
+/**
+ * Facebook Page information
+ */
+export interface FacebookPageInfo {
+  pageId: string;
+  pageName: string;
+  pageAccessToken: string;
+  category?: string;
+  instagramAccount?: {
+    id: string;
+    username: string;
+  };
+}
+
+/**
+ * Instagram Business account information
+ */
+export interface InstagramBusinessAccount {
+  id: string;
+  username: string;
+  name?: string;
+  profilePictureUrl?: string;
+  followersCount?: number;
+  mediaCount?: number;
+  biography?: string;
+  website?: string;
+  linkedPageId: string;
+  linkedPageName: string;
+}
+
+/**
+ * LinkedIn account information
+ */
+export interface LinkedInAccountInfo {
+  personId: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  email?: string;
+  profilePictureUrl?: string;
+  organizations?: Array<{
+    id: number;
+    localizedName: string;
+    vanityName?: string;
+  }>;
+}
+
+/**
+ * Twitter/X account information
+ */
+export interface TwitterAccountInfo {
+  userId: string;
+  username: string;
+  name: string;
+  profilePictureUrl?: string;
+  description?: string;
+}
+
+/**
+ * Threads account information
+ */
+export interface ThreadsAccountInfo {
+  userId: string;
+  username: string;
+  name?: string;
+  profilePictureUrl?: string;
+  biography?: string;
+}
+
+// ===========================================
+// OAuth State Management
+// ===========================================
+
+/**
+ * OAuth state data stored in cookies/session
+ */
+export interface OAuthStateData {
+  /** Random state token for CSRF protection */
+  state: string;
+  /** Code verifier for PKCE (Twitter) */
+  codeVerifier?: string;
+  /** Timestamp when state was created */
+  createdAt: number;
+  /** Additional context data */
+  context?: Record<string, unknown>;
+}
+
+/**
+ * OAuth callback parameters
+ */
+export interface OAuthCallbackParams {
+  code: string;
+  state: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+// ===========================================
+// Helper to build account metadata
+// ===========================================
+
+export type AccountMetadataBuilder<T> = (info: T) => SocialAccountMetadata;

--- a/packages/social/src/posting/facebook.ts
+++ b/packages/social/src/posting/facebook.ts
@@ -1,0 +1,287 @@
+/**
+ * @kairn/social/posting - Facebook Publisher
+ *
+ * Publishes content to Facebook Pages via Graph API.
+ */
+
+import type { SocialPlatform } from '../types';
+import { PLATFORM_SPECS } from '../types';
+import { buildUrlWithUtm } from '../utils/utm';
+
+import type {
+  SocialPublisher,
+  PublishPostInput,
+  PublishResult,
+  GetAnalyticsInput,
+  AnalyticsResult,
+  ContentValidationResult,
+} from './types';
+
+const GRAPH_API_VERSION = 'v18.0';
+const GRAPH_API_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
+
+export class FacebookPublisher implements SocialPublisher {
+  readonly platform: SocialPlatform = 'FACEBOOK';
+  private baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl || process.env.NEXT_PUBLIC_SITE_URL || '';
+  }
+
+  /**
+   * Publish a post to a Facebook Page
+   */
+  async publish(input: PublishPostInput): Promise<PublishResult> {
+    const { content, mediaUrls, hashtags, linkUrl, accessToken, accountMetadata } = input;
+
+    const pageId = accountMetadata?.pageId;
+    if (!pageId) {
+      return {
+        success: false,
+        error: 'Page ID missing in account metadata',
+      };
+    }
+
+    try {
+      // Build message with hashtags
+      let message = content;
+      if (hashtags.length > 0) {
+        message += '\n\n' + hashtags.map(h => `#${h}`).join(' ');
+      }
+
+      // Decide publication type
+      if (mediaUrls.length > 0 && mediaUrls[0]) {
+        return await this.publishWithPhoto(pageId, message, mediaUrls[0], linkUrl, accessToken);
+      } else if (linkUrl) {
+        return await this.publishWithLink(pageId, message, linkUrl, accessToken);
+      } else {
+        return await this.publishText(pageId, message, accessToken);
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async publishText(
+    pageId: string,
+    message: string,
+    accessToken: string
+  ): Promise<PublishResult> {
+    const url = `${GRAPH_API_BASE}/${pageId}/feed`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, access_token: accessToken }),
+    });
+
+    const data = (await response.json()) as { id?: string; error?: { message?: string } };
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.error?.message || `HTTP error ${response.status}`,
+        rawResponse: data,
+      };
+    }
+
+    return {
+      success: true,
+      externalPostId: data.id,
+      platformUrl: `https://facebook.com/${data.id}`,
+      rawResponse: data,
+    };
+  }
+
+  private async publishWithLink(
+    pageId: string,
+    message: string,
+    linkUrl: string,
+    accessToken: string
+  ): Promise<PublishResult> {
+    const url = `${GRAPH_API_BASE}/${pageId}/feed`;
+
+    const trackedLinkUrl = buildUrlWithUtm(linkUrl, {
+      source: 'FACEBOOK',
+      medium: 'social',
+      content: linkUrl.includes('/blog/')
+        ? 'blog'
+        : linkUrl.includes('/seminars/')
+          ? 'seminar'
+          : undefined,
+    });
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, link: trackedLinkUrl, access_token: accessToken }),
+    });
+
+    const data = (await response.json()) as { id?: string; error?: { message?: string } };
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.error?.message || `HTTP error ${response.status}`,
+        rawResponse: data,
+      };
+    }
+
+    return {
+      success: true,
+      externalPostId: data.id,
+      platformUrl: `https://facebook.com/${data.id}`,
+      rawResponse: data,
+    };
+  }
+
+  private async publishWithPhoto(
+    pageId: string,
+    caption: string,
+    imageUrl: string,
+    linkUrl: string | null,
+    accessToken: string
+  ): Promise<PublishResult> {
+    const url = `${GRAPH_API_BASE}/${pageId}/photos`;
+
+    const fullImageUrl = imageUrl.startsWith('http') ? imageUrl : `${this.baseUrl}${imageUrl}`;
+
+    // Add link to caption since photos don't support separate link
+    let finalCaption = caption;
+    if (linkUrl) {
+      const trackedLinkUrl = buildUrlWithUtm(linkUrl, {
+        source: 'FACEBOOK',
+        medium: 'social',
+        content: linkUrl.includes('/blog/')
+          ? 'blog'
+          : linkUrl.includes('/seminars/')
+            ? 'seminar'
+            : undefined,
+      });
+      finalCaption += `\n\n🔗 ${trackedLinkUrl}`;
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: fullImageUrl,
+        caption: finalCaption,
+        access_token: accessToken,
+      }),
+    });
+
+    const data = (await response.json()) as {
+      id?: string;
+      post_id?: string;
+      error?: { message?: string };
+    };
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.error?.message || `HTTP error ${response.status}`,
+        rawResponse: data,
+      };
+    }
+
+    return {
+      success: true,
+      externalPostId: data.id,
+      platformUrl: `https://facebook.com/${data.post_id || data.id}`,
+      rawResponse: data,
+    };
+  }
+
+  async getAnalytics(input: GetAnalyticsInput): Promise<AnalyticsResult> {
+    const { externalPostId, accessToken } = input;
+
+    try {
+      const insightsUrl = `${GRAPH_API_BASE}/${externalPostId}/insights`;
+      const metrics = [
+        'post_impressions',
+        'post_impressions_unique',
+        'post_engaged_users',
+        'post_clicks',
+        'post_reactions_like_total',
+      ].join(',');
+
+      const response = await fetch(`${insightsUrl}?metric=${metrics}&access_token=${accessToken}`);
+      const data = (await response.json()) as {
+        data?: Array<{ name: string; values?: Array<{ value?: number }> }>;
+        error?: { message?: string };
+      };
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: data.error?.message || `HTTP error ${response.status}`,
+        };
+      }
+
+      const metricsMap: Record<string, number> = {};
+      for (const metric of data.data || []) {
+        if (metric.values?.[0]?.value !== undefined) {
+          metricsMap[metric.name] = metric.values[0].value;
+        }
+      }
+
+      const engagementUrl = `${GRAPH_API_BASE}/${externalPostId}`;
+      const engagementResponse = await fetch(
+        `${engagementUrl}?fields=shares,comments.summary(true),reactions.summary(true)&access_token=${accessToken}`
+      );
+      const engagementData = (await engagementResponse.json()) as {
+        shares?: { count?: number };
+        comments?: { summary?: { total_count?: number } };
+        reactions?: { summary?: { total_count?: number } };
+      };
+
+      return {
+        success: true,
+        impressions: metricsMap['post_impressions'] || 0,
+        reach: metricsMap['post_impressions_unique'] || 0,
+        engagements: metricsMap['post_engaged_users'] || 0,
+        clicks: metricsMap['post_clicks'] || 0,
+        likes:
+          engagementData.reactions?.summary?.total_count ||
+          metricsMap['post_reactions_like_total'] ||
+          0,
+        comments: engagementData.comments?.summary?.total_count || 0,
+        shares: engagementData.shares?.count || 0,
+        rawData: { insights: data, engagement: engagementData },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  validateContent(content: string, hashtags: string[]): ContentValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const specs = PLATFORM_SPECS.FACEBOOK;
+
+    const fullContent =
+      content + (hashtags.length > 0 ? '\n\n' + hashtags.map(h => `#${h}`).join(' ') : '');
+
+    if (fullContent.length > specs.maxTextLength) {
+      errors.push(`Content exceeds the ${specs.maxTextLength} character limit`);
+    }
+
+    if (hashtags.length > specs.maxHashtags) {
+      warnings.push(`Facebook recommends ${specs.optimalHashtags} hashtags maximum`);
+    }
+
+    const wordCount = content.split(/\s+/).filter(Boolean).length;
+    if (wordCount > specs.optimalTextLength * 2) {
+      warnings.push(`Text is longer than optimal (${specs.optimalTextLength} words recommended)`);
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+}

--- a/packages/social/src/posting/index.ts
+++ b/packages/social/src/posting/index.ts
@@ -1,0 +1,61 @@
+/**
+ * @kairn/social/posting - Publishing Module
+ *
+ * Social media post publishing utilities.
+ */
+
+// Types
+export * from './types';
+
+// Publishers
+export { FacebookPublisher } from './facebook';
+export { InstagramPublisher } from './instagram';
+export { LinkedInPublisher } from './linkedin';
+export { TwitterPublisher } from './twitter';
+export { ThreadsPublisher } from './threads';
+
+// Scheduler
+export { PostScheduler, type SchedulerConfig, type SchedulerBatchResult } from './scheduler';
+
+// Multi-Publisher
+export {
+  MultiPublisher,
+  type MultiPublisherConfig,
+  type ContentAdaptOptions,
+} from './multi-publisher';
+
+// Factory function to get a publisher
+import type { SocialPlatform } from '../types';
+
+import { FacebookPublisher } from './facebook';
+import { InstagramPublisher } from './instagram';
+import { LinkedInPublisher } from './linkedin';
+import { ThreadsPublisher } from './threads';
+import { TwitterPublisher } from './twitter';
+import type { SocialPublisher } from './types';
+
+/**
+ * Get a publisher instance for a platform
+ *
+ * @param platform - Social platform
+ * @param baseUrl - Base URL for media (optional)
+ * @returns Publisher instance
+ */
+export function getPublisher(platform: SocialPlatform, baseUrl?: string): SocialPublisher {
+  switch (platform) {
+    case 'FACEBOOK':
+      return new FacebookPublisher(baseUrl);
+    case 'INSTAGRAM':
+      return new InstagramPublisher(baseUrl);
+    case 'LINKEDIN':
+      return new LinkedInPublisher();
+    case 'TWITTER':
+      return new TwitterPublisher();
+    case 'THREADS':
+      return new ThreadsPublisher(baseUrl);
+    default: {
+      const unknownPlatform: string = platform;
+      throw new Error(`Unsupported platform: ${unknownPlatform}`);
+    }
+  }
+}

--- a/packages/social/src/posting/instagram.ts
+++ b/packages/social/src/posting/instagram.ts
@@ -1,0 +1,293 @@
+/**
+ * @kairn/social/posting - Instagram Publisher
+ *
+ * Publishes content to Instagram Business/Creator accounts via Graph API.
+ * Instagram requires a 2-step process: create media container, then publish.
+ */
+
+import type { SocialPlatform } from '../types';
+import { PLATFORM_SPECS } from '../types';
+import { buildUrlWithUtm } from '../utils/utm';
+
+import type {
+  SocialPublisher,
+  PublishPostInput,
+  PublishResult,
+  GetAnalyticsInput,
+  AnalyticsResult,
+  ContentValidationResult,
+} from './types';
+
+const GRAPH_API_VERSION = 'v18.0';
+const GRAPH_API_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
+
+export class InstagramPublisher implements SocialPublisher {
+  readonly platform: SocialPlatform = 'INSTAGRAM';
+  private baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl || process.env.NEXT_PUBLIC_SITE_URL || '';
+  }
+
+  /**
+   * Publish a post to Instagram
+   */
+  async publish(input: PublishPostInput): Promise<PublishResult> {
+    const { content, mediaUrls, hashtags, linkUrl, accessToken, accountMetadata } = input;
+
+    const igUserId = accountMetadata?.igUserId;
+    if (!igUserId) {
+      return {
+        success: false,
+        error: 'Instagram user ID missing in metadata',
+      };
+    }
+
+    // Instagram requires an image
+    if (mediaUrls.length === 0) {
+      return {
+        success: false,
+        error: 'Instagram requires at least one image to publish',
+      };
+    }
+
+    try {
+      // Build caption with link and hashtags
+      let caption = content;
+
+      // Add link (not clickable on Instagram but included for discoverability)
+      if (linkUrl) {
+        const trackedLinkUrl = buildUrlWithUtm(linkUrl, {
+          source: 'INSTAGRAM',
+          medium: 'social',
+          content: linkUrl.includes('/blog/')
+            ? 'blog'
+            : linkUrl.includes('/seminars/')
+              ? 'seminar'
+              : undefined,
+        });
+        caption += '\n\n🔗 Full article: ' + trackedLinkUrl;
+      }
+
+      if (hashtags.length > 0) {
+        // On Instagram, hashtags are often separated by dots
+        caption += '\n.\n.\n.\n' + hashtags.map(h => `#${h}`).join(' ');
+      }
+
+      // Step 1: Create media container
+      const imageUrl = mediaUrls[0];
+      if (!imageUrl) {
+        return {
+          success: false,
+          error: 'Media URL is required',
+        };
+      }
+
+      const containerId = await this.createMediaContainer(igUserId, imageUrl, caption, accessToken);
+
+      if (!containerId) {
+        return {
+          success: false,
+          error: 'Failed to create media container',
+        };
+      }
+
+      // Wait for media processing
+      await this.waitForMediaProcessing(containerId, accessToken);
+
+      // Step 2: Publish container
+      return await this.publishMediaContainer(igUserId, containerId, accessToken);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async createMediaContainer(
+    igUserId: string,
+    imageUrl: string,
+    caption: string,
+    accessToken: string
+  ): Promise<string | null> {
+    const url = `${GRAPH_API_BASE}/${igUserId}/media`;
+
+    const fullImageUrl = imageUrl.startsWith('http') ? imageUrl : `${this.baseUrl}${imageUrl}`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        image_url: fullImageUrl,
+        caption,
+        access_token: accessToken,
+      }),
+    });
+
+    const data = (await response.json()) as { id?: string; error?: { message?: string } };
+
+    if (!response.ok) {
+      console.error('[InstagramPublisher] Container creation error:', data);
+      return null;
+    }
+
+    return data.id || null;
+  }
+
+  private async waitForMediaProcessing(
+    containerId: string,
+    accessToken: string,
+    maxAttempts = 10
+  ): Promise<void> {
+    const url = `${GRAPH_API_BASE}/${containerId}?fields=status_code&access_token=${accessToken}`;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const response = await fetch(url);
+      const data = (await response.json()) as { status_code?: string };
+
+      if (data.status_code === 'FINISHED') {
+        return;
+      }
+
+      if (data.status_code === 'ERROR') {
+        throw new Error('Instagram media processing failed');
+      }
+
+      // Wait 2 seconds before retry
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+
+    throw new Error('Timeout: media was not processed in time');
+  }
+
+  private async publishMediaContainer(
+    igUserId: string,
+    containerId: string,
+    accessToken: string
+  ): Promise<PublishResult> {
+    const url = `${GRAPH_API_BASE}/${igUserId}/media_publish`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        creation_id: containerId,
+        access_token: accessToken,
+      }),
+    });
+
+    const data = (await response.json()) as { id?: string; error?: { message?: string } };
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.error?.message || `HTTP error ${response.status}`,
+        rawResponse: data,
+      };
+    }
+
+    // Get permalink
+    const mediaId = data.id;
+    let platformUrl: string | undefined;
+
+    try {
+      const permalinkResponse = await fetch(
+        `${GRAPH_API_BASE}/${mediaId}?fields=permalink&access_token=${accessToken}`
+      );
+      const permalinkData = (await permalinkResponse.json()) as { permalink?: string };
+      platformUrl = permalinkData.permalink;
+    } catch {
+      // Not critical
+    }
+
+    return {
+      success: true,
+      externalPostId: mediaId,
+      platformUrl,
+      rawResponse: data,
+    };
+  }
+
+  async getAnalytics(input: GetAnalyticsInput): Promise<AnalyticsResult> {
+    const { externalPostId, accessToken } = input;
+
+    try {
+      const insightsUrl = `${GRAPH_API_BASE}/${externalPostId}/insights`;
+      const metrics = ['impressions', 'reach', 'engagement', 'saved'].join(',');
+
+      const insightsResponse = await fetch(
+        `${insightsUrl}?metric=${metrics}&access_token=${accessToken}`
+      );
+      const insightsData = (await insightsResponse.json()) as {
+        data?: Array<{ name: string; values?: Array<{ value?: number }> }>;
+      };
+
+      const mediaUrl = `${GRAPH_API_BASE}/${externalPostId}`;
+      const mediaResponse = await fetch(
+        `${mediaUrl}?fields=like_count,comments_count&access_token=${accessToken}`
+      );
+      const mediaData = (await mediaResponse.json()) as {
+        like_count?: number;
+        comments_count?: number;
+      };
+
+      const metricsMap: Record<string, number> = {};
+      for (const metric of insightsData.data || []) {
+        if (metric.values?.[0]?.value !== undefined) {
+          metricsMap[metric.name] = metric.values[0].value;
+        }
+      }
+
+      return {
+        success: true,
+        impressions: metricsMap['impressions'] || 0,
+        reach: metricsMap['reach'] || 0,
+        engagements: metricsMap['engagement'] || 0,
+        likes: mediaData.like_count || 0,
+        comments: mediaData.comments_count || 0,
+        saves: metricsMap['saved'] || 0,
+        shares: 0, // Instagram doesn't provide this metric
+        rawData: { insights: insightsData, media: mediaData },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  validateContent(content: string, hashtags: string[]): ContentValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const specs = PLATFORM_SPECS.INSTAGRAM;
+
+    const hashtagsText =
+      hashtags.length > 0 ? '\n.\n.\n.\n' + hashtags.map(h => `#${h}`).join(' ') : '';
+    const fullContent = content + hashtagsText;
+
+    if (fullContent.length > specs.maxTextLength) {
+      errors.push(`Content exceeds the ${specs.maxTextLength} character limit`);
+    }
+
+    if (hashtags.length > specs.maxHashtags) {
+      errors.push(`Maximum ${specs.maxHashtags} hashtags allowed on Instagram`);
+    }
+
+    if (hashtags.length > specs.optimalHashtags) {
+      warnings.push(`${specs.optimalHashtags} hashtags recommended for optimal engagement`);
+    }
+
+    if (hashtags.length < 5 && hashtags.length > 0) {
+      warnings.push('Instagram works better with 5-10 relevant hashtags');
+    }
+
+    const firstLine = content.split('\n')[0] ?? '';
+    if (firstLine.length > 125) {
+      warnings.push('First line will be truncated - keep the hook short');
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+}

--- a/packages/social/src/posting/linkedin.ts
+++ b/packages/social/src/posting/linkedin.ts
@@ -1,0 +1,305 @@
+/**
+ * @kairn/social/posting - LinkedIn Publisher
+ *
+ * Publishes content to LinkedIn profiles and organization pages via API v2.
+ */
+
+import type { SocialPlatform } from '../types';
+import { PLATFORM_SPECS } from '../types';
+import { buildUrlWithUtm } from '../utils/utm';
+
+import type {
+  SocialPublisher,
+  PublishPostInput,
+  PublishResult,
+  GetAnalyticsInput,
+  AnalyticsResult,
+  ContentValidationResult,
+} from './types';
+
+const LINKEDIN_API_BASE = 'https://api.linkedin.com/v2';
+
+export class LinkedInPublisher implements SocialPublisher {
+  readonly platform: SocialPlatform = 'LINKEDIN';
+
+  /**
+   * Publish a post to LinkedIn
+   */
+  async publish(input: PublishPostInput): Promise<PublishResult> {
+    const { content, hashtags, linkUrl, accessToken, accountMetadata } = input;
+
+    const personId = accountMetadata?.personId;
+    const organizationId = accountMetadata?.organizationId;
+
+    if (!personId && !organizationId) {
+      return {
+        success: false,
+        error: 'Person ID or Organization ID missing',
+      };
+    }
+
+    const author = organizationId
+      ? `urn:li:organization:${organizationId}`
+      : `urn:li:person:${personId}`;
+
+    try {
+      // Build content with hashtags
+      let fullContent = content;
+      if (hashtags.length > 0) {
+        fullContent += '\n\n' + hashtags.map(h => `#${h}`).join(' ');
+      }
+
+      if (linkUrl) {
+        return await this.publishWithArticle(author, fullContent, linkUrl, accessToken);
+      } else {
+        return await this.publishText(author, fullContent, accessToken);
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async publishText(
+    author: string,
+    content: string,
+    accessToken: string
+  ): Promise<PublishResult> {
+    const url = `${LINKEDIN_API_BASE}/ugcPosts`;
+
+    const body = {
+      author,
+      lifecycleState: 'PUBLISHED',
+      specificContent: {
+        'com.linkedin.ugc.ShareContent': {
+          shareCommentary: { text: content },
+          shareMediaCategory: 'NONE',
+        },
+      },
+      visibility: {
+        'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC',
+      },
+    };
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: (data as { message?: string }).message || `HTTP error ${response.status}`,
+        rawResponse: data,
+      };
+    }
+
+    const postId = response.headers.get('x-restli-id') || (data as { id?: string }).id;
+    const activityUrn = postId?.replace('urn:li:share:', 'urn:li:activity:');
+
+    return {
+      success: true,
+      externalPostId: postId || undefined,
+      platformUrl: activityUrn ? `https://www.linkedin.com/feed/update/${activityUrn}` : undefined,
+      rawResponse: data,
+    };
+  }
+
+  private async publishWithArticle(
+    author: string,
+    content: string,
+    linkUrl: string,
+    accessToken: string
+  ): Promise<PublishResult> {
+    const url = `${LINKEDIN_API_BASE}/ugcPosts`;
+
+    const trackedLinkUrl = buildUrlWithUtm(linkUrl, {
+      source: 'LINKEDIN',
+      medium: 'social',
+      content: linkUrl.includes('/blog/')
+        ? 'blog'
+        : linkUrl.includes('/seminars/')
+          ? 'seminar'
+          : undefined,
+    });
+
+    const body = {
+      author,
+      lifecycleState: 'PUBLISHED',
+      specificContent: {
+        'com.linkedin.ugc.ShareContent': {
+          shareCommentary: { text: content },
+          shareMediaCategory: 'ARTICLE',
+          media: [
+            {
+              status: 'READY',
+              originalUrl: trackedLinkUrl,
+            },
+          ],
+        },
+      },
+      visibility: {
+        'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC',
+      },
+    };
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0',
+      },
+      body: JSON.stringify(body),
+    });
+
+    let data: Record<string, unknown> = {};
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      try {
+        data = (await response.json()) as Record<string, unknown>;
+      } catch {
+        // Empty body is OK
+      }
+    }
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: (data as { message?: string }).message || `HTTP error ${response.status}`,
+        rawResponse: data,
+      };
+    }
+
+    const postId = response.headers.get('x-restli-id') || (data as { id?: string }).id;
+    const activityUrn = postId?.replace('urn:li:share:', 'urn:li:activity:');
+
+    return {
+      success: true,
+      externalPostId: postId || undefined,
+      platformUrl: activityUrn ? `https://www.linkedin.com/feed/update/${activityUrn}` : undefined,
+      rawResponse: data,
+    };
+  }
+
+  async getAnalytics(input: GetAnalyticsInput): Promise<AnalyticsResult> {
+    const { externalPostId, accessToken, accountMetadata } = input;
+
+    try {
+      const organizationId = accountMetadata?.organizationId;
+
+      if (organizationId) {
+        return await this.getOrganizationPostAnalytics(externalPostId, organizationId, accessToken);
+      } else {
+        // Limited analytics for personal profiles
+        return {
+          success: true,
+          impressions: 0,
+          reach: 0,
+          engagements: 0,
+          likes: 0,
+          comments: 0,
+          shares: 0,
+          rawData: { note: 'Limited analytics for personal profiles' },
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async getOrganizationPostAnalytics(
+    postId: string,
+    organizationId: string,
+    accessToken: string
+  ): Promise<AnalyticsResult> {
+    const activityUrn = postId.includes('share') ? postId.replace('share', 'activity') : postId;
+
+    const url = `${LINKEDIN_API_BASE}/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn:li:organization:${organizationId}&shares[0]=${activityUrn}`;
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'X-Restli-Protocol-Version': '2.0.0',
+      },
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `HTTP error ${response.status}`,
+      };
+    }
+
+    const data = (await response.json()) as {
+      elements?: Array<{
+        totalShareStatistics?: {
+          impressionCount?: number;
+          uniqueImpressionsCount?: number;
+          engagement?: number;
+          likeCount?: number;
+          commentCount?: number;
+          shareCount?: number;
+          clickCount?: number;
+        };
+      }>;
+    };
+    const stats = data.elements?.[0]?.totalShareStatistics;
+
+    if (!stats) {
+      return { success: true, rawData: data };
+    }
+
+    return {
+      success: true,
+      impressions: stats.impressionCount || 0,
+      reach: stats.uniqueImpressionsCount || 0,
+      engagements: stats.engagement || 0,
+      likes: stats.likeCount || 0,
+      comments: stats.commentCount || 0,
+      shares: stats.shareCount || 0,
+      clicks: stats.clickCount || 0,
+      rawData: data,
+    };
+  }
+
+  validateContent(content: string, hashtags: string[]): ContentValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const specs = PLATFORM_SPECS.LINKEDIN;
+
+    const fullContent =
+      content + (hashtags.length > 0 ? '\n\n' + hashtags.map(h => `#${h}`).join(' ') : '');
+
+    if (fullContent.length > specs.maxTextLength) {
+      errors.push(`Content exceeds the ${specs.maxTextLength} character limit`);
+    }
+
+    if (hashtags.length > specs.maxHashtags) {
+      errors.push(`Maximum ${specs.maxHashtags} hashtags allowed`);
+    }
+
+    if (hashtags.length > specs.optimalHashtags) {
+      warnings.push(`LinkedIn recommends ${specs.optimalHashtags} hashtags for optimal engagement`);
+    }
+
+    const firstLine = content.split('\n')[0] ?? '';
+    if (firstLine.length > 150) {
+      warnings.push('First line is long - it will be truncated before "see more"');
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+}

--- a/packages/social/src/posting/multi-publisher.ts
+++ b/packages/social/src/posting/multi-publisher.ts
@@ -1,0 +1,313 @@
+/**
+ * @kairn/social/posting - Multi-Platform Publisher
+ *
+ * Publishes content simultaneously to multiple social platforms.
+ */
+
+import type { SocialPlatform } from '../types';
+import { PLATFORM_SPECS } from '../types';
+
+import { FacebookPublisher } from './facebook';
+import { InstagramPublisher } from './instagram';
+import { LinkedInPublisher } from './linkedin';
+import { ThreadsPublisher } from './threads';
+import { TwitterPublisher } from './twitter';
+import type {
+  MultiPublishInput,
+  MultiPublishResult,
+  PublishResult,
+  SocialPublisher,
+} from './types';
+
+/**
+ * Multi-publisher configuration
+ */
+export interface MultiPublisherConfig {
+  /** Base URL for media */
+  baseUrl?: string;
+  /** Publish concurrently (default: true) */
+  concurrent?: boolean;
+  /** Delay between sequential publishes (ms) */
+  delayMs?: number;
+}
+
+/**
+ * Content adaptation options
+ */
+export interface ContentAdaptOptions {
+  /** Truncate content that exceeds platform limits */
+  truncate?: boolean;
+  /** Limit hashtags to platform optimal */
+  limitHashtags?: boolean;
+  /** Add platform-specific formatting */
+  formatContent?: boolean;
+}
+
+/**
+ * Multi-Platform Publisher
+ *
+ * Handles publishing to multiple platforms simultaneously with
+ * optional content adaptation per platform.
+ */
+export class MultiPublisher {
+  private publishers: Map<SocialPlatform, SocialPublisher>;
+  private config: Required<MultiPublisherConfig>;
+
+  constructor(config?: MultiPublisherConfig) {
+    this.config = {
+      baseUrl: config?.baseUrl ?? process.env.NEXT_PUBLIC_SITE_URL ?? '',
+      concurrent: config?.concurrent ?? true,
+      delayMs: config?.delayMs ?? 500,
+    };
+
+    // Initialize publishers
+    this.publishers = new Map();
+    this.publishers.set('FACEBOOK', new FacebookPublisher(this.config.baseUrl));
+    this.publishers.set('INSTAGRAM', new InstagramPublisher(this.config.baseUrl));
+    this.publishers.set('LINKEDIN', new LinkedInPublisher());
+    this.publishers.set('TWITTER', new TwitterPublisher());
+    this.publishers.set('THREADS', new ThreadsPublisher(this.config.baseUrl));
+  }
+
+  /**
+   * Publish to multiple platforms
+   */
+  async publish(input: MultiPublishInput): Promise<MultiPublishResult> {
+    const { platforms, content, mediaUrls, hashtags, linkUrl, adaptContent } = input;
+
+    const publishTasks = platforms.map(async platformConfig => {
+      const { platform, accountId, accessToken, metadata, contentOverride, hashtagsOverride } =
+        platformConfig;
+
+      const publisher = this.publishers.get(platform);
+      if (!publisher) {
+        return {
+          platform,
+          accountId,
+          result: {
+            success: false,
+            error: `Unsupported platform: ${platform}`,
+          } as PublishResult,
+        };
+      }
+
+      // Use override or adapt content
+      let finalContent = contentOverride || content;
+      let finalHashtags = hashtagsOverride || hashtags;
+
+      if (adaptContent && !contentOverride) {
+        const adapted = this.adaptContent(platform, content, hashtags);
+        finalContent = adapted.content;
+        finalHashtags = adapted.hashtags;
+      }
+
+      try {
+        const result = await publisher.publish({
+          content: finalContent,
+          mediaUrls,
+          hashtags: finalHashtags,
+          linkUrl,
+          accessToken,
+          accountMetadata: metadata,
+          baseUrl: input.baseUrl || this.config.baseUrl,
+        });
+
+        return { platform, accountId, result };
+      } catch (error) {
+        return {
+          platform,
+          accountId,
+          result: {
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          } as PublishResult,
+        };
+      }
+    });
+
+    let results: Array<{ platform: SocialPlatform; accountId: string; result: PublishResult }>;
+
+    if (this.config.concurrent) {
+      // Publish all platforms concurrently
+      results = await Promise.all(publishTasks);
+    } else {
+      // Publish sequentially with delay
+      results = [];
+      for (const task of publishTasks) {
+        results.push(await task);
+        await new Promise(resolve => setTimeout(resolve, this.config.delayMs));
+      }
+    }
+
+    const successful = results.filter(r => r.result.success).length;
+    const failed = results.filter(r => !r.result.success).length;
+
+    return {
+      total: results.length,
+      successful,
+      failed,
+      results,
+    };
+  }
+
+  /**
+   * Adapt content for a specific platform
+   */
+  adaptContent(
+    platform: SocialPlatform,
+    content: string,
+    hashtags: string[],
+    options?: ContentAdaptOptions
+  ): { content: string; hashtags: string[] } {
+    const specs = PLATFORM_SPECS[platform];
+    const opts = {
+      truncate: options?.truncate ?? true,
+      limitHashtags: options?.limitHashtags ?? true,
+      formatContent: options?.formatContent ?? false,
+    };
+
+    let adaptedContent = content;
+    let adaptedHashtags = [...hashtags];
+
+    // Limit hashtags
+    if (opts.limitHashtags && adaptedHashtags.length > specs.optimalHashtags) {
+      adaptedHashtags = adaptedHashtags.slice(0, specs.optimalHashtags);
+    }
+
+    // Calculate available space for content
+    const hashtagsLength =
+      adaptedHashtags.length > 0 ? adaptedHashtags.map(h => `#${h}`).join(' ').length + 2 : 0;
+
+    // For Twitter, account for URL shortening (23 chars)
+    let urlLength = 0;
+    if (platform === 'TWITTER') {
+      const urlRegex = /https?:\/\/[^\s]+/g;
+      const urls = adaptedContent.match(urlRegex) || [];
+      urlLength = urls.length * 23;
+      // Remove actual URLs from length calculation
+      for (const url of urls) {
+        adaptedContent = adaptedContent.replace(url, '');
+      }
+    }
+
+    const maxContentLength = specs.maxTextLength - hashtagsLength - urlLength;
+
+    // Truncate content if needed
+    if (opts.truncate && adaptedContent.length > maxContentLength) {
+      adaptedContent = adaptedContent.slice(0, maxContentLength - 3) + '...';
+    }
+
+    // Platform-specific formatting
+    if (opts.formatContent) {
+      switch (platform) {
+        case 'LINKEDIN':
+          // LinkedIn benefits from line breaks for readability
+          adaptedContent = this.addLineBreaksForLinkedIn(adaptedContent);
+          break;
+        case 'INSTAGRAM':
+          // Instagram often has hashtags separated by dots
+          break;
+        case 'TWITTER':
+          // Twitter should be concise
+          if (adaptedContent.length > specs.optimalTextLength * 2) {
+            const sentences = adaptedContent.split(/[.!?]\s+/);
+            adaptedContent = sentences.slice(0, 2).join('. ') + '.';
+          }
+          break;
+      }
+    }
+
+    return { content: adaptedContent, hashtags: adaptedHashtags };
+  }
+
+  /**
+   * Add strategic line breaks for LinkedIn readability
+   */
+  private addLineBreaksForLinkedIn(content: string): string {
+    // If content already has line breaks, leave it
+    if (content.includes('\n\n')) {
+      return content;
+    }
+
+    // Split into sentences and group
+    const sentences = content.split(/(?<=[.!?])\s+/);
+    if (sentences.length <= 2) {
+      return content;
+    }
+
+    // Add breaks every 2-3 sentences
+    const result: string[] = [];
+    for (let i = 0; i < sentences.length; i += 2) {
+      const chunk = sentences.slice(i, i + 2).join(' ');
+      result.push(chunk);
+    }
+
+    return result.join('\n\n');
+  }
+
+  /**
+   * Validate content for multiple platforms
+   */
+  validateForPlatforms(
+    platforms: SocialPlatform[],
+    content: string,
+    hashtags: string[]
+  ): Map<SocialPlatform, { valid: boolean; errors: string[]; warnings: string[] }> {
+    const results = new Map<
+      SocialPlatform,
+      { valid: boolean; errors: string[]; warnings: string[] }
+    >();
+
+    for (const platform of platforms) {
+      const publisher = this.publishers.get(platform);
+      if (publisher) {
+        results.set(platform, publisher.validateContent(content, hashtags));
+      } else {
+        results.set(platform, {
+          valid: false,
+          errors: [`Unsupported platform: ${platform}`],
+          warnings: [],
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Get recommended content length for multi-platform posting
+   */
+  getRecommendedContentLength(platforms: SocialPlatform[]): {
+    maxLength: number;
+    optimalLength: number;
+    platform: SocialPlatform;
+  } {
+    let minMax = Infinity;
+    let minOptimal = Infinity;
+    let limitingPlatform: SocialPlatform = 'TWITTER';
+
+    for (const platform of platforms) {
+      const specs = PLATFORM_SPECS[platform];
+      if (specs.maxTextLength < minMax) {
+        minMax = specs.maxTextLength;
+        limitingPlatform = platform;
+      }
+      if (specs.optimalTextLength < minOptimal) {
+        minOptimal = specs.optimalTextLength;
+      }
+    }
+
+    return {
+      maxLength: minMax,
+      optimalLength: minOptimal,
+      platform: limitingPlatform,
+    };
+  }
+
+  /**
+   * Get publisher for direct use
+   */
+  getPublisher(platform: SocialPlatform): SocialPublisher | undefined {
+    return this.publishers.get(platform);
+  }
+}

--- a/packages/social/src/posting/scheduler.ts
+++ b/packages/social/src/posting/scheduler.ts
@@ -1,0 +1,255 @@
+/**
+ * @kairn/social/posting - Post Scheduler
+ *
+ * Manages scheduling and automated publishing of social media posts.
+ */
+
+import type { SocialPlatform } from '../types';
+
+import { FacebookPublisher } from './facebook';
+import { InstagramPublisher } from './instagram';
+import { LinkedInPublisher } from './linkedin';
+import { ThreadsPublisher } from './threads';
+import { TwitterPublisher } from './twitter';
+import type { ScheduledPost, PostStorage, PublishResult } from './types';
+
+/**
+ * Scheduler configuration
+ */
+export interface SchedulerConfig {
+  /** Maximum retry attempts per post */
+  maxRetries?: number;
+  /** Delay between retries (ms) */
+  retryDelayMs?: number;
+  /** Base URL for media */
+  baseUrl?: string;
+  /** Callback when post is published */
+  onPublished?: (postId: string, result: PublishResult) => void | Promise<void>;
+  /** Callback when post fails */
+  onFailed?: (postId: string, error: string) => void | Promise<void>;
+}
+
+/**
+ * Result of processing a batch of posts
+ */
+export interface SchedulerBatchResult {
+  /** Total posts processed */
+  total: number;
+  /** Successfully published */
+  published: number;
+  /** Failed to publish */
+  failed: number;
+  /** Posts skipped (exceeded retries, etc.) */
+  skipped: number;
+  /** Detailed results */
+  results: Array<{
+    postId: string;
+    platform: SocialPlatform;
+    success: boolean;
+    error?: string;
+    externalPostId?: string;
+    platformUrl?: string;
+  }>;
+}
+
+/**
+ * Post Scheduler
+ *
+ * Processes scheduled posts and publishes them to social platforms.
+ */
+export class PostScheduler {
+  private storage: PostStorage;
+  private config: Required<Omit<SchedulerConfig, 'onPublished' | 'onFailed'>> &
+    Pick<SchedulerConfig, 'onPublished' | 'onFailed'>;
+  private publishers: Map<
+    SocialPlatform,
+    FacebookPublisher | InstagramPublisher | LinkedInPublisher | TwitterPublisher | ThreadsPublisher
+  >;
+
+  constructor(storage: PostStorage, config?: SchedulerConfig) {
+    this.storage = storage;
+    this.config = {
+      maxRetries: config?.maxRetries ?? 3,
+      retryDelayMs: config?.retryDelayMs ?? 5000,
+      baseUrl: config?.baseUrl ?? process.env.NEXT_PUBLIC_SITE_URL ?? '',
+      onPublished: config?.onPublished,
+      onFailed: config?.onFailed,
+    };
+
+    // Initialize publishers
+    this.publishers = new Map();
+    this.publishers.set('FACEBOOK', new FacebookPublisher(this.config.baseUrl));
+    this.publishers.set('INSTAGRAM', new InstagramPublisher(this.config.baseUrl));
+    this.publishers.set('LINKEDIN', new LinkedInPublisher());
+    this.publishers.set('TWITTER', new TwitterPublisher());
+    this.publishers.set('THREADS', new ThreadsPublisher(this.config.baseUrl));
+  }
+
+  /**
+   * Process all posts due for publishing
+   */
+  async processDuePosts(): Promise<SchedulerBatchResult> {
+    const posts = await this.storage.getPostsDueForPublishing();
+
+    const results: SchedulerBatchResult['results'] = [];
+    let published = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const post of posts) {
+      // Skip if exceeded max retries
+      if (post.retryCount >= this.config.maxRetries) {
+        skipped++;
+        await this.storage.updatePostStatus(post.id, 'failed', {
+          errorMessage: 'Maximum retries exceeded',
+        });
+        continue;
+      }
+
+      // Mark as processing
+      await this.storage.updatePostStatus(post.id, 'processing');
+
+      try {
+        const result = await this.publishPost(post);
+
+        if (result.success) {
+          published++;
+          await this.storage.updatePostStatus(post.id, 'published', {
+            externalPostId: result.externalPostId,
+            platformUrl: result.platformUrl,
+            publishedAt: new Date(),
+          });
+
+          if (this.config.onPublished) {
+            await this.config.onPublished(post.id, result);
+          }
+
+          results.push({
+            postId: post.id,
+            platform: post.platform,
+            success: true,
+            externalPostId: result.externalPostId,
+            platformUrl: result.platformUrl,
+          });
+        } else {
+          failed++;
+          const newRetryCount = post.retryCount + 1;
+
+          await this.storage.updatePostStatus(
+            post.id,
+            newRetryCount >= this.config.maxRetries ? 'failed' : 'pending',
+            {
+              errorMessage: result.error,
+              retryCount: newRetryCount,
+            }
+          );
+
+          if (this.config.onFailed && newRetryCount >= this.config.maxRetries) {
+            await this.config.onFailed(post.id, result.error || 'Unknown error');
+          }
+
+          results.push({
+            postId: post.id,
+            platform: post.platform,
+            success: false,
+            error: result.error,
+          });
+        }
+      } catch (error) {
+        failed++;
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        const newRetryCount = post.retryCount + 1;
+
+        await this.storage.updatePostStatus(
+          post.id,
+          newRetryCount >= this.config.maxRetries ? 'failed' : 'pending',
+          {
+            errorMessage,
+            retryCount: newRetryCount,
+          }
+        );
+
+        if (this.config.onFailed && newRetryCount >= this.config.maxRetries) {
+          await this.config.onFailed(post.id, errorMessage);
+        }
+
+        results.push({
+          postId: post.id,
+          platform: post.platform,
+          success: false,
+          error: errorMessage,
+        });
+      }
+
+      // Delay between posts to avoid rate limiting
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    return {
+      total: posts.length,
+      published,
+      failed,
+      skipped,
+      results,
+    };
+  }
+
+  /**
+   * Publish a single post
+   */
+  private async publishPost(post: ScheduledPost): Promise<PublishResult> {
+    const publisher = this.publishers.get(post.platform);
+    if (!publisher) {
+      return {
+        success: false,
+        error: `Unsupported platform: ${post.platform}`,
+      };
+    }
+
+    // Get account details
+    const account = await this.storage.getAccountForPublishing(post.accountId);
+    if (!account) {
+      return {
+        success: false,
+        error: 'Account not found or inactive',
+      };
+    }
+
+    return publisher.publish({
+      content: post.content,
+      mediaUrls: post.mediaUrls,
+      hashtags: post.hashtags,
+      linkUrl: post.linkUrl,
+      accessToken: account.accessToken,
+      accountMetadata: account.metadata,
+      baseUrl: this.config.baseUrl,
+    });
+  }
+
+  /**
+   * Validate content for a platform before scheduling
+   */
+  validateContent(
+    platform: SocialPlatform,
+    content: string,
+    hashtags: string[]
+  ): { valid: boolean; errors: string[]; warnings: string[] } {
+    const publisher = this.publishers.get(platform);
+    if (!publisher) {
+      return {
+        valid: false,
+        errors: [`Unsupported platform: ${platform}`],
+        warnings: [],
+      };
+    }
+
+    return publisher.validateContent(content, hashtags);
+  }
+
+  /**
+   * Get publisher for direct use
+   */
+  getPublisher(platform: SocialPlatform) {
+    return this.publishers.get(platform);
+  }
+}

--- a/packages/social/src/posting/threads.ts
+++ b/packages/social/src/posting/threads.ts
@@ -1,0 +1,282 @@
+/**
+ * @kairn/social/posting - Threads Publisher
+ *
+ * Publishes content to Threads via the Threads API.
+ * Unlike Instagram, Threads allows text-only posts.
+ */
+
+import type { SocialPlatform } from '../types';
+import { PLATFORM_SPECS } from '../types';
+import { buildUrlWithUtm } from '../utils/utm';
+
+import type {
+  SocialPublisher,
+  PublishPostInput,
+  PublishResult,
+  GetAnalyticsInput,
+  AnalyticsResult,
+  ContentValidationResult,
+} from './types';
+
+const THREADS_API_VERSION = 'v1.0';
+const THREADS_API_BASE = 'https://graph.threads.net';
+
+export class ThreadsPublisher implements SocialPublisher {
+  readonly platform: SocialPlatform = 'THREADS';
+  private baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl || process.env.NEXT_PUBLIC_SITE_URL || '';
+  }
+
+  /**
+   * Publish a post to Threads
+   */
+  async publish(input: PublishPostInput): Promise<PublishResult> {
+    const { content, mediaUrls, hashtags, linkUrl, accessToken, accountMetadata } = input;
+
+    const threadsUserId = accountMetadata?.threadsUserId;
+    if (!threadsUserId) {
+      return {
+        success: false,
+        error: 'Threads user ID missing in metadata',
+      };
+    }
+
+    try {
+      // Build text with hashtags
+      let text = content;
+      if (hashtags.length > 0) {
+        text += '\n\n' + hashtags.map(h => `#${h}`).join(' ');
+      }
+
+      // Add link with UTM tracking
+      if (linkUrl) {
+        const trackedLinkUrl = buildUrlWithUtm(linkUrl, {
+          source: 'THREADS',
+          medium: 'social',
+          content: linkUrl.includes('/blog/')
+            ? 'blog'
+            : linkUrl.includes('/seminars/')
+              ? 'seminar'
+              : undefined,
+        });
+        text += '\n\n' + trackedLinkUrl;
+      }
+
+      // Step 1: Create container
+      const containerId = await this.createMediaContainer(
+        threadsUserId,
+        text,
+        mediaUrls.length > 0 ? mediaUrls[0] : undefined,
+        accessToken
+      );
+
+      if (!containerId) {
+        return {
+          success: false,
+          error: 'Failed to create media container',
+        };
+      }
+
+      // Wait for processing
+      await this.waitForMediaProcessing(containerId, accessToken);
+
+      // Step 2: Publish container
+      return await this.publishMediaContainer(threadsUserId, containerId, accessToken);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  private async createMediaContainer(
+    userId: string,
+    text: string,
+    imageUrl?: string,
+    accessToken?: string
+  ): Promise<string | null> {
+    const url = `${THREADS_API_BASE}/${THREADS_API_VERSION}/${userId}/threads`;
+
+    const body: Record<string, string> = {
+      text,
+      access_token: accessToken || '',
+    };
+
+    if (imageUrl) {
+      body.media_type = 'IMAGE';
+      body.image_url = imageUrl.startsWith('http') ? imageUrl : `${this.baseUrl}${imageUrl}`;
+    } else {
+      body.media_type = 'TEXT';
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    const data = (await response.json()) as { id?: string; error?: { message?: string } };
+
+    if (!response.ok) {
+      console.error('[ThreadsPublisher] Container creation error:', data);
+      throw new Error(data.error?.message || `HTTP error ${response.status}`);
+    }
+
+    return data.id || null;
+  }
+
+  private async waitForMediaProcessing(
+    containerId: string,
+    accessToken: string,
+    maxAttempts = 10
+  ): Promise<void> {
+    const url = `${THREADS_API_BASE}/${THREADS_API_VERSION}/${containerId}?fields=status&access_token=${accessToken}`;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const response = await fetch(url);
+      const data = (await response.json()) as { status?: string; error_message?: string };
+
+      if (data.status === 'FINISHED') {
+        return;
+      }
+
+      if (data.status === 'ERROR') {
+        throw new Error(data.error_message || 'Threads media processing error');
+      }
+
+      // Wait 2 seconds before retry
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+
+    throw new Error('Timeout: media was not processed in time');
+  }
+
+  private async publishMediaContainer(
+    userId: string,
+    containerId: string,
+    accessToken: string
+  ): Promise<PublishResult> {
+    const url = `${THREADS_API_BASE}/${THREADS_API_VERSION}/${userId}/threads_publish`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        creation_id: containerId,
+        access_token: accessToken,
+      }),
+    });
+
+    const data = (await response.json()) as { id?: string; error?: { message?: string } };
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.error?.message || `HTTP error ${response.status}`,
+        rawResponse: data,
+      };
+    }
+
+    // Get permalink
+    const postId = data.id;
+    let platformUrl: string | undefined;
+
+    try {
+      const permalinkResponse = await fetch(
+        `${THREADS_API_BASE}/${THREADS_API_VERSION}/${postId}?fields=permalink&access_token=${accessToken}`
+      );
+      const permalinkData = (await permalinkResponse.json()) as { permalink?: string };
+      platformUrl = permalinkData.permalink;
+    } catch {
+      // Not critical
+    }
+
+    return {
+      success: true,
+      externalPostId: postId,
+      platformUrl,
+      rawResponse: data,
+    };
+  }
+
+  async getAnalytics(input: GetAnalyticsInput): Promise<AnalyticsResult> {
+    const { externalPostId, accessToken } = input;
+
+    try {
+      const metrics = ['views', 'likes', 'replies', 'reposts', 'quotes'].join(',');
+
+      const insightsUrl = `${THREADS_API_BASE}/${THREADS_API_VERSION}/${externalPostId}/insights?metric=${metrics}&access_token=${accessToken}`;
+      const insightsResponse = await fetch(insightsUrl);
+      const insightsData = (await insightsResponse.json()) as {
+        data?: Array<{ name: string; values?: Array<{ value?: number }> }>;
+      };
+
+      const metricsMap: Record<string, number> = {};
+      for (const metric of insightsData.data || []) {
+        if (metric.values?.[0]?.value !== undefined) {
+          metricsMap[metric.name] = metric.values[0].value;
+        }
+      }
+
+      return {
+        success: true,
+        impressions: metricsMap['views'] || 0,
+        reach: metricsMap['views'] || 0,
+        likes: metricsMap['likes'] || 0,
+        comments: metricsMap['replies'] || 0,
+        shares: (metricsMap['reposts'] || 0) + (metricsMap['quotes'] || 0),
+        engagements:
+          (metricsMap['likes'] || 0) +
+          (metricsMap['replies'] || 0) +
+          (metricsMap['reposts'] || 0) +
+          (metricsMap['quotes'] || 0),
+        rawData: insightsData,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  validateContent(content: string, hashtags: string[]): ContentValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const specs = PLATFORM_SPECS.THREADS;
+
+    const hashtagsText = hashtags.length > 0 ? '\n\n' + hashtags.map(h => `#${h}`).join(' ') : '';
+    const fullContent = content + hashtagsText;
+
+    if (fullContent.length > specs.maxTextLength) {
+      errors.push(
+        `Content exceeds ${specs.maxTextLength} character limit (currently ${fullContent.length})`
+      );
+    }
+
+    const minRecommendedLength = 50;
+    if (fullContent.length < minRecommendedLength) {
+      warnings.push(
+        `Content is short (${fullContent.length} chars). Minimum recommended: ${minRecommendedLength}`
+      );
+    }
+
+    if (hashtags.length > specs.maxHashtags) {
+      errors.push(`Maximum ${specs.maxHashtags} hashtags allowed on Threads`);
+    }
+
+    if (hashtags.length > specs.optimalHashtags) {
+      warnings.push(`Threads works better with ${specs.optimalHashtags} hashtags or less`);
+    }
+
+    const wordCount = content.split(/\s+/).length;
+    if (wordCount > 100) {
+      warnings.push('Threads favors short, punchy messages');
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+}

--- a/packages/social/src/posting/twitter.ts
+++ b/packages/social/src/posting/twitter.ts
@@ -1,0 +1,264 @@
+/**
+ * @kairn/social/posting - Twitter/X Publisher
+ *
+ * Publishes tweets via Twitter API v2.
+ */
+
+import type { SocialPlatform } from '../types';
+import { PLATFORM_SPECS } from '../types';
+import { buildUrlWithUtm } from '../utils/utm';
+
+import type {
+  SocialPublisher,
+  PublishPostInput,
+  PublishResult,
+  GetAnalyticsInput,
+  AnalyticsResult,
+  ContentValidationResult,
+} from './types';
+
+const TWITTER_API_BASE = 'https://api.twitter.com/2';
+
+export class TwitterPublisher implements SocialPublisher {
+  readonly platform: SocialPlatform = 'TWITTER';
+
+  /**
+   * Publish a tweet
+   */
+  async publish(input: PublishPostInput): Promise<PublishResult> {
+    const { content, hashtags, linkUrl, accessToken, accountMetadata } = input;
+
+    try {
+      // Build tweet text
+      let text = content;
+
+      // Add hashtags
+      if (hashtags.length > 0) {
+        const hashtagsText = hashtags.map(h => `#${h}`).join(' ');
+        text += '\n\n' + hashtagsText;
+      }
+
+      // Add link with UTM tracking
+      if (linkUrl) {
+        const trackedLinkUrl = buildUrlWithUtm(linkUrl, {
+          source: 'TWITTER',
+          medium: 'social',
+          content: linkUrl.includes('/blog/')
+            ? 'blog'
+            : linkUrl.includes('/seminars/')
+              ? 'seminar'
+              : undefined,
+        });
+        text += '\n\n' + trackedLinkUrl;
+      }
+
+      // Validate content
+      const validation = this.validateContent(content, hashtags);
+      if (!validation.valid) {
+        return {
+          success: false,
+          error: validation.errors.join(', '),
+        };
+      }
+
+      // Publish tweet
+      const response = await fetch(`${TWITTER_API_BASE}/tweets`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ text }),
+      });
+
+      const data = (await response.json()) as {
+        data?: { id?: string };
+        detail?: string;
+        title?: string;
+        errors?: Array<{ message?: string }>;
+      };
+
+      if (!response.ok) {
+        const errorMessage =
+          data.detail || data.title || data.errors?.[0]?.message || `HTTP error ${response.status}`;
+        return {
+          success: false,
+          error: errorMessage,
+          rawResponse: data,
+        };
+      }
+
+      const tweetId = data.data?.id;
+      const username = accountMetadata?.twitterUsername;
+      const platformUrl = tweetId
+        ? username
+          ? `https://twitter.com/${username}/status/${tweetId}`
+          : `https://twitter.com/i/web/status/${tweetId}`
+        : undefined;
+
+      return {
+        success: true,
+        externalPostId: tweetId,
+        platformUrl,
+        rawResponse: data,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  async getAnalytics(input: GetAnalyticsInput): Promise<AnalyticsResult> {
+    const { externalPostId, accessToken } = input;
+
+    try {
+      const metricsFields = ['public_metrics', 'organic_metrics', 'non_public_metrics'].join(',');
+
+      const response = await fetch(
+        `${TWITTER_API_BASE}/tweets/${externalPostId}?tweet.fields=${metricsFields}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+
+      type TwitterMetrics = {
+        impression_count?: number;
+        like_count?: number;
+        reply_count?: number;
+        retweet_count?: number;
+        quote_count?: number;
+        url_link_clicks?: number;
+      };
+
+      type TwitterResponse = {
+        data?: {
+          public_metrics?: TwitterMetrics;
+          organic_metrics?: TwitterMetrics;
+          non_public_metrics?: TwitterMetrics;
+        };
+        detail?: string;
+        title?: string;
+      };
+
+      const data = (await response.json()) as TwitterResponse;
+
+      if (!response.ok) {
+        // Non-public metrics may be inaccessible
+        if (response.status === 403) {
+          const publicResponse = await fetch(
+            `${TWITTER_API_BASE}/tweets/${externalPostId}?tweet.fields=public_metrics`,
+            {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+              },
+            }
+          );
+
+          if (publicResponse.ok) {
+            const publicData = (await publicResponse.json()) as TwitterResponse;
+            const metrics = publicData.data?.public_metrics || {};
+
+            return {
+              success: true,
+              impressions: metrics.impression_count || 0,
+              reach: metrics.impression_count || 0,
+              likes: metrics.like_count || 0,
+              comments: metrics.reply_count || 0,
+              shares: metrics.retweet_count || 0,
+              engagements:
+                (metrics.like_count || 0) +
+                (metrics.reply_count || 0) +
+                (metrics.retweet_count || 0) +
+                (metrics.quote_count || 0),
+              rawData: publicData,
+            };
+          }
+        }
+
+        return {
+          success: false,
+          error: data.detail || data.title || `HTTP error ${response.status}`,
+        };
+      }
+
+      const publicMetrics = data.data?.public_metrics || {};
+      const organicMetrics = data.data?.organic_metrics || {};
+      const nonPublicMetrics = data.data?.non_public_metrics || {};
+
+      const impressions =
+        organicMetrics.impression_count ||
+        nonPublicMetrics.impression_count ||
+        publicMetrics.impression_count ||
+        0;
+
+      return {
+        success: true,
+        impressions,
+        reach: impressions,
+        likes: publicMetrics.like_count || 0,
+        comments: publicMetrics.reply_count || 0,
+        shares: publicMetrics.retweet_count || 0,
+        clicks: nonPublicMetrics.url_link_clicks || 0,
+        engagements:
+          (publicMetrics.like_count || 0) +
+          (publicMetrics.reply_count || 0) +
+          (publicMetrics.retweet_count || 0) +
+          (publicMetrics.quote_count || 0),
+        rawData: data,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  validateContent(content: string, hashtags: string[]): ContentValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const specs = PLATFORM_SPECS.TWITTER;
+
+    // Calculate total length
+    const hashtagsText = hashtags.length > 0 ? '\n\n' + hashtags.map(h => `#${h}`).join(' ') : '';
+    const fullContent = content + hashtagsText;
+
+    // Calculate effective length (URLs are shortened to 23 chars)
+    const urlRegex = /https?:\/\/[^\s]+/g;
+    const urls = fullContent.match(urlRegex) || [];
+    let effectiveLength = fullContent.length;
+
+    for (const url of urls) {
+      effectiveLength = effectiveLength - url.length + 23;
+    }
+
+    if (effectiveLength > specs.maxTextLength) {
+      errors.push(
+        `Tweet exceeds ${specs.maxTextLength} character limit (currently ${effectiveLength})`
+      );
+    }
+
+    if (hashtags.length > specs.maxHashtags) {
+      errors.push(`Maximum ${specs.maxHashtags} hashtags on Twitter`);
+    }
+
+    if (hashtags.length > specs.optimalHashtags) {
+      warnings.push(`Twitter works better with ${specs.optimalHashtags} hashtags or less`);
+    }
+
+    if (effectiveLength < 50) {
+      warnings.push('Short tweets generally have less engagement');
+    }
+
+    const mentions = content.match(/@[a-zA-Z0-9_]+/g) || [];
+    if (mentions.length > 5) {
+      warnings.push('Too many mentions may reduce tweet visibility');
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
+  }
+}

--- a/packages/social/src/posting/types.ts
+++ b/packages/social/src/posting/types.ts
@@ -1,0 +1,278 @@
+/**
+ * @kairn/social/posting - Publishing Types
+ *
+ * Types and interfaces for social media post publishing.
+ */
+
+import type { SocialPlatform, SocialAccountMetadata } from '../types';
+
+// ===========================================
+// Publishing Types
+// ===========================================
+
+/**
+ * Input for publishing a post
+ */
+export interface PublishPostInput {
+  /** Post content/text */
+  content: string;
+  /** Media URLs (images) */
+  mediaUrls: string[];
+  /** Hashtags (without #) */
+  hashtags: string[];
+  /** Link URL to include */
+  linkUrl: string | null;
+  /** Decrypted access token */
+  accessToken: string;
+  /** Account-specific metadata (pageId, igUserId, etc.) */
+  accountMetadata: SocialAccountMetadata | null;
+  /** Base URL for constructing full media URLs */
+  baseUrl?: string;
+}
+
+/**
+ * Result of a publish operation
+ */
+export interface PublishResult {
+  /** Whether publishing succeeded */
+  success: boolean;
+  /** Platform-specific post ID */
+  externalPostId?: string;
+  /** Direct URL to the published post */
+  platformUrl?: string;
+  /** Error message if failed */
+  error?: string;
+  /** Raw API response for debugging */
+  rawResponse?: unknown;
+}
+
+/**
+ * Input for retrieving post analytics
+ */
+export interface GetAnalyticsInput {
+  /** Platform-specific post ID */
+  externalPostId: string;
+  /** Decrypted access token */
+  accessToken: string;
+  /** Account-specific metadata */
+  accountMetadata: SocialAccountMetadata | null;
+}
+
+/**
+ * Analytics data for a post
+ */
+export interface AnalyticsResult {
+  /** Whether retrieval succeeded */
+  success: boolean;
+  /** Number of impressions */
+  impressions?: number;
+  /** Unique reach */
+  reach?: number;
+  /** Total engagements */
+  engagements?: number;
+  /** Likes count */
+  likes?: number;
+  /** Comments count */
+  comments?: number;
+  /** Shares/retweets count */
+  shares?: number;
+  /** Saves count (Instagram) */
+  saves?: number;
+  /** Link clicks */
+  clicks?: number;
+  /** Raw API data for debugging */
+  rawData?: Record<string, unknown>;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Content validation result
+ */
+export interface ContentValidationResult {
+  /** Whether content is valid */
+  valid: boolean;
+  /** Hard errors (content cannot be published) */
+  errors: string[];
+  /** Warnings (content can be published but may not perform well) */
+  warnings: string[];
+}
+
+// ===========================================
+// Publisher Interface
+// ===========================================
+
+/**
+ * Social media publisher interface
+ * All platform-specific publishers implement this interface.
+ */
+export interface SocialPublisher {
+  /** Platform identifier */
+  readonly platform: SocialPlatform;
+
+  /**
+   * Publish a post to the platform
+   */
+  publish(input: PublishPostInput): Promise<PublishResult>;
+
+  /**
+   * Retrieve analytics for a published post
+   */
+  getAnalytics(input: GetAnalyticsInput): Promise<AnalyticsResult>;
+
+  /**
+   * Validate content against platform limits
+   */
+  validateContent(content: string, hashtags: string[]): ContentValidationResult;
+}
+
+// ===========================================
+// Retry Configuration
+// ===========================================
+
+/**
+ * Retry configuration for API calls
+ */
+export interface RetryConfig {
+  /** Maximum number of retry attempts */
+  maxRetries: number;
+  /** Base delay between retries (ms) */
+  baseDelayMs: number;
+  /** Maximum delay between retries (ms) */
+  maxDelayMs: number;
+  /** Error patterns that should trigger retry */
+  retryableErrors: string[];
+}
+
+/**
+ * Default retry configuration
+ */
+export const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 30000,
+  retryableErrors: [
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ENOTFOUND',
+    'rate_limit',
+    'temporarily_unavailable',
+    '429',
+    '500',
+    '502',
+    '503',
+    '504',
+  ],
+};
+
+// ===========================================
+// Scheduling Types
+// ===========================================
+
+/**
+ * Scheduled post data
+ */
+export interface ScheduledPost {
+  /** Post ID */
+  id: string;
+  /** Platform to publish to */
+  platform: SocialPlatform;
+  /** Account ID to use */
+  accountId: string;
+  /** Post content */
+  content: string;
+  /** Media URLs */
+  mediaUrls: string[];
+  /** Hashtags */
+  hashtags: string[];
+  /** Link URL */
+  linkUrl: string | null;
+  /** Scheduled publish time */
+  scheduledAt: Date;
+  /** Current status */
+  status: 'pending' | 'processing' | 'published' | 'failed';
+  /** Number of retry attempts */
+  retryCount: number;
+  /** Error message if failed */
+  errorMessage?: string;
+  /** Metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Post storage interface for scheduler
+ */
+export interface PostStorage {
+  /** Get posts due for publishing */
+  getPostsDueForPublishing(): Promise<ScheduledPost[]>;
+
+  /** Update post status */
+  updatePostStatus(
+    postId: string,
+    status: ScheduledPost['status'],
+    data?: {
+      externalPostId?: string;
+      platformUrl?: string;
+      errorMessage?: string;
+      retryCount?: number;
+      publishedAt?: Date;
+    }
+  ): Promise<void>;
+
+  /** Get account details for publishing */
+  getAccountForPublishing(accountId: string): Promise<{
+    accessToken: string;
+    metadata: SocialAccountMetadata | null;
+  } | null>;
+}
+
+// ===========================================
+// Multi-Publisher Types
+// ===========================================
+
+/**
+ * Input for multi-platform publishing
+ */
+export interface MultiPublishInput {
+  /** Content (may be adapted per platform) */
+  content: string;
+  /** Media URLs */
+  mediaUrls: string[];
+  /** Hashtags */
+  hashtags: string[];
+  /** Link URL */
+  linkUrl: string | null;
+  /** Platforms to publish to */
+  platforms: Array<{
+    platform: SocialPlatform;
+    accountId: string;
+    accessToken: string;
+    metadata: SocialAccountMetadata | null;
+    /** Platform-specific content override */
+    contentOverride?: string;
+    /** Platform-specific hashtags override */
+    hashtagsOverride?: string[];
+  }>;
+  /** Base URL for media */
+  baseUrl?: string;
+  /** Adapt content per platform automatically */
+  adaptContent?: boolean;
+}
+
+/**
+ * Result of multi-platform publishing
+ */
+export interface MultiPublishResult {
+  /** Total platforms attempted */
+  total: number;
+  /** Successfully published */
+  successful: number;
+  /** Failed publications */
+  failed: number;
+  /** Results per platform */
+  results: Array<{
+    platform: SocialPlatform;
+    accountId: string;
+    result: PublishResult;
+  }>;
+}

--- a/packages/social/src/types.ts
+++ b/packages/social/src/types.ts
@@ -1,0 +1,403 @@
+/**
+ * @kairn/social - Types and Interfaces
+ *
+ * Core type definitions for the social media integration module.
+ */
+
+// ===========================================
+// Enums and Constants
+// ===========================================
+
+/**
+ * Supported social platforms
+ */
+export type SocialPlatform = 'FACEBOOK' | 'LINKEDIN' | 'INSTAGRAM' | 'TWITTER' | 'THREADS';
+
+/**
+ * Currently implemented platforms
+ */
+export const IMPLEMENTED_PLATFORMS: SocialPlatform[] = [
+  'FACEBOOK',
+  'LINKEDIN',
+  'INSTAGRAM',
+  'TWITTER',
+  'THREADS',
+];
+
+/**
+ * Post status values
+ */
+export type PostStatus =
+  | 'DRAFT'
+  | 'SCHEDULED'
+  | 'PUBLISHING'
+  | 'PUBLISHED'
+  | 'FAILED'
+  | 'CANCELLED';
+
+/**
+ * Content generation source
+ */
+export type GenerationSource = 'ai' | 'manual';
+
+/**
+ * Content tone options
+ */
+export type ContentTone = 'informatif' | 'inspirant' | 'promotionnel' | 'educatif' | 'personnel';
+
+/**
+ * Content angle options
+ */
+export type ContentAngle = 'benefices' | 'probleme' | 'histoire' | 'expert' | 'pratique';
+
+// ===========================================
+// Platform-specific post formats
+// ===========================================
+
+export type InstagramPostFormat =
+  | 'hook_reveal'
+  | 'liste_visuelle'
+  | 'micro_storytelling'
+  | 'question_rhethorique'
+  | 'citation_reflexion'
+  | 'mythe_realite';
+
+export type ThreadsPostFormat =
+  | 'pensee_brute'
+  | 'observation_cabinet'
+  | 'question_ouverte'
+  | 'micro_confession'
+  | 'fragment_poetique'
+  | 'contre_intuitif';
+
+export type FacebookPostFormat =
+  | 'confession'
+  | 'question_provocante'
+  | 'micro_histoire'
+  | 'liste_inversee'
+  | 'observation_cabinet'
+  | 'avant_apres';
+
+export type LinkedInPostFormat =
+  | 'observation_pro'
+  | 'contre_intuition'
+  | 'liste_puces'
+  | 'storytelling_court'
+  | 'question_provocante'
+  | 'temoignage_terrain';
+
+// ===========================================
+// Social Accounts
+// ===========================================
+
+/**
+ * Platform-specific metadata for accounts
+ */
+export interface SocialAccountMetadata {
+  // Facebook
+  pageId?: string;
+  pageName?: string;
+
+  // LinkedIn
+  organizationId?: string;
+  organizationName?: string;
+  personId?: string;
+
+  // Instagram
+  igUserId?: string;
+  igUsername?: string;
+  linkedFacebookPageId?: string;
+
+  // Threads
+  threadsUserId?: string;
+  threadsUsername?: string;
+
+  // Twitter
+  twitterUserId?: string;
+  twitterUsername?: string;
+
+  // Generic
+  profileUrl?: string;
+  avatarUrl?: string;
+}
+
+/**
+ * Public account data (without sensitive tokens)
+ */
+export interface SocialAccountPublic {
+  id: string;
+  platform: SocialPlatform;
+  accountId: string;
+  accountName: string;
+  tokenExpiry: Date | null;
+  scope: string[];
+  isActive: boolean;
+  lastUsed: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Full account data (with encrypted tokens)
+ */
+export interface SocialAccountFull extends SocialAccountPublic {
+  accessToken: string;
+  refreshToken: string | null;
+  metadata: SocialAccountMetadata | null;
+}
+
+/**
+ * Input for creating a social account
+ */
+export interface CreateSocialAccountInput {
+  platform: SocialPlatform;
+  accountId: string;
+  accountName: string;
+  accessToken: string;
+  refreshToken?: string;
+  tokenExpiry?: Date | null;
+  scope: string[];
+  metadata?: SocialAccountMetadata;
+}
+
+/**
+ * Input for updating a social account
+ */
+export interface UpdateSocialAccountInput {
+  accountName?: string;
+  accessToken?: string;
+  refreshToken?: string | null;
+  tokenExpiry?: Date | null;
+  scope?: string[];
+  metadata?: SocialAccountMetadata;
+  isActive?: boolean;
+}
+
+// ===========================================
+// Social Posts
+// ===========================================
+
+/**
+ * Post metadata
+ */
+export interface SocialPostMetadata {
+  tone?: ContentTone;
+  angle?: ContentAngle;
+  customInstructions?: string;
+  instagramFormat?: InstagramPostFormat;
+  threadsFormat?: ThreadsPostFormat;
+  facebookFormat?: FacebookPostFormat;
+  linkedinFormat?: LinkedInPostFormat;
+  articleCategory?: string;
+  articleTags?: string[];
+  publishAttempts?: number;
+  lastPublishError?: string;
+}
+
+/**
+ * Social post data
+ */
+export interface SocialPost {
+  id: string;
+  blogSlug: string | null;
+  blogTitle: string | null;
+  platform: SocialPlatform;
+  content: string;
+  mediaUrls: string[];
+  hashtags: string[];
+  linkUrl: string | null;
+  scheduledAt: Date | null;
+  publishedAt: Date | null;
+  status: PostStatus;
+  externalPostId: string | null;
+  platformUrl: string | null;
+  errorMessage: string | null;
+  retryCount: number;
+  generatedBy: GenerationSource | null;
+  aiPrompt: string | null;
+  aiModel: string | null;
+  metadata: SocialPostMetadata | null;
+  accountId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Post analytics data
+ */
+export interface SocialPostAnalytics {
+  id: string;
+  postId: string;
+  impressions: number;
+  reach: number;
+  engagements: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  saves: number;
+  clicks: number;
+  rawData: Record<string, unknown> | null;
+  fetchedAt: Date;
+  updatedAt: Date;
+}
+
+// ===========================================
+// Platform Specifications
+// ===========================================
+
+/**
+ * Platform specifications
+ */
+export interface PlatformSpecs {
+  platform: SocialPlatform;
+  name: string;
+  maxTextLength: number;
+  optimalTextLength: number;
+  maxHashtags: number;
+  optimalHashtags: number;
+  supportsLinks: boolean;
+  linkInComment: boolean;
+  requiresMedia: boolean;
+  imageRatio: string;
+  imageWidth: number;
+  imageHeight: number;
+}
+
+/**
+ * Platform specifications lookup
+ */
+export const PLATFORM_SPECS: Record<SocialPlatform, PlatformSpecs> = {
+  FACEBOOK: {
+    platform: 'FACEBOOK',
+    name: 'Facebook',
+    maxTextLength: 63206,
+    optimalTextLength: 80,
+    maxHashtags: 30,
+    optimalHashtags: 2,
+    supportsLinks: true,
+    linkInComment: false,
+    requiresMedia: false,
+    imageRatio: '1.91:1',
+    imageWidth: 1200,
+    imageHeight: 630,
+  },
+  LINKEDIN: {
+    platform: 'LINKEDIN',
+    name: 'LinkedIn',
+    maxTextLength: 3000,
+    optimalTextLength: 200,
+    maxHashtags: 30,
+    optimalHashtags: 5,
+    supportsLinks: true,
+    linkInComment: true,
+    requiresMedia: false,
+    imageRatio: '1.91:1',
+    imageWidth: 1200,
+    imageHeight: 627,
+  },
+  INSTAGRAM: {
+    platform: 'INSTAGRAM',
+    name: 'Instagram',
+    maxTextLength: 2200,
+    optimalTextLength: 150,
+    maxHashtags: 30,
+    optimalHashtags: 10,
+    supportsLinks: false,
+    linkInComment: false,
+    requiresMedia: true,
+    imageRatio: '1:1',
+    imageWidth: 1080,
+    imageHeight: 1080,
+  },
+  TWITTER: {
+    platform: 'TWITTER',
+    name: 'Twitter/X',
+    maxTextLength: 280,
+    optimalTextLength: 100,
+    maxHashtags: 5,
+    optimalHashtags: 2,
+    supportsLinks: true,
+    linkInComment: false,
+    requiresMedia: false,
+    imageRatio: '16:9',
+    imageWidth: 1200,
+    imageHeight: 675,
+  },
+  THREADS: {
+    platform: 'THREADS',
+    name: 'Threads',
+    maxTextLength: 500,
+    optimalTextLength: 150,
+    maxHashtags: 10,
+    optimalHashtags: 3,
+    supportsLinks: true,
+    linkInComment: false,
+    requiresMedia: false,
+    imageRatio: '1:1',
+    imageWidth: 1080,
+    imageHeight: 1080,
+  },
+};
+
+// ===========================================
+// Optimal Posting Times
+// ===========================================
+
+/**
+ * Optimal time slot definition
+ */
+export interface OptimalTimeSlot {
+  dayOfWeek: number;
+  hour: number;
+  priority: 'primary' | 'secondary';
+}
+
+/**
+ * Optimal posting times by platform
+ */
+export const OPTIMAL_POSTING_TIMES: Record<SocialPlatform, OptimalTimeSlot[]> = {
+  FACEBOOK: [
+    { dayOfWeek: 1, hour: 9, priority: 'primary' },
+    { dayOfWeek: 2, hour: 9, priority: 'primary' },
+    { dayOfWeek: 3, hour: 9, priority: 'primary' },
+    { dayOfWeek: 4, hour: 9, priority: 'primary' },
+    { dayOfWeek: 5, hour: 9, priority: 'primary' },
+    { dayOfWeek: 1, hour: 13, priority: 'secondary' },
+    { dayOfWeek: 2, hour: 13, priority: 'secondary' },
+    { dayOfWeek: 3, hour: 13, priority: 'secondary' },
+    { dayOfWeek: 6, hour: 10, priority: 'secondary' },
+    { dayOfWeek: 0, hour: 10, priority: 'secondary' },
+  ],
+  LINKEDIN: [
+    { dayOfWeek: 2, hour: 7, priority: 'primary' },
+    { dayOfWeek: 3, hour: 7, priority: 'primary' },
+    { dayOfWeek: 4, hour: 7, priority: 'primary' },
+    { dayOfWeek: 2, hour: 12, priority: 'secondary' },
+    { dayOfWeek: 3, hour: 12, priority: 'secondary' },
+    { dayOfWeek: 3, hour: 17, priority: 'secondary' },
+  ],
+  INSTAGRAM: [
+    { dayOfWeek: 0, hour: 10, priority: 'primary' },
+    { dayOfWeek: 1, hour: 11, priority: 'primary' },
+    { dayOfWeek: 2, hour: 11, priority: 'primary' },
+    { dayOfWeek: 3, hour: 11, priority: 'primary' },
+    { dayOfWeek: 4, hour: 11, priority: 'primary' },
+    { dayOfWeek: 5, hour: 11, priority: 'primary' },
+    { dayOfWeek: 6, hour: 10, priority: 'primary' },
+    { dayOfWeek: 0, hour: 19, priority: 'secondary' },
+    { dayOfWeek: 1, hour: 19, priority: 'secondary' },
+    { dayOfWeek: 2, hour: 19, priority: 'secondary' },
+  ],
+  TWITTER: [
+    { dayOfWeek: 1, hour: 8, priority: 'primary' },
+    { dayOfWeek: 2, hour: 8, priority: 'primary' },
+    { dayOfWeek: 3, hour: 8, priority: 'primary' },
+    { dayOfWeek: 4, hour: 8, priority: 'primary' },
+    { dayOfWeek: 5, hour: 8, priority: 'primary' },
+  ],
+  THREADS: [
+    { dayOfWeek: 1, hour: 10, priority: 'primary' },
+    { dayOfWeek: 2, hour: 10, priority: 'primary' },
+    { dayOfWeek: 3, hour: 10, priority: 'primary' },
+  ],
+};

--- a/packages/social/src/utils/crypto.ts
+++ b/packages/social/src/utils/crypto.ts
@@ -1,0 +1,232 @@
+/**
+ * @kairn/social - Token Encryption Module
+ *
+ * Provides AES-256-GCM encryption for storing OAuth tokens securely.
+ *
+ * Security:
+ * - AES-256-GCM provides both confidentiality and integrity
+ * - Unique IV per encryption (16 bytes)
+ * - Auth tag for integrity verification (16 bytes)
+ *
+ * Format: iv:authTag:encryptedData (hexadecimal)
+ */
+
+import * as crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+
+/**
+ * Encryption configuration
+ */
+export interface EncryptionConfig {
+  /** 64-character hex key (32 bytes) */
+  encryptionKey?: string;
+  /** Environment variable name for the key */
+  keyEnvVar?: string;
+}
+
+const defaultConfig: EncryptionConfig = {
+  keyEnvVar: 'SOCIAL_ENCRYPTION_KEY',
+};
+
+/**
+ * Get the encryption key from configuration or environment
+ */
+function getEncryptionKey(config: EncryptionConfig = defaultConfig): Buffer {
+  const keyHex = config.encryptionKey || process.env[config.keyEnvVar || 'SOCIAL_ENCRYPTION_KEY'];
+
+  if (!keyHex) {
+    throw new Error(
+      `[SocialCrypto] Encryption key not configured. ` +
+        `Set ${config.keyEnvVar || 'SOCIAL_ENCRYPTION_KEY'} or pass encryptionKey option. ` +
+        `Generate with: openssl rand -hex 32`
+    );
+  }
+
+  if (!/^[0-9a-fA-F]{64}$/.test(keyHex)) {
+    throw new Error(
+      `[SocialCrypto] Invalid encryption key format. ` +
+        `Key must be 64 hexadecimal characters (32 bytes).`
+    );
+  }
+
+  return Buffer.from(keyHex, 'hex');
+}
+
+/**
+ * Encrypt a token using AES-256-GCM
+ *
+ * @param plaintext - The token to encrypt
+ * @param config - Optional encryption configuration
+ * @returns Encrypted token in format iv:authTag:ciphertext (hex)
+ *
+ * @example
+ * const encrypted = encryptToken('access_token_12345');
+ * // Returns: "a1b2c3...:d4e5f6...:g7h8i9..."
+ */
+export function encryptToken(plaintext: string, config?: EncryptionConfig): string {
+  if (!plaintext) {
+    throw new Error('[SocialCrypto] Cannot encrypt empty token');
+  }
+
+  try {
+    const key = getEncryptionKey(config);
+    const iv = crypto.randomBytes(IV_LENGTH);
+
+    const cipher = crypto.createCipheriv(ALGORITHM, key, iv, {
+      authTagLength: AUTH_TAG_LENGTH,
+    });
+
+    let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    const authTag = cipher.getAuthTag();
+
+    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('[SocialCrypto]')) {
+      throw error;
+    }
+    throw new Error(
+      `[SocialCrypto] Encryption error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+/**
+ * Decrypt a token encrypted with AES-256-GCM
+ *
+ * @param encryptedData - Encrypted token in format iv:authTag:ciphertext
+ * @param config - Optional encryption configuration
+ * @returns Decrypted token
+ *
+ * @example
+ * const decrypted = decryptToken("a1b2c3...:d4e5f6...:g7h8i9...");
+ * // Returns: "access_token_12345"
+ */
+export function decryptToken(encryptedData: string, config?: EncryptionConfig): string {
+  if (!encryptedData) {
+    throw new Error('[SocialCrypto] Cannot decrypt empty token');
+  }
+
+  try {
+    const parts = encryptedData.split(':');
+
+    if (parts.length !== 3) {
+      throw new Error(
+        '[SocialCrypto] Invalid encrypted token format. Expected: iv:authTag:ciphertext'
+      );
+    }
+
+    const ivHex = parts[0]!;
+    const authTagHex = parts[1]!;
+    const ciphertext = parts[2]!;
+
+    if (ivHex.length !== IV_LENGTH * 2) {
+      throw new Error('[SocialCrypto] Invalid IV length');
+    }
+    if (authTagHex.length !== AUTH_TAG_LENGTH * 2) {
+      throw new Error('[SocialCrypto] Invalid auth tag length');
+    }
+
+    const key = getEncryptionKey(config);
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, {
+      authTagLength: AUTH_TAG_LENGTH,
+    });
+
+    decipher.setAuthTag(authTag);
+
+    let decrypted = decipher.update(ciphertext, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+
+    return decrypted;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('[SocialCrypto]')) {
+      throw error;
+    }
+    if (
+      error instanceof Error &&
+      error.message.includes('Unsupported state or unable to authenticate data')
+    ) {
+      throw new Error(
+        `[SocialCrypto] Token authentication failed. ` +
+          `The token may have been tampered with or the encryption key has changed.`
+      );
+    }
+    throw new Error(
+      `[SocialCrypto] Decryption error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+/**
+ * Check if a string is in valid encrypted token format
+ *
+ * @param data - String to check
+ * @returns true if the format matches an encrypted token
+ */
+export function isEncryptedToken(data: string): boolean {
+  if (!data) return false;
+
+  const parts = data.split(':');
+  if (parts.length !== 3) return false;
+
+  const ivHex = parts[0];
+  const authTagHex = parts[1];
+  const ciphertext = parts[2];
+  const hexRegex = /^[0-9a-fA-F]+$/;
+
+  return (
+    ivHex !== undefined &&
+    authTagHex !== undefined &&
+    ciphertext !== undefined &&
+    ivHex.length === IV_LENGTH * 2 &&
+    authTagHex.length === AUTH_TAG_LENGTH * 2 &&
+    ciphertext.length > 0 &&
+    hexRegex.test(ivHex) &&
+    hexRegex.test(authTagHex) &&
+    hexRegex.test(ciphertext)
+  );
+}
+
+/**
+ * Generate a new encryption key
+ *
+ * @returns 64-character hex string (32 bytes)
+ */
+export function generateEncryptionKey(): string {
+  return crypto.randomBytes(KEY_LENGTH).toString('hex');
+}
+
+/**
+ * Test encryption/decryption with current configuration
+ *
+ * @param config - Optional encryption configuration
+ * @returns true if encryption test passes
+ */
+export function testEncryption(config?: EncryptionConfig): boolean {
+  try {
+    const testData = `test_token_${Date.now()}`;
+    const encrypted = encryptToken(testData, config);
+    const decrypted = decryptToken(encrypted, config);
+    return decrypted === testData;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Generate a random state token for OAuth CSRF protection
+ *
+ * @param length - Number of random bytes (default: 32)
+ * @returns Hex-encoded random string
+ */
+export function generateStateToken(length = 32): string {
+  return crypto.randomBytes(length).toString('hex');
+}

--- a/packages/social/src/utils/index.ts
+++ b/packages/social/src/utils/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @kairn/social/utils - Utility Functions
+ */
+
+export * from './crypto';
+export * from './utm';

--- a/packages/social/src/utils/utm.ts
+++ b/packages/social/src/utils/utm.ts
@@ -1,0 +1,163 @@
+/**
+ * @kairn/social - UTM Parameter Utilities
+ *
+ * Automatically adds UTM tracking parameters to URLs shared on social media.
+ */
+
+import type { SocialPlatform } from '../types';
+
+/**
+ * UTM parameter options
+ */
+export interface UtmParams {
+  /** Source platform (facebook, linkedin, instagram, twitter, threads) */
+  source: string;
+  /** Campaign medium (default: 'social') */
+  medium?: string;
+  /** Campaign name (optional, e.g., article slug or seminar ID) */
+  campaign?: string;
+  /** Campaign content (optional, e.g., 'blog', 'seminar') */
+  content?: string;
+  /** Search term (rarely used for social) */
+  term?: string;
+}
+
+/**
+ * Platform to UTM source name mapping
+ */
+const PLATFORM_SOURCE_MAP: Record<SocialPlatform, string> = {
+  FACEBOOK: 'facebook',
+  LINKEDIN: 'linkedin',
+  INSTAGRAM: 'instagram',
+  TWITTER: 'twitter',
+  THREADS: 'threads',
+};
+
+/**
+ * Build a URL with UTM parameters
+ *
+ * @param baseUrl - The base URL to enrich
+ * @param params - UTM parameters to add
+ * @returns URL with UTM parameters
+ *
+ * @example
+ * ```ts
+ * const url = buildUrlWithUtm('https://example.com/blog/article', {
+ *   source: 'FACEBOOK',
+ *   campaign: 'my-article',
+ *   content: 'blog',
+ * });
+ * // => https://example.com/blog/article?utm_source=facebook&utm_medium=social&utm_campaign=my-article&utm_content=blog
+ * ```
+ */
+export function buildUrlWithUtm(baseUrl: string, params: UtmParams): string {
+  if (!baseUrl) {
+    return baseUrl;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+
+    // Source (required)
+    const source =
+      typeof params.source === 'string' && params.source in PLATFORM_SOURCE_MAP
+        ? PLATFORM_SOURCE_MAP[params.source as SocialPlatform]
+        : params.source.toLowerCase();
+    url.searchParams.set('utm_source', source);
+
+    // Medium (default: social)
+    url.searchParams.set('utm_medium', params.medium || 'social');
+
+    // Campaign (optional)
+    if (params.campaign) {
+      url.searchParams.set('utm_campaign', params.campaign);
+    }
+
+    // Content (optional)
+    if (params.content) {
+      url.searchParams.set('utm_content', params.content);
+    }
+
+    // Term (optional)
+    if (params.term) {
+      url.searchParams.set('utm_term', params.term);
+    }
+
+    return url.toString();
+  } catch {
+    // If URL is invalid, return base URL
+    return baseUrl;
+  }
+}
+
+/**
+ * Build URL with UTM for a blog article
+ *
+ * @param baseUrl - Article URL
+ * @param platform - Sharing platform
+ * @param blogSlug - Article slug (optional, used for campaign)
+ */
+export function buildBlogUrlWithUtm(
+  baseUrl: string,
+  platform: SocialPlatform,
+  blogSlug?: string
+): string {
+  return buildUrlWithUtm(baseUrl, {
+    source: platform,
+    medium: 'social',
+    campaign: blogSlug || undefined,
+    content: 'blog',
+  });
+}
+
+/**
+ * Build URL with UTM for a seminar
+ *
+ * @param baseUrl - Seminar URL
+ * @param platform - Sharing platform
+ * @param seminarId - Seminar ID (optional, used for campaign)
+ */
+export function buildSeminarUrlWithUtm(
+  baseUrl: string,
+  platform: SocialPlatform,
+  seminarId?: string
+): string {
+  return buildUrlWithUtm(baseUrl, {
+    source: platform,
+    medium: 'social',
+    campaign: seminarId ? `seminar-${seminarId}` : undefined,
+    content: 'seminar',
+  });
+}
+
+/**
+ * Extract UTM parameters from a URL
+ *
+ * @param url - URL to analyze
+ * @returns Extracted UTM parameters
+ */
+export function extractUtmParams(url: string): Partial<UtmParams> {
+  try {
+    const urlObj = new URL(url);
+    const params: Partial<UtmParams> = {};
+
+    const source = urlObj.searchParams.get('utm_source');
+    if (source) params.source = source;
+
+    const medium = urlObj.searchParams.get('utm_medium');
+    if (medium) params.medium = medium;
+
+    const campaign = urlObj.searchParams.get('utm_campaign');
+    if (campaign) params.campaign = campaign;
+
+    const content = urlObj.searchParams.get('utm_content');
+    if (content) params.content = content;
+
+    const term = urlObj.searchParams.get('utm_term');
+    if (term) params.term = term;
+
+    return params;
+  } catch {
+    return {};
+  }
+}

--- a/packages/social/tsconfig.json
+++ b/packages/social/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@kairn/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,9 +494,15 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@kairn/eslint-config':
+        specifier: workspace:*
+        version: link:../../tooling/eslint-config
       '@kairn/typescript-config':
         specifier: workspace:*
         version: link:../../tooling/typescript-config
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.30
       typescript:
         specifier: ^5.4.0
         version: 5.9.3


### PR DESCRIPTION
Add OAuth flows for all social platforms:
- Facebook OAuth provider with long-lived token exchange
- Instagram OAuth via Facebook Graph API
- LinkedIn OAuth with OpenID Connect
- Twitter OAuth 2.0 with PKCE support
- Threads OAuth provider

Add publishing capabilities:
- Platform-specific publishers (Facebook, Instagram, LinkedIn, Twitter, Threads)
- Multi-publisher for simultaneous cross-platform posting
- Post scheduler for automated publishing
- Content validation per platform specifications

Add utilities:
- AES-256-GCM token encryption
- UTM tracking parameter builder
- Token manager with automatic refresh

Exports available at:
- @kairn/social (core types)
- @kairn/social/oauth (authentication)
- @kairn/social/posting (publishing)
- @kairn/social/utils (utilities)