### PR TITLE
Replace static data with API calls in blog, seminars & testimonials

### DIFF
--- a/apps/psypnos/app/(pages)/sections/blog.tsx
+++ b/apps/psypnos/app/(pages)/sections/blog.tsx
@@ -1,37 +1,23 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { CTAButton } from "../../../components/CTAButton";
 import { SectionTitle } from "../../../components/SectionTitle";
 
-// Articles statiques (à remplacer par API plus tard)
-const blogPosts = [
-  {
-    slug: "comprendre-anxiete",
-    title: "Comprendre l'anxiété : origines et accompagnement",
-    excerpt: "L'anxiété est une réponse naturelle du corps face au stress. Découvrez comment la psychothérapie et l'hypnose peuvent vous aider à mieux la gérer.",
-    category: "Psychothérapie",
-    date: "2024-01-15",
-    readingTime: "5 min",
-  },
-  {
-    slug: "hypnose-mythes-realites",
-    title: "L'hypnose ericksonienne : mythes et réalités",
-    excerpt: "Loin des clichés du spectacle, l'hypnose ericksonienne est un outil thérapeutique puissant et respectueux de votre autonomie.",
-    category: "Hypnose",
-    date: "2024-01-10",
-    readingTime: "7 min",
-  },
-  {
-    slug: "respiration-holotropique-introduction",
-    title: "Introduction à la respiration holotropique",
-    excerpt: "Découvrez cette technique de respiration profonde qui permet d'accéder à des états modifiés de conscience pour la guérison et la transformation.",
-    category: "Respiration",
-    date: "2024-01-05",
-    readingTime: "6 min",
-  },
-];
+interface BlogPost {
+  slug: string;
+  title: string;
+  description?: string;
+  author: string;
+  category: string;
+  tags: string[];
+  image?: string;
+  published: boolean;
+  featured: boolean;
+  date: string;
+}
 
 const defaultColors = { bg: "bg-gold/20", text: "text-gold", gradient: "from-gold to-gold/60" };
 
@@ -42,7 +28,31 @@ const categoryColors: Record<string, { bg: string; text: string; gradient: strin
 };
 
 export function BlogSection() {
+  const [blogPosts, setBlogPosts] = useState<BlogPost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchPosts() {
+      try {
+        const response = await fetch("/api/blog/posts?limit=3&featuredFirst=true");
+        if (response.ok) {
+          const data = await response.json();
+          setBlogPosts(data);
+        }
+      } catch (error) {
+        console.error("Erreur lors du chargement des articles:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchPosts();
+  }, []);
+
   // Ne pas afficher la section si pas d'articles
+  if (loading) {
+    return null;
+  }
+
   if (blogPosts.length === 0) {
     return null;
   }
@@ -100,9 +110,9 @@ export function BlogSection() {
                     {post.title}
                   </h3>
 
-                  {/* Excerpt */}
+                  {/* Description */}
                   <p className="mb-4 flex-1 line-clamp-3 text-sm text-ivory/70">
-                    {post.excerpt}
+                    {post.description}
                   </p>
 
                   {/* Métadonnées */}
@@ -112,12 +122,6 @@ export function BlogSection() {
                         <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
                       <time dateTime={post.date}>{formattedDate}</time>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      <span>{post.readingTime}</span>
                     </div>
                   </div>
 

--- a/apps/psypnos/app/(pages)/sections/seminars.tsx
+++ b/apps/psypnos/app/(pages)/sections/seminars.tsx
@@ -1,22 +1,64 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { CTAButton } from "../../../components/CTAButton";
 import { SectionTitle } from "../../../components/SectionTitle";
 
-// Données statiques pour les séminaires à venir (à remplacer par API plus tard)
-const upcomingSeminars = [
-  {
-    id: "1",
-    title: "Séminaire de Respiration Holotropique",
-    description: "Un week-end d'exploration intérieure à travers la respiration holotropique, dans le cadre enchanteur du Moulin d'en Bas.",
-    date: "Dates à venir",
-    location: "Le Moulin d'en Bas, Saint-Julien du Sault",
-    seminarType: "Respiration Holotropique",
-  },
-];
+interface Seminar {
+  id: string;
+  title: string;
+  description: string;
+  speakers: Array<{ firstName: string; lastName: string }>;
+  startAt: string;
+  endAt: string;
+  capacity: number;
+  price?: number;
+  deposit?: number;
+  tags: string[];
+  thumbnail?: string;
+  seminarType?: string;
+}
+
+function formatSeminarDate(startAt: string, endAt: string): string {
+  const start = new Date(startAt);
+  const end = new Date(endAt);
+  const options: Intl.DateTimeFormatOptions = { day: "numeric", month: "long", year: "numeric" };
+
+  if (start.toDateString() === end.toDateString()) {
+    return start.toLocaleDateString("fr-FR", options);
+  }
+
+  const startStr = start.toLocaleDateString("fr-FR", { day: "numeric", month: "long" });
+  const endStr = end.toLocaleDateString("fr-FR", options);
+  return `${startStr} - ${endStr}`;
+}
 
 export function SeminarsSection() {
+  const [upcomingSeminars, setUpcomingSeminars] = useState<Seminar[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchSeminars() {
+      try {
+        const response = await fetch("/api/seminars?upcoming=true&limit=3");
+        if (response.ok) {
+          const data = await response.json();
+          setUpcomingSeminars(data);
+        }
+      } catch (error) {
+        console.error("Erreur lors du chargement des séminaires:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSeminars();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
   return (
     <section
       id="seminaires"
@@ -30,7 +72,7 @@ export function SeminarsSection() {
         />
         <div className="grid gap-10 md:grid-cols-3">
           {upcomingSeminars.length > 0 ? (
-            upcomingSeminars.map(({ id, title, description, date, location, seminarType }, index) => (
+            upcomingSeminars.map(({ id, title, description, startAt, endAt, seminarType, capacity }, index) => (
               <motion.article
                 key={id}
                 initial={{ opacity: 0, y: 24 }}
@@ -61,14 +103,13 @@ export function SeminarsSection() {
                       <svg className="h-4 w-4 flex-shrink-0 text-gold" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
-                      <span>{date}</span>
+                      <span>{formatSeminarDate(startAt, endAt)}</span>
                     </div>
                     <div className="flex items-center gap-2">
                       <svg className="h-4 w-4 flex-shrink-0 text-gold" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                       </svg>
-                      <span>{location}</span>
+                      <span>{capacity} places</span>
                     </div>
                   </dl>
                   <div className="mt-6 flex justify-center">

--- a/apps/psypnos/app/(pages)/sections/testimonials.tsx
+++ b/apps/psypnos/app/(pages)/sections/testimonials.tsx
@@ -1,31 +1,17 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { SectionTitle } from "../../../components/SectionTitle";
 
-// Témoignages statiques (à remplacer par API plus tard)
-const testimonials = [
-  {
-    id: "1",
-    quote: "David m'a accompagné avec une bienveillance rare dans une période très difficile de ma vie. Grâce à son écoute et à l'hypnose, j'ai pu traverser mon deuil et retrouver un équilibre intérieur.",
-    author: "Marie L.",
-    role: "Accompagnement deuil",
-  },
-  {
-    id: "2",
-    quote: "Les séances d'hypnose avec David ont été transformatrices. J'ai enfin pu me libérer de mon anxiété chronique et retrouver confiance en moi. Une approche douce et profondément humaine.",
-    author: "Thomas B.",
-    role: "Gestion de l'anxiété",
-  },
-  {
-    id: "3",
-    quote: "Le séminaire de respiration holotropique au Moulin d'en Bas a été une expérience unique. Un cadre magnifique, un accompagnement sécurisant et une transformation profonde.",
-    author: "Sophie M.",
-    role: "Séminaire respiration holotropique",
-  },
-];
+interface Testimonial {
+  id: string;
+  quote: string;
+  author: string;
+  role?: string;
+}
 
-function TestimonialCard({ quote, author, role, index }: { quote: string; author: string; role: string; index: number }) {
+function TestimonialCard({ quote, author, role, index }: { quote: string; author: string; role?: string; index: number }) {
   return (
     <motion.article
       initial={{ opacity: 0, y: 24 }}
@@ -42,13 +28,37 @@ function TestimonialCard({ quote, author, role, index }: { quote: string; author
       </div>
       <div className="mt-6 border-t border-ivory/10 pt-4">
         <p className="font-semibold text-gold">{author}</p>
-        <p className="text-sm text-ivory/60">{role}</p>
+        {role && <p className="text-sm text-ivory/60">{role}</p>}
       </div>
     </motion.article>
   );
 }
 
 export function TestimonialsSection() {
+  const [testimonials, setTestimonials] = useState<Testimonial[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchTestimonials() {
+      try {
+        const response = await fetch("/api/testimonials?limit=3");
+        if (response.ok) {
+          const data = await response.json();
+          setTestimonials(data);
+        }
+      } catch (error) {
+        console.error("Erreur lors du chargement des témoignages:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchTestimonials();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
   return (
     <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">


### PR DESCRIPTION
## Description

Replace hardcoded static data with dynamic API calls in three main sections of the PSYPNOS website:

- **Blog Section**: Fetch blog posts from `/api/blog/posts` endpoint with featured posts prioritized
- **Seminars Section**: Fetch upcoming seminars from `/api/seminars` endpoint with proper date formatting
- **Testimonials Section**: Fetch testimonials from `/api/testimonials` endpoint

### Key Changes:
- Added `useEffect` hooks to fetch data on component mount
- Implemented loading states to prevent rendering during data fetch
- Updated TypeScript interfaces to match API response structures
- Removed hardcoded mock data
- Updated field mappings (e.g., `excerpt` → `description`, `date` → `startAt`/`endAt`)
- Improved date formatting for seminars (handles multi-day events)
- Removed `readingTime` display from blog posts (no longer in API)
- Changed location display to capacity in seminars section

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [ ] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [ ] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : préciser