### PR TITLE
Fix hydration mismatches in seminars and registration form

### DIFF
--- a/apps/psypnos/app/(pages)/sections/seminars.tsx
+++ b/apps/psypnos/app/(pages)/sections/seminars.tsx
@@ -23,13 +23,13 @@ interface Seminar {
 function formatSeminarDate(startAt: string, endAt: string): string {
   const start = new Date(startAt);
   const end = new Date(endAt);
-  const options: Intl.DateTimeFormatOptions = { day: "numeric", month: "long", year: "numeric" };
+  const options: Intl.DateTimeFormatOptions = { day: "numeric", month: "long", year: "numeric", timeZone: "Europe/Paris" };
 
   if (start.toDateString() === end.toDateString()) {
     return start.toLocaleDateString("fr-FR", options);
   }
 
-  const startStr = start.toLocaleDateString("fr-FR", { day: "numeric", month: "long" });
+  const startStr = start.toLocaleDateString("fr-FR", { day: "numeric", month: "long", timeZone: "Europe/Paris" });
   const endStr = end.toLocaleDateString("fr-FR", options);
   return `${startStr} - ${endStr}`;
 }
@@ -37,6 +37,12 @@ function formatSeminarDate(startAt: string, endAt: string): string {
 export function SeminarsSection() {
   const [upcomingSeminars, setUpcomingSeminars] = useState<Seminar[]>([]);
   const [loading, setLoading] = useState(true);
+  const [hasMounted, setHasMounted] = useState(false);
+
+  // Track mounting to avoid hydration mismatch
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   useEffect(() => {
     async function fetchSeminars() {
@@ -55,8 +61,40 @@ export function SeminarsSection() {
     fetchSeminars();
   }, []);
 
-  if (loading) {
-    return null;
+  // During SSR and initial client render, show skeleton to prevent hydration mismatch
+  if (!hasMounted || loading) {
+    return (
+      <section
+        id="seminaires"
+        className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16"
+      >
+        <div className="mx-auto max-w-6xl space-y-12">
+          <SectionTitle
+            eyebrow="Séminaires à venir"
+            title="Une exploration profonde au Cœur de Soi"
+            description="Nos séminaires sont limités en places pour préserver une attention personnalisée et un cercle intime."
+          />
+          <div className="grid gap-10 md:grid-cols-3">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="flex h-full flex-col overflow-hidden rounded-3xl border border-ivory/10 bg-night/50 shadow-xl shadow-night/60 animate-pulse"
+              >
+                <div className="aspect-[16/9] w-full bg-night/80" />
+                <div className="flex flex-1 flex-col justify-between p-6 space-y-4">
+                  <div className="h-6 bg-ivory/10 rounded w-3/4" />
+                  <div className="space-y-2">
+                    <div className="h-4 bg-ivory/10 rounded" />
+                    <div className="h-4 bg-ivory/10 rounded w-5/6" />
+                  </div>
+                  <div className="h-10 bg-ivory/10 rounded-full w-1/2 mx-auto" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    );
   }
 
   return (

--- a/apps/psypnos/components/SeminarRegistration/index.tsx
+++ b/apps/psypnos/components/SeminarRegistration/index.tsx
@@ -7,7 +7,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
 
@@ -21,7 +21,7 @@ import { IdentitySection } from "./components/IdentitySection";
 import { SeminarSection } from "./components/SeminarSection";
 import { FormField } from "./components/FormField";
 import { FORM_VARIANTS, FIELD_MOTION, ALL_FIELDS_TOUCHED, COUNTRY_LIST, REASSURANCE_MESSAGES } from "./constants";
-import { MIN_BIRTH_YEAR, MAX_BIRTH_YEAR } from "./schema";
+import { getBirthYearBounds } from "./schema";
 import { joinClassNames } from "./utils";
 
 const CARD_SECTION_CLASS =
@@ -35,6 +35,15 @@ export default function SeminarRegistrationForm() {
   const [generalError, setGeneralError] = useState<string | null>(null);
   const [isMutationPending, setIsMutationPending] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hasMounted, setHasMounted] = useState(false);
+
+  // Get birth year bounds at runtime to avoid hydration mismatch
+  const { minBirthYear, maxBirthYear } = useMemo(() => getBirthYearBounds(), []);
+
+  // Track mounting to avoid hydration mismatch with date-based filtering
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   const {
     formValues,
@@ -51,11 +60,20 @@ export default function SeminarRegistrationForm() {
   const { executeRecaptcha } = useGoogleReCaptcha();
   const { csrfToken, isLoading: csrfLoading, error: csrfError, refreshToken } = useCSRF();
 
-  // Séminaires depuis le JSON
+  // Séminaires depuis le JSON - defer date filtering to client-side only
   const seminars: Seminar[] = useMemo(() => {
     const list = Array.isArray((seminarsData as any)?.seminars)
       ? ((seminarsData as any).seminars as Seminar[])
       : [];
+
+    // On server/initial render, return all seminars sorted by date
+    // On client after mount, filter by current date
+    if (!hasMounted) {
+      return list.sort(
+        (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
+      );
+    }
+
     const now = new Date();
     const upcomingSeminars = list.filter(
       (seminar) => new Date(seminar.startAt).getTime() >= now.getTime()
@@ -63,7 +81,7 @@ export default function SeminarRegistrationForm() {
     return upcomingSeminars.sort(
       (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
     );
-  }, []);
+  }, [hasMounted]);
 
   const selectedSeminar = useMemo(
     () => seminars.find((s) => s.id === formValues.seminarId),
@@ -218,8 +236,8 @@ export default function SeminarRegistrationForm() {
               label="Année de naissance"
               type="number"
               placeholder="YYYY"
-              min={MIN_BIRTH_YEAR}
-              max={MAX_BIRTH_YEAR}
+              min={minBirthYear}
+              max={maxBirthYear}
               inputMode="numeric"
               value={formValues.birthYear}
               onChange={handleChange("birthYear")}

--- a/apps/psypnos/components/SeminarRegistration/schema.ts
+++ b/apps/psypnos/components/SeminarRegistration/schema.ts
@@ -6,9 +6,20 @@
 
 import { z } from "zod";
 
-const CURRENT_YEAR = new Date().getFullYear();
-const MIN_BIRTH_YEAR = CURRENT_YEAR - 100;
-const MAX_BIRTH_YEAR = CURRENT_YEAR - 16;
+// Use a fixed reference year for schema validation to avoid hydration mismatches
+// The schema uses conservative bounds that will always be valid
+const REFERENCE_YEAR = 2025;
+const SCHEMA_MIN_BIRTH_YEAR = REFERENCE_YEAR - 100; // 1925
+const SCHEMA_MAX_BIRTH_YEAR = REFERENCE_YEAR - 16;  // 2009
+
+// Runtime function to get accurate birth year bounds (use in UI only)
+export function getBirthYearBounds() {
+  const currentYear = new Date().getFullYear();
+  return {
+    minBirthYear: currentYear - 100,
+    maxBirthYear: currentYear - 16,
+  };
+}
 
 const sexSchema = z
   .union([z.literal("homme"), z.literal("femme"), z.literal("autre"), z.literal("")])
@@ -54,8 +65,8 @@ export const seminarRegistrationSchema = z.object({
   birthYear: z.coerce
     .number()
     .int("L'année doit être un nombre entier.")
-    .gte(MIN_BIRTH_YEAR, `Veuillez indiquer une année ≥ ${MIN_BIRTH_YEAR}.`)
-    .lte(MAX_BIRTH_YEAR, `Veuillez indiquer une année ≤ ${MAX_BIRTH_YEAR}.`),
+    .gte(SCHEMA_MIN_BIRTH_YEAR, `Veuillez indiquer une année valide.`)
+    .lte(SCHEMA_MAX_BIRTH_YEAR, `Veuillez indiquer une année valide (vous devez avoir au moins 16 ans).`),
   sex: sexSchema,
   sexOther: z
     .string()
@@ -119,4 +130,6 @@ export const seminarRegistrationSchema = z.object({
   }
 });
 
-export { MIN_BIRTH_YEAR, MAX_BIRTH_YEAR };
+// Export for backwards compatibility if needed elsewhere
+export const MIN_BIRTH_YEAR = SCHEMA_MIN_BIRTH_YEAR;
+export const MAX_BIRTH_YEAR = SCHEMA_MAX_BIRTH_YEAR;


### PR DESCRIPTION
## Description

This PR fixes hydration mismatches between server-side rendering (SSR) and client-side rendering in the seminars section and seminar registration form. The issues were caused by:

1. **Date/timezone-dependent rendering**: The seminar date formatting and filtering logic depended on the current date/time, which could differ between server and client
2. **Dynamic birth year bounds**: Birth year validation limits were calculated at runtime, causing different values on server vs client
3. **Missing loading state**: The seminars section returned `null` during loading, which could cause hydration mismatches

### Changes made:

**seminars.tsx:**
- Added `hasMounted` state to track client-side mounting
- Added timezone specification ("Europe/Paris") to date formatting for consistency
- Replaced `null` loading state with a skeleton UI that matches the final layout
- Only render actual content after client-side mount to ensure consistency

**SeminarRegistration/index.tsx:**
- Added `hasMounted` state to defer date-based filtering to client-side only
- Replaced hardcoded `MIN_BIRTH_YEAR` and `MAX_BIRTH_YEAR` with runtime `getBirthYearBounds()` function
- Modified seminar filtering to return all seminars on server/initial render, then filter on client after mount
- Updated birth year input constraints to use runtime-calculated bounds

**schema.ts:**
- Introduced `getBirthYearBounds()` function for runtime calculation of birth year limits
- Changed schema validation to use fixed reference year (2025) for consistent server-side validation
- Updated error messages to be more generic (avoiding year-specific text that could mismatch)
- Maintained backwards compatibility by exporting the schema constants

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre