### PR TITLE
feat(ui): harmonize H1 titles with design charter

### DIFF
--- a/apps/psypnos/app/(pages)/sections/hero.tsx
+++ b/apps/psypnos/app/(pages)/sections/hero.tsx
@@ -140,10 +140,10 @@ export function HeroSection() {
           transition={hasMounted ? { duration: 0.8, delay: 3.3, ease: "easeOut" } : { duration: 0 }}
           className="max-w-3xl"
         >
-          <h1 className="text-2xl font-semibold text-ivory sm:text-3xl lg:text-4xl">
+          <h1 className="font-display text-3xl font-bold text-gold sm:text-4xl lg:text-5xl">
             {heroContent.h1}
           </h1>
-          <h2 className="mt-4 text-3xl font-semibold text-gold sm:text-4xl lg:text-5xl">
+          <h2 className="mt-4 text-2xl font-semibold text-ivory sm:text-3xl lg:text-4xl">
             <span className="block">{heroContent.slogan1}</span>
             <span className="block">{heroContent.slogan2}</span>
           </h2>

--- a/packages/ui/src/components/page-title.tsx
+++ b/packages/ui/src/components/page-title.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { cn } from '../utils/cn';
+
+export interface PageTitleProps {
+  /** The title text */
+  children: React.ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+  /** Size variant for responsive typography */
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  /** Color variant (uses CSS custom properties or Tailwind classes) */
+  color?: 'primary' | 'text' | 'custom';
+  /** Custom color class when color="custom" */
+  customColorClass?: string;
+  /** Whether to use display font (serif) or body font (sans-serif) */
+  useDisplayFont?: boolean;
+  /** Text alignment */
+  align?: 'left' | 'center' | 'right';
+  /** HTML tag to use (defaults to h1) */
+  as?: 'h1' | 'h2' | 'h3' | 'h4';
+}
+
+const sizeClasses = {
+  sm: 'text-2xl sm:text-3xl lg:text-4xl',
+  md: 'text-3xl sm:text-4xl lg:text-5xl',
+  lg: 'text-4xl sm:text-5xl lg:text-6xl',
+  xl: 'text-5xl sm:text-6xl lg:text-7xl',
+};
+
+const colorClasses = {
+  primary: 'text-gold',
+  text: 'text-ivory',
+  custom: '',
+};
+
+const alignClasses = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+};
+
+/**
+ * PageTitle component for consistent H1 styling across sites
+ *
+ * Follows the Kairn design charter:
+ * - Uses Playfair Display (font-display) for serif headings
+ * - Gold (#c7a962) as primary accent color
+ * - Bold weight for main titles
+ * - Responsive sizing with mobile-first approach
+ *
+ * @example
+ * ```tsx
+ * // Default usage (gold, display font, medium size)
+ * <PageTitle>Psychotherapist in Paris</PageTitle>
+ *
+ * // Custom size and alignment
+ * <PageTitle size="lg" align="center">
+ *   Welcome to Our Practice
+ * </PageTitle>
+ *
+ * // With custom color class
+ * <PageTitle color="custom" customColorClass="text-blue-500">
+ *   Custom Styled Title
+ * </PageTitle>
+ *
+ * // As a different heading level
+ * <PageTitle as="h2" size="sm">
+ *   Section Title
+ * </PageTitle>
+ * ```
+ */
+export function PageTitle({
+  children,
+  className,
+  size = 'md',
+  color = 'primary',
+  customColorClass,
+  useDisplayFont = true,
+  align = 'left',
+  as: Component = 'h1',
+}: PageTitleProps) {
+  return (
+    <Component
+      className={cn(
+        'font-bold leading-tight',
+        useDisplayFont && 'font-display',
+        sizeClasses[size],
+        color === 'custom' ? customColorClass : colorClasses[color],
+        alignClasses[align],
+        className
+      )}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -133,5 +133,8 @@ export {
   type ServiceConfig,
 } from './components/seo';
 
+// Typography Components
+export { PageTitle, type PageTitleProps } from './components/page-title';
+
 // Utils
 export { cn } from './utils/cn';


### PR DESCRIPTION
- Update Psypnos homepage hero H1 to use font-display (Playfair Display),
  text-gold color and font-bold weight, matching the site's design charter
- Adjust H2 slogans to text-ivory for visual hierarchy contrast
- Create reusable PageTitle component in kairn-ui package for consistent
  H1 styling across sites
- Export PageTitle component and types from packages/ui

The H1 title now follows the same styling as geolocated pages, ensuring
visual consistency across the entire Psypnos website.

https://claude.ai/code/session_011iKizYfPYt9pgiGGEeqYLH