### PR TITLE
Refactor hero section heading styling and content

### DIFF
--- a/apps/psypnos/app/(pages)/sections/hero.tsx
+++ b/apps/psypnos/app/(pages)/sections/hero.tsx
@@ -8,7 +8,7 @@ import { useRef, useEffect, useState } from 'react';
 import { CTAButton } from '../../../components/CTAButton';
 
 const heroContent = {
-  h1: 'Psychothérapeute et Hypnothérapeute à Saint-Julien-du-Sault (Yonne)',
+  h1: 'Psychothérapie et Hypnose à Saint-Julien-du-Sault (Yonne)',
   slogan1: 'Accueillir ce qui est.',
   slogan2: 'Explorer ce qui vient.',
   subtitle:
@@ -134,7 +134,7 @@ export function HeroSection() {
           transition={hasMounted ? { duration: 0.8, delay: 3.3, ease: 'easeOut' } : { duration: 0 }}
           className="max-w-3xl"
         >
-          <h1 className="font-display text-gold-accessible text-3xl font-bold sm:text-4xl lg:text-5xl">
+          <h1 className="text-gold-accessible mb-2 text-sm uppercase tracking-[0.3em]">
             {heroContent.h1}
           </h1>
           <h2 className="font-display text-ivory mt-4 text-2xl font-semibold sm:text-3xl lg:text-4xl">


### PR DESCRIPTION
## Description

Mise à jour de la section héro du site PSYPNOS :
- Modification du titre principal (h1) : passage de "Psychothérapeute et Hypnothérapeute" à "Psychothérapie et Hypnose" pour une meilleure clarté
- Refonte du style du titre : transformation d'un grand titre display en un petit titre uppercase avec espacement des lettres, créant une hiérarchie visuelle plus claire avec le slogan qui devient l'élément principal

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [ ] J'ai testé mes changements localement
- [ ] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [ ] Pas de nouvelles erreurs ESLint
- [ ] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

https://claude.ai/code/session_01FN5inLdHdvJfuw8C21VcZu