### PR TITLE
chore: add build dependency to dev task in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,7 @@
       "env": ["NODE_ENV"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Description

Ajoute une dépendance explicite sur la tâche `build` pour la tâche `dev` dans la configuration Turbo. Cela garantit que les packages sont construits avant de démarrer le serveur de développement.

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [ ] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [x] Tous les sites (packages/)
- [ ] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

## Détails techniques

La modification ajoute `"dependsOn": ["^build"]` à la tâche `dev`, ce qui signifie que chaque package doit avoir sa tâche `build` exécutée avant sa tâche `dev`. Le symbole `^` indique une dépendance topologique sur les packages dépendants.

https://claude.ai/code/session_01C4qzco1JVR2wLNH8zS3E2n