### PR TITLE
feat: add blog migration scripts from PSYPNOS to KAIRN

### DIFF
--- a/apps/psypnos/scripts/MIGRATION-BLOG.md
+++ b/apps/psypnos/scripts/MIGRATION-BLOG.md
@@ -1,0 +1,130 @@
+# Migration des Articles Blog PSYPNOS → KAIRN
+
+## Prérequis
+
+1. **Accès à la base PSYPNOS** (source)
+   - URL de la base de données PostgreSQL Supabase
+   - Disponible dans le dashboard Supabase: https://supabase.com/dashboard/project/ukbbkoadbgifnxbcuxbr/settings/database
+
+2. **Accès à la base KAIRN** (destination)
+   - Déjà configuré via `DATABASE_URL` dans l'environnement
+
+3. **Supabase Storage KAIRN** (pour les images)
+   - `SUPABASE_URL` et `SUPABASE_SERVICE_KEY` configurés
+
+## Scripts Disponibles
+
+### 1. `migrate-blog-standalone.ts` (Recommandé)
+
+Script autonome utilisant uniquement `pg` (pas de dépendance Prisma).
+
+```bash
+# Configuration
+export PSYPNOS_DATABASE_URL="postgresql://postgres:[PASSWORD]@db.ukbbkoadbgifnxbcuxbr.supabase.co:5432/postgres"
+
+# Exécution
+tsx apps/psypnos/scripts/migrate-blog-standalone.ts
+```
+
+### 2. `migrate-blog-from-psypnos.ts`
+
+Version avec Prisma (nécessite que le client Prisma soit généré).
+
+```bash
+# Configuration
+export PSYPNOS_DATABASE_URL="postgresql://postgres:[PASSWORD]@db.ukbbkoadbgifnxbcuxbr.supabase.co:5432/postgres"
+# OU via Supabase API
+export PSYPNOS_SUPABASE_SERVICE_KEY="eyJ..."
+
+# Exécution
+tsx apps/psypnos/scripts/migrate-blog-from-psypnos.ts
+```
+
+### 3. `migrate-blog-from-json.ts`
+
+Alternative utilisant un fichier JSON exporté depuis Supabase.
+
+```bash
+# Étape 1: Exporter les données depuis PSYPNOS Supabase
+# Dashboard > Table Editor > BlogPostExtended > Export as JSON
+# Sauvegarder dans: apps/psypnos/data/psypnos-blog-export.json
+
+# Étape 2: Exécuter
+tsx apps/psypnos/scripts/migrate-blog-from-json.ts
+```
+
+## Obtenir le mot de passe PSYPNOS
+
+1. Accéder à https://supabase.com/dashboard/project/ukbbkoadbgifnxbcuxbr
+2. Aller dans **Settings** > **Database**
+3. Copier la **Connection string** (URI)
+4. Le mot de passe est masqué - utiliser "Reveal" ou le réinitialiser si nécessaire
+
+## Ce que fait la migration
+
+1. **Analyse préalable**
+   - Liste tous les articles de PSYPNOS
+   - Identifie les articles avec images
+   - Vérifie les doublons dans KAIRN (par slug)
+
+2. **Migration des images**
+   - Télécharge depuis PSYPNOS Supabase Storage
+   - Convertit en WebP (qualité 90%)
+   - Upload vers KAIRN Supabase Storage (bucket `blog-images`)
+   - Convention: `{slug}.webp`
+
+3. **Migration des articles**
+   - Crée un nouvel ID (CUID) pour chaque article
+   - Préserve toutes les données (slug, title, content, faq, jsonLd, etc.)
+   - Met à jour l'URL de l'image si migrée
+   - Préserve les dates originales (date, createdAt)
+   - Met à jour `updatedAt` à maintenant
+
+4. **Vérifications**
+   - Compare le nombre d'articles source/destination
+   - Vérifie l'accessibilité des images migrées
+   - Signale les URLs PSYPNOS hardcodées dans le contenu
+
+## Rapport de Migration
+
+Le script génère un rapport incluant:
+
+- Nombre total d'articles source
+- Nombre d'articles migrés
+- Nombre d'articles ignorés (doublons)
+- Nombre d'images transférées/échouées
+- Liste des erreurs
+- URLs PSYPNOS hardcodées à corriger manuellement
+
+## Points d'Attention
+
+- **Non destructif**: Les données source ne sont pas modifiées
+- **Idempotent**: Peut être exécuté plusieurs fois (ignore les doublons par slug)
+- **URLs hardcodées**: Cherche les URLs contenant "psypnos" ou "ukbbkoadbgifnxbcuxbr" dans le contenu
+- **UTF-8**: Vérifie l'encodage des caractères français
+
+## Troubleshooting
+
+### Erreur de connexion PostgreSQL
+
+```
+Error: connect ECONNREFUSED
+```
+
+Vérifier que l'URL de connexion est correcte et que l'IP est autorisée dans Supabase.
+
+### Erreur d'upload d'image
+
+```
+Upload error: Bucket not found
+```
+
+Créer le bucket `blog-images` dans Supabase Storage KAIRN avec accès public.
+
+### Erreur de module
+
+```
+Cannot find module 'pg'
+```
+
+Exécuter `pnpm install` à la racine du projet.

--- a/apps/psypnos/scripts/migrate-blog-from-json.ts
+++ b/apps/psypnos/scripts/migrate-blog-from-json.ts
@@ -1,0 +1,508 @@
+/**
+ * Migration script: Import blog articles from JSON export to KAIRN
+ *
+ * This script imports articles from a JSON file (exported from PSYPNOS Supabase)
+ *
+ * Usage:
+ * 1. Export BlogPostExtended table from PSYPNOS Supabase as JSON
+ * 2. Save as apps/psypnos/data/psypnos-blog-export.json
+ * 3. Run: npx tsx apps/psypnos/scripts/migrate-blog-from-json.ts
+ *
+ * Required env variables:
+ * - DATABASE_URL: PostgreSQL connection string for KAIRN
+ * - SUPABASE_URL: KAIRN Supabase URL (for image upload)
+ * - SUPABASE_SERVICE_ROLE_KEY: KAIRN Supabase service role key
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { PrismaClient, Prisma } from '@prisma/client';
+import type { InputJsonValue } from '@prisma/client/runtime/library';
+import { createClient } from '@supabase/supabase-js';
+import sharp from 'sharp';
+
+// ============================================
+// Configuration
+// ============================================
+
+const BATCH_SIZE = 10;
+const KAIRN_BUCKET = 'blog-images';
+const DATA_FILE = path.join(process.cwd(), 'apps/psypnos/data/psypnos-blog-export.json');
+
+// ============================================
+// Types
+// ============================================
+
+interface PsypnosBlogPost {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  content: string;
+  author: string;
+  category: string;
+  tags: string[];
+  image: string | null;
+  imagePrompt: string | null;
+  seoIntent: string | null;
+  persona: string | null;
+  tones: string[];
+  faq: unknown;
+  jsonLd: unknown;
+  published: boolean;
+  featured: boolean;
+  date: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MigrationReport {
+  totalArticles: number;
+  migratedArticles: number;
+  skippedArticles: number;
+  imagesTransferred: number;
+  imagesFailed: number;
+  errors: Array<{ slug: string; error: string }>;
+  hardcodedUrls: Array<{ slug: string; urls: string[] }>;
+}
+
+// ============================================
+// Clients
+// ============================================
+
+const prisma = new PrismaClient();
+
+function createKairnSupabase() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    console.warn("⚠️  Supabase not configured - images won't be migrated");
+    return null;
+  }
+
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+const kairnSupabase = createKairnSupabase();
+
+// ============================================
+// Helper Functions
+// ============================================
+
+/**
+ * Load articles from JSON file
+ */
+async function loadArticlesFromJson(): Promise<PsypnosBlogPost[]> {
+  try {
+    const content = await fs.readFile(DATA_FILE, 'utf-8');
+    const data = JSON.parse(content);
+
+    // Handle both array and object with articles property
+    if (Array.isArray(data)) {
+      return data;
+    }
+    if (data.articles && Array.isArray(data.articles)) {
+      return data.articles;
+    }
+
+    throw new Error("Invalid JSON format: expected array or object with 'articles' property");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.error(`❌ File not found: ${DATA_FILE}`);
+      console.error(`\nTo export data from PSYPNOS Supabase:`);
+      console.error(`1. Go to https://supabase.com/dashboard/project/ukbbkoadbgifnxbcuxbr`);
+      console.error(`2. Navigate to Table Editor > BlogPostExtended`);
+      console.error(`3. Click "Export" > "Export as JSON"`);
+      console.error(`4. Save the file as: ${DATA_FILE}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Check existing slugs in KAIRN
+ */
+async function getExistingKairnSlugs(): Promise<Set<string>> {
+  const posts = await prisma.blogPostExtended.findMany({
+    select: { slug: true },
+  });
+  return new Set(posts.map(p => p.slug));
+}
+
+/**
+ * Download image from URL
+ */
+async function downloadImage(url: string): Promise<Buffer | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'KAIRN-Migration-Script/1.0' },
+    });
+
+    if (!response.ok) {
+      console.warn(`  ⚠️  Failed to download image: ${response.status} ${url}`);
+      return null;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  } catch (error) {
+    console.warn(`  ⚠️  Image download error: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * Upload image to KAIRN Supabase storage
+ */
+async function uploadImageToKairn(slug: string, buffer: Buffer): Promise<string | null> {
+  if (!kairnSupabase) {
+    return null;
+  }
+
+  try {
+    const webpBuffer = await sharp(buffer).webp({ quality: 90 }).toBuffer();
+    const filename = `${slug}.webp`;
+
+    const { error } = await kairnSupabase.storage.from(KAIRN_BUCKET).upload(filename, webpBuffer, {
+      contentType: 'image/webp',
+      upsert: true,
+    });
+
+    if (error) {
+      console.warn(`  ⚠️  Upload error: ${error.message}`);
+      return null;
+    }
+
+    const {
+      data: { publicUrl },
+    } = kairnSupabase.storage.from(KAIRN_BUCKET).getPublicUrl(filename);
+
+    return publicUrl;
+  } catch (error) {
+    console.warn(`  ⚠️  Image processing error: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * Migrate a single image
+ */
+async function migrateImage(slug: string, imageUrl: string): Promise<string | null> {
+  console.log(`  📷 Migrating image for "${slug}"...`);
+
+  const buffer = await downloadImage(imageUrl);
+  if (!buffer) {
+    return null;
+  }
+
+  const newUrl = await uploadImageToKairn(slug, buffer);
+  if (newUrl) {
+    console.log(`  ✅ Image migrated: ${newUrl}`);
+  }
+
+  return newUrl;
+}
+
+/**
+ * Find hardcoded PSYPNOS URLs in content
+ */
+function findHardcodedUrls(content: string): string[] {
+  const patterns = [
+    /https?:\/\/[^"'\s]*psypnos[^"'\s]*/gi,
+    /https?:\/\/[^"'\s]*ukbbkoadbgifnxbcuxbr[^"'\s]*/gi,
+  ];
+
+  const urls: string[] = [];
+  for (const pattern of patterns) {
+    const matches = content.match(pattern);
+    if (matches) {
+      urls.push(...matches);
+    }
+  }
+
+  return [...new Set(urls)];
+}
+
+/**
+ * Validate UTF-8 encoding
+ */
+function validateUtf8(text: string, field: string, slug: string): boolean {
+  try {
+    // Check for common encoding issues
+    if (text.includes('Ã©') || text.includes('Ã¨') || text.includes('Ã ')) {
+      console.warn(`  ⚠️  Possible UTF-8 encoding issue in ${field} for "${slug}"`);
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create article in KAIRN database
+ */
+async function createKairnArticle(
+  article: PsypnosBlogPost,
+  newImageUrl: string | null
+): Promise<boolean> {
+  try {
+    await prisma.blogPostExtended.create({
+      data: {
+        slug: article.slug,
+        title: article.title,
+        description: article.description,
+        content: article.content,
+        author: article.author,
+        category: article.category,
+        tags: article.tags || [],
+        image: newImageUrl || article.image,
+        imagePrompt: article.imagePrompt,
+        seoIntent: article.seoIntent,
+        persona: article.persona,
+        tones: article.tones || [],
+        faq: article.faq ? (article.faq as InputJsonValue) : Prisma.DbNull,
+        jsonLd: article.jsonLd ? (article.jsonLd as InputJsonValue) : Prisma.DbNull,
+        published: article.published,
+        featured: article.featured,
+        date: new Date(article.date),
+        createdAt: new Date(article.createdAt),
+        updatedAt: new Date(),
+      },
+    });
+
+    return true;
+  } catch (error) {
+    console.error(`  ❌ Failed to create article: ${error}`);
+    return false;
+  }
+}
+
+// ============================================
+// Main Migration
+// ============================================
+
+async function migrate() {
+  console.log('╔════════════════════════════════════════════════════════════╗');
+  console.log('║    MIGRATION BLOG PSYPNOS → KAIRN (depuis fichier JSON)   ║');
+  console.log('╚════════════════════════════════════════════════════════════╝\n');
+
+  const report: MigrationReport = {
+    totalArticles: 0,
+    migratedArticles: 0,
+    skippedArticles: 0,
+    imagesTransferred: 0,
+    imagesFailed: 0,
+    errors: [],
+    hardcodedUrls: [],
+  };
+
+  try {
+    // ========================================
+    // ÉTAPE 1: Chargement des données
+    // ========================================
+    console.log('📋 ÉTAPE 1: Chargement des données\n');
+
+    console.log(`Lecture du fichier: ${DATA_FILE}`);
+    const psypnosArticles = await loadArticlesFromJson();
+    console.log(`✅ ${psypnosArticles.length} articles trouvés dans le fichier JSON\n`);
+
+    report.totalArticles = psypnosArticles.length;
+
+    // Count articles with images
+    const articlesWithImages = psypnosArticles.filter(a => a.image);
+    console.log(`📷 ${articlesWithImages.length} articles avec images`);
+
+    // Get existing KAIRN slugs
+    console.log('\nConnexion à KAIRN...');
+    const existingSlugs = await getExistingKairnSlugs();
+    console.log(`✅ ${existingSlugs.size} articles existants dans KAIRN\n`);
+
+    // Check for duplicates
+    const duplicates = psypnosArticles.filter(a => existingSlugs.has(a.slug));
+    if (duplicates.length > 0) {
+      console.log(`⚠️  ${duplicates.length} slugs déjà présents (seront ignorés):`);
+      duplicates.forEach(d => console.log(`   - ${d.slug}`));
+      report.skippedArticles = duplicates.length;
+      console.log('');
+    }
+
+    // Articles to migrate
+    const toMigrate = psypnosArticles.filter(a => !existingSlugs.has(a.slug));
+    console.log(`📦 ${toMigrate.length} articles à migrer\n`);
+
+    if (toMigrate.length === 0) {
+      console.log('✅ Aucun article à migrer. Migration terminée.\n');
+      return report;
+    }
+
+    // ========================================
+    // ÉTAPE 2: Migration par batch
+    // ========================================
+    console.log('═'.repeat(60));
+    console.log('📦 ÉTAPE 2: Migration des articles\n');
+
+    for (let i = 0; i < toMigrate.length; i += BATCH_SIZE) {
+      const batch = toMigrate.slice(i, i + BATCH_SIZE);
+      const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+      const totalBatches = Math.ceil(toMigrate.length / BATCH_SIZE);
+
+      console.log(`\n── Batch ${batchNum}/${totalBatches} ──\n`);
+
+      for (const article of batch) {
+        console.log(`📝 Traitement: "${article.title}" (${article.slug})`);
+
+        // Validate UTF-8
+        validateUtf8(article.title, 'title', article.slug);
+        validateUtf8(article.content, 'content', article.slug);
+
+        // Check for hardcoded URLs
+        const hardcodedUrls = findHardcodedUrls(article.content);
+        if (hardcodedUrls.length > 0) {
+          console.log(`  ⚠️  URLs PSYPNOS détectées dans le contenu:`);
+          hardcodedUrls.forEach(url => console.log(`     ${url}`));
+          report.hardcodedUrls.push({ slug: article.slug, urls: hardcodedUrls });
+        }
+
+        // Migrate image if present
+        let newImageUrl: string | null = null;
+        if (article.image && kairnSupabase) {
+          newImageUrl = await migrateImage(article.slug, article.image);
+          if (newImageUrl) {
+            report.imagesTransferred++;
+          } else {
+            report.imagesFailed++;
+          }
+        }
+
+        // Create article in KAIRN
+        const success = await createKairnArticle(article, newImageUrl);
+        if (success) {
+          console.log(`  ✅ Article créé dans KAIRN`);
+          report.migratedArticles++;
+        } else {
+          report.errors.push({
+            slug: article.slug,
+            error: 'Failed to create in KAIRN',
+          });
+        }
+      }
+    }
+
+    // ========================================
+    // ÉTAPE 3: Vérifications post-migration
+    // ========================================
+    console.log('\n' + '═'.repeat(60));
+    console.log('🔍 ÉTAPE 3: Vérifications post-migration\n');
+
+    const finalCount = await prisma.blogPostExtended.count();
+    console.log(`📊 Total articles dans KAIRN: ${finalCount}`);
+
+    // Verify a sample article
+    if (report.migratedArticles > 0) {
+      const sampleSlug = toMigrate[0]?.slug;
+      if (sampleSlug) {
+        const sample = await prisma.blogPostExtended.findUnique({
+          where: { slug: sampleSlug },
+        });
+
+        if (sample) {
+          console.log(`\n✅ Vérification article sample "${sampleSlug}":`);
+          console.log(`   - Titre: ${sample.title}`);
+          console.log(`   - Catégorie: ${sample.category}`);
+          console.log(`   - Tags: ${sample.tags.join(', ')}`);
+          console.log(`   - Image: ${sample.image ? '✓' : '✗'}`);
+          console.log(`   - FAQ: ${sample.faq ? '✓' : '✗'}`);
+          console.log(`   - JSON-LD: ${sample.jsonLd ? '✓' : '✗'}`);
+          console.log(`   - Publié: ${sample.published ? 'Oui' : 'Non'}`);
+        }
+      }
+    }
+
+    return report;
+  } catch (error) {
+    console.error('\n❌ ERREUR FATALE:', error);
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// ============================================
+// Generate Report
+// ============================================
+
+function printReport(report: MigrationReport) {
+  console.log('\n' + '═'.repeat(60));
+  console.log('📋 RAPPORT DE MIGRATION');
+  console.log('═'.repeat(60) + '\n');
+
+  console.log('┌─────────────────────────────────────┬──────────┐');
+  console.log('│ Métrique                            │ Valeur   │');
+  console.log('├─────────────────────────────────────┼──────────┤');
+  console.log(
+    `│ Articles source (JSON)              │ ${String(report.totalArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Articles migrés                     │ ${String(report.migratedArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Articles ignorés (doublons)         │ ${String(report.skippedArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Images transférées                  │ ${String(report.imagesTransferred).padStart(8)} │`
+  );
+  console.log(
+    `│ Images échouées                     │ ${String(report.imagesFailed).padStart(8)} │`
+  );
+  console.log('└─────────────────────────────────────┴──────────┘');
+
+  if (report.errors.length > 0) {
+    console.log('\n⚠️  ERREURS RENCONTRÉES:');
+    report.errors.forEach(e => {
+      console.log(`   - ${e.slug}: ${e.error}`);
+    });
+  }
+
+  if (report.hardcodedUrls.length > 0) {
+    console.log('\n⚠️  URLs PSYPNOS HARDCODÉES À CORRIGER:');
+    report.hardcodedUrls.forEach(item => {
+      console.log(`   📝 ${item.slug}:`);
+      item.urls.forEach(url => console.log(`      ${url}`));
+    });
+  }
+
+  console.log('\n' + '═'.repeat(60));
+  console.log(
+    report.errors.length === 0
+      ? '✅ MIGRATION TERMINÉE AVEC SUCCÈS'
+      : '⚠️  MIGRATION TERMINÉE AVEC DES AVERTISSEMENTS'
+  );
+  console.log('═'.repeat(60) + '\n');
+}
+
+// ============================================
+// Execute
+// ============================================
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error('❌ DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
+
+  try {
+    const report = await migrate();
+    printReport(report);
+    process.exit(report.errors.length > 0 ? 1 : 0);
+  } catch (error) {
+    console.error('Migration failed:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/apps/psypnos/scripts/migrate-blog-from-psypnos.ts
+++ b/apps/psypnos/scripts/migrate-blog-from-psypnos.ts
@@ -1,0 +1,630 @@
+/**
+ * Migration script: Import blog articles from PSYPNOS to KAIRN
+ *
+ * This script supports multiple data sources:
+ * 1. Direct PostgreSQL connection to PSYPNOS (PSYPNOS_DATABASE_URL)
+ * 2. Supabase REST API (PSYPNOS_SUPABASE_URL + PSYPNOS_SUPABASE_SERVICE_KEY)
+ *
+ * Run with: npx tsx apps/psypnos/scripts/migrate-blog-from-psypnos.ts
+ *
+ * Required env variables for KAIRN (destination):
+ * - DATABASE_URL: PostgreSQL connection string for KAIRN
+ * - SUPABASE_URL: KAIRN Supabase URL
+ * - SUPABASE_SERVICE_KEY or SUPABASE_SERVICE_ROLE_KEY: KAIRN Supabase service key
+ *
+ * Required env variables for PSYPNOS (source) - ONE of these:
+ * - PSYPNOS_DATABASE_URL: PostgreSQL connection string for PSYPNOS
+ *   OR
+ * - PSYPNOS_SUPABASE_URL + PSYPNOS_SUPABASE_SERVICE_KEY: Supabase REST API credentials
+ */
+
+import { PrismaClient, Prisma } from '@prisma/client';
+import type { InputJsonValue } from '@prisma/client/runtime/library';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { Pool } from 'pg';
+import sharp from 'sharp';
+
+// ============================================
+// Configuration
+// ============================================
+
+const BATCH_SIZE = 10;
+const KAIRN_BUCKET = 'blog-images';
+
+// PSYPNOS Supabase defaults (from MCP config)
+const PSYPNOS_PROJECT_REF = 'ukbbkoadbgifnxbcuxbr';
+const PSYPNOS_DEFAULT_URL = `https://${PSYPNOS_PROJECT_REF}.supabase.co`;
+
+// ============================================
+// Types
+// ============================================
+
+interface PsypnosBlogPost {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  content: string;
+  author: string;
+  category: string;
+  tags: string[];
+  image: string | null;
+  imagePrompt: string | null;
+  seoIntent: string | null;
+  persona: string | null;
+  tones: string[];
+  faq: unknown;
+  jsonLd: unknown;
+  published: boolean;
+  featured: boolean;
+  date: Date | string;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+
+interface MigrationReport {
+  totalArticles: number;
+  migratedArticles: number;
+  skippedArticles: number;
+  imagesTransferred: number;
+  imagesFailed: number;
+  errors: Array<{ slug: string; error: string }>;
+  hardcodedUrls: Array<{ slug: string; urls: string[] }>;
+}
+
+type DataSource = 'postgres' | 'supabase-api';
+
+// ============================================
+// Clients
+// ============================================
+
+// KAIRN Prisma client (destination)
+const kairnPrisma = new PrismaClient();
+
+// PSYPNOS data source
+let psypnosPool: Pool | null = null;
+let psypnosSupabase: SupabaseClient | null = null;
+let dataSource: DataSource = 'postgres';
+
+function initPsypnosConnection(): DataSource {
+  // Try PostgreSQL direct connection first
+  if (process.env.PSYPNOS_DATABASE_URL) {
+    psypnosPool = new Pool({
+      connectionString: process.env.PSYPNOS_DATABASE_URL,
+      ssl: { rejectUnauthorized: false },
+    });
+    console.log('📦 Source PSYPNOS: PostgreSQL direct connection');
+    return 'postgres';
+  }
+
+  // Try Supabase REST API
+  const supabaseUrl = process.env.PSYPNOS_SUPABASE_URL || PSYPNOS_DEFAULT_URL;
+  const supabaseKey = process.env.PSYPNOS_SUPABASE_SERVICE_KEY;
+
+  if (supabaseKey) {
+    psypnosSupabase = createClient(supabaseUrl, supabaseKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    console.log('📦 Source PSYPNOS: Supabase REST API');
+    return 'supabase-api';
+  }
+
+  console.error('❌ No PSYPNOS data source configured!');
+  console.error('   Set one of:');
+  console.error('   - PSYPNOS_DATABASE_URL (PostgreSQL connection string)');
+  console.error('   - PSYPNOS_SUPABASE_SERVICE_KEY (with optional PSYPNOS_SUPABASE_URL)');
+  process.exit(1);
+}
+
+// KAIRN Supabase client for storage
+function createKairnSupabase(): SupabaseClient | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    console.warn("⚠️  KAIRN Supabase not configured - images won't be migrated");
+    return null;
+  }
+
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+let kairnSupabase: SupabaseClient | null = null;
+
+// ============================================
+// Helper Functions
+// ============================================
+
+/**
+ * Fetch all articles from PSYPNOS database via PostgreSQL
+ */
+async function fetchPsypnosArticlesPostgres(): Promise<PsypnosBlogPost[]> {
+  if (!psypnosPool) {
+    throw new Error('PostgreSQL pool not initialized');
+  }
+
+  const query = `
+    SELECT
+      id, slug, title, description, content, author, category,
+      tags, image, "imagePrompt", "seoIntent", persona, tones,
+      faq, "jsonLd", published, featured, date, "createdAt", "updatedAt"
+    FROM "BlogPostExtended"
+    ORDER BY date DESC
+  `;
+
+  const result = await psypnosPool.query(query);
+  return result.rows;
+}
+
+/**
+ * Fetch all articles from PSYPNOS via Supabase REST API
+ */
+async function fetchPsypnosArticlesSupabase(): Promise<PsypnosBlogPost[]> {
+  if (!psypnosSupabase) {
+    throw new Error('Supabase client not initialized');
+  }
+
+  const { data, error } = await psypnosSupabase
+    .from('BlogPostExtended')
+    .select('*')
+    .order('date', { ascending: false });
+
+  if (error) {
+    throw new Error(`Supabase query error: ${error.message}`);
+  }
+
+  return data || [];
+}
+
+/**
+ * Fetch articles from PSYPNOS using the configured data source
+ */
+async function fetchPsypnosArticles(): Promise<PsypnosBlogPost[]> {
+  if (dataSource === 'postgres') {
+    return fetchPsypnosArticlesPostgres();
+  }
+  return fetchPsypnosArticlesSupabase();
+}
+
+/**
+ * Check existing slugs in KAIRN
+ */
+async function getExistingKairnSlugs(): Promise<Set<string>> {
+  const posts = await kairnPrisma.blogPostExtended.findMany({
+    select: { slug: true },
+  });
+  return new Set(posts.map(p => p.slug));
+}
+
+/**
+ * Download image from URL
+ */
+async function downloadImage(url: string): Promise<Buffer | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'KAIRN-Migration-Script/1.0' },
+    });
+
+    if (!response.ok) {
+      console.warn(`  ⚠️  Failed to download image: ${response.status} ${url}`);
+      return null;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  } catch (error) {
+    console.warn(`  ⚠️  Image download error: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * Upload image to KAIRN Supabase storage
+ */
+async function uploadImageToKairn(slug: string, buffer: Buffer): Promise<string | null> {
+  if (!kairnSupabase) {
+    return null;
+  }
+
+  try {
+    const webpBuffer = await sharp(buffer).webp({ quality: 90 }).toBuffer();
+    const filename = `${slug}.webp`;
+
+    const { error } = await kairnSupabase.storage.from(KAIRN_BUCKET).upload(filename, webpBuffer, {
+      contentType: 'image/webp',
+      upsert: true,
+    });
+
+    if (error) {
+      console.warn(`  ⚠️  Upload error: ${error.message}`);
+      return null;
+    }
+
+    const {
+      data: { publicUrl },
+    } = kairnSupabase.storage.from(KAIRN_BUCKET).getPublicUrl(filename);
+
+    return publicUrl;
+  } catch (error) {
+    console.warn(`  ⚠️  Image processing error: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * Migrate a single image
+ */
+async function migrateImage(slug: string, imageUrl: string): Promise<string | null> {
+  if (!kairnSupabase) {
+    return null;
+  }
+
+  console.log(`  📷 Migrating image for "${slug}"...`);
+
+  const buffer = await downloadImage(imageUrl);
+  if (!buffer) {
+    return null;
+  }
+
+  const newUrl = await uploadImageToKairn(slug, buffer);
+  if (newUrl) {
+    console.log(`  ✅ Image migrated: ${newUrl}`);
+  }
+
+  return newUrl;
+}
+
+/**
+ * Find hardcoded PSYPNOS URLs in content
+ */
+function findHardcodedUrls(content: string): string[] {
+  const patterns = [
+    /https?:\/\/[^"'\s]*psypnos[^"'\s]*/gi,
+    /https?:\/\/[^"'\s]*ukbbkoadbgifnxbcuxbr[^"'\s]*/gi,
+  ];
+
+  const urls: string[] = [];
+  for (const pattern of patterns) {
+    const matches = content.match(pattern);
+    if (matches) {
+      urls.push(...matches);
+    }
+  }
+
+  return [...new Set(urls)];
+}
+
+/**
+ * Validate JSON fields
+ */
+function validateJsonField(value: unknown, fieldName: string, slug: string): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  try {
+    if (typeof value === 'object') {
+      return true;
+    }
+
+    if (typeof value === 'string') {
+      JSON.parse(value);
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    console.warn(`  ⚠️  Invalid JSON in ${fieldName} for "${slug}": ${error}`);
+    return false;
+  }
+}
+
+/**
+ * Validate UTF-8 encoding
+ */
+function validateUtf8(text: string, field: string, slug: string): void {
+  if (text.includes('Ã©') || text.includes('Ã¨') || text.includes('Ã ')) {
+    console.warn(`  ⚠️  Possible UTF-8 encoding issue in ${field} for "${slug}"`);
+  }
+}
+
+/**
+ * Create article in KAIRN database
+ */
+async function createKairnArticle(
+  article: PsypnosBlogPost,
+  newImageUrl: string | null
+): Promise<boolean> {
+  try {
+    await kairnPrisma.blogPostExtended.create({
+      data: {
+        slug: article.slug,
+        title: article.title,
+        description: article.description,
+        content: article.content,
+        author: article.author,
+        category: article.category,
+        tags: article.tags || [],
+        image: newImageUrl || article.image,
+        imagePrompt: article.imagePrompt,
+        seoIntent: article.seoIntent,
+        persona: article.persona,
+        tones: article.tones || [],
+        faq: article.faq ? (article.faq as InputJsonValue) : Prisma.DbNull,
+        jsonLd: article.jsonLd ? (article.jsonLd as InputJsonValue) : Prisma.DbNull,
+        published: article.published,
+        featured: article.featured,
+        date: new Date(article.date),
+        createdAt: new Date(article.createdAt),
+        updatedAt: new Date(),
+      },
+    });
+
+    return true;
+  } catch (error) {
+    console.error(`  ❌ Failed to create article: ${error}`);
+    return false;
+  }
+}
+
+// ============================================
+// Main Migration
+// ============================================
+
+async function migrate() {
+  console.log('╔════════════════════════════════════════════════════════════╗');
+  console.log('║       MIGRATION DES ARTICLES BLOG PSYPNOS → KAIRN         ║');
+  console.log('╚════════════════════════════════════════════════════════════╝\n');
+
+  const report: MigrationReport = {
+    totalArticles: 0,
+    migratedArticles: 0,
+    skippedArticles: 0,
+    imagesTransferred: 0,
+    imagesFailed: 0,
+    errors: [],
+    hardcodedUrls: [],
+  };
+
+  try {
+    // ========================================
+    // ÉTAPE 1: Analyse préalable
+    // ========================================
+    console.log('📋 ÉTAPE 1: Analyse préalable\n');
+
+    // Initialize connections
+    dataSource = initPsypnosConnection();
+    kairnSupabase = createKairnSupabase();
+
+    console.log('\nConnexion à PSYPNOS...');
+    const psypnosArticles = await fetchPsypnosArticles();
+    console.log(`✅ ${psypnosArticles.length} articles trouvés dans PSYPNOS\n`);
+
+    report.totalArticles = psypnosArticles.length;
+
+    // Count articles with images
+    const articlesWithImages = psypnosArticles.filter(a => a.image);
+    console.log(`📷 ${articlesWithImages.length} articles avec images`);
+
+    // Get existing KAIRN slugs
+    console.log('\nConnexion à KAIRN...');
+    const existingSlugs = await getExistingKairnSlugs();
+    console.log(`✅ ${existingSlugs.size} articles existants dans KAIRN\n`);
+
+    // Check for duplicates
+    const duplicates = psypnosArticles.filter(a => existingSlugs.has(a.slug));
+    if (duplicates.length > 0) {
+      console.log(`⚠️  ${duplicates.length} slugs déjà présents (seront ignorés):`);
+      duplicates.forEach(d => console.log(`   - ${d.slug}`));
+      report.skippedArticles = duplicates.length;
+      console.log('');
+    }
+
+    // Articles to migrate
+    const toMigrate = psypnosArticles.filter(a => !existingSlugs.has(a.slug));
+    console.log(`📦 ${toMigrate.length} articles à migrer\n`);
+
+    if (toMigrate.length === 0) {
+      console.log('✅ Aucun article à migrer. Migration terminée.\n');
+      return report;
+    }
+
+    // ========================================
+    // ÉTAPE 2: Migration par batch
+    // ========================================
+    console.log('═'.repeat(60));
+    console.log('📦 ÉTAPE 2: Migration des articles\n');
+
+    for (let i = 0; i < toMigrate.length; i += BATCH_SIZE) {
+      const batch = toMigrate.slice(i, i + BATCH_SIZE);
+      const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+      const totalBatches = Math.ceil(toMigrate.length / BATCH_SIZE);
+
+      console.log(`\n── Batch ${batchNum}/${totalBatches} ──\n`);
+
+      for (const article of batch) {
+        console.log(`📝 Traitement: "${article.title}" (${article.slug})`);
+
+        // Validate UTF-8
+        validateUtf8(article.title, 'title', article.slug);
+        validateUtf8(article.content, 'content', article.slug);
+
+        // Check for hardcoded URLs
+        const hardcodedUrls = findHardcodedUrls(article.content);
+        if (hardcodedUrls.length > 0) {
+          console.log(`  ⚠️  URLs PSYPNOS détectées dans le contenu:`);
+          hardcodedUrls.forEach(url => console.log(`     ${url}`));
+          report.hardcodedUrls.push({ slug: article.slug, urls: hardcodedUrls });
+        }
+
+        // Validate JSON fields
+        validateJsonField(article.faq, 'faq', article.slug);
+        validateJsonField(article.jsonLd, 'jsonLd', article.slug);
+
+        // Migrate image if present
+        let newImageUrl: string | null = null;
+        if (article.image && kairnSupabase) {
+          newImageUrl = await migrateImage(article.slug, article.image);
+          if (newImageUrl) {
+            report.imagesTransferred++;
+          } else {
+            report.imagesFailed++;
+          }
+        }
+
+        // Create article in KAIRN
+        const success = await createKairnArticle(article, newImageUrl);
+        if (success) {
+          console.log(`  ✅ Article créé dans KAIRN`);
+          report.migratedArticles++;
+        } else {
+          report.errors.push({
+            slug: article.slug,
+            error: 'Failed to create in KAIRN',
+          });
+        }
+      }
+    }
+
+    // ========================================
+    // ÉTAPE 3: Vérifications post-migration
+    // ========================================
+    console.log('\n' + '═'.repeat(60));
+    console.log('🔍 ÉTAPE 3: Vérifications post-migration\n');
+
+    const finalCount = await kairnPrisma.blogPostExtended.count();
+    console.log(`📊 Total articles dans KAIRN: ${finalCount}`);
+
+    // Verify a sample article
+    if (report.migratedArticles > 0) {
+      const sampleSlug = toMigrate[0]?.slug;
+      if (sampleSlug) {
+        const sample = await kairnPrisma.blogPostExtended.findUnique({
+          where: { slug: sampleSlug },
+        });
+
+        if (sample) {
+          console.log(`\n✅ Vérification article sample "${sampleSlug}":`);
+          console.log(`   - Titre: ${sample.title}`);
+          console.log(`   - Catégorie: ${sample.category}`);
+          console.log(`   - Tags: ${sample.tags.join(', ')}`);
+          console.log(`   - Image: ${sample.image ? '✓' : '✗'}`);
+          console.log(`   - FAQ: ${sample.faq ? '✓' : '✗'}`);
+          console.log(`   - JSON-LD: ${sample.jsonLd ? '✓' : '✗'}`);
+          console.log(`   - Publié: ${sample.published ? 'Oui' : 'Non'}`);
+        }
+      }
+    }
+
+    // Test image URLs
+    if (report.imagesTransferred > 0) {
+      console.log("\n🔗 Test d'accessibilité des images:");
+      const articlesWithNewImages = await kairnPrisma.blogPostExtended.findMany({
+        where: { image: { contains: 'supabase' } },
+        take: 3,
+        select: { slug: true, image: true },
+      });
+
+      for (const article of articlesWithNewImages) {
+        if (article.image) {
+          try {
+            const response = await fetch(article.image, { method: 'HEAD' });
+            console.log(`   ${response.ok ? '✅' : '❌'} ${article.slug}: ${response.status}`);
+          } catch {
+            console.log(`   ❌ ${article.slug}: Erreur de connexion`);
+          }
+        }
+      }
+    }
+
+    return report;
+  } catch (error) {
+    console.error('\n❌ ERREUR FATALE:', error);
+    throw error;
+  } finally {
+    await kairnPrisma.$disconnect();
+    if (psypnosPool) {
+      await psypnosPool.end();
+    }
+  }
+}
+
+// ============================================
+// Generate Report
+// ============================================
+
+function printReport(report: MigrationReport) {
+  console.log('\n' + '═'.repeat(60));
+  console.log('📋 RAPPORT DE MIGRATION');
+  console.log('═'.repeat(60) + '\n');
+
+  console.log('┌─────────────────────────────────────┬──────────┐');
+  console.log('│ Métrique                            │ Valeur   │');
+  console.log('├─────────────────────────────────────┼──────────┤');
+  console.log(
+    `│ Articles source (PSYPNOS)           │ ${String(report.totalArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Articles migrés                     │ ${String(report.migratedArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Articles ignorés (doublons)         │ ${String(report.skippedArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Images transférées                  │ ${String(report.imagesTransferred).padStart(8)} │`
+  );
+  console.log(
+    `│ Images échouées                     │ ${String(report.imagesFailed).padStart(8)} │`
+  );
+  console.log('└─────────────────────────────────────┴──────────┘');
+
+  if (report.errors.length > 0) {
+    console.log('\n⚠️  ERREURS RENCONTRÉES:');
+    report.errors.forEach(e => {
+      console.log(`   - ${e.slug}: ${e.error}`);
+    });
+  }
+
+  if (report.hardcodedUrls.length > 0) {
+    console.log('\n⚠️  URLs PSYPNOS HARDCODÉES À CORRIGER:');
+    report.hardcodedUrls.forEach(item => {
+      console.log(`   📝 ${item.slug}:`);
+      item.urls.forEach(url => console.log(`      ${url}`));
+    });
+  }
+
+  console.log('\n' + '═'.repeat(60));
+  console.log(
+    report.errors.length === 0
+      ? '✅ MIGRATION TERMINÉE AVEC SUCCÈS'
+      : '⚠️  MIGRATION TERMINÉE AVEC DES AVERTISSEMENTS'
+  );
+  console.log('═'.repeat(60) + '\n');
+}
+
+// ============================================
+// Execute
+// ============================================
+
+async function main() {
+  // Check KAIRN required env vars
+  if (!process.env.DATABASE_URL) {
+    console.error('❌ DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
+
+  // PSYPNOS source will be checked in initPsypnosConnection()
+
+  try {
+    const report = await migrate();
+    printReport(report);
+    process.exit(report.errors.length > 0 ? 1 : 0);
+  } catch (error) {
+    console.error('Migration failed:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/apps/psypnos/scripts/migrate-blog-standalone.ts
+++ b/apps/psypnos/scripts/migrate-blog-standalone.ts
@@ -1,0 +1,455 @@
+#!/usr/bin/env npx tsx
+/**
+ * Standalone Migration Script: PSYPNOS → KAIRN Blog Articles
+ *
+ * This script uses only pg and native Node.js modules (no Prisma dependency).
+ * It can be run directly without installing the full monorepo dependencies.
+ *
+ * Usage:
+ *   PSYPNOS_DATABASE_URL="..." npx tsx apps/psypnos/scripts/migrate-blog-standalone.ts
+ *
+ * Required environment variables:
+ * - PSYPNOS_DATABASE_URL: Source database connection string
+ * - DATABASE_URL: Destination database connection string (KAIRN)
+ * - SUPABASE_URL: KAIRN Supabase URL (for image migration)
+ * - SUPABASE_SERVICE_KEY: KAIRN Supabase service key (for image migration)
+ */
+
+import { randomUUID } from 'crypto';
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { Pool } from 'pg';
+import sharp from 'sharp';
+
+// ============================================
+// Configuration
+// ============================================
+
+const BATCH_SIZE = 10;
+const KAIRN_BUCKET = 'blog-images';
+
+// ============================================
+// Types
+// ============================================
+
+interface BlogPost {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  content: string;
+  author: string;
+  category: string;
+  tags: string[];
+  image: string | null;
+  imagePrompt: string | null;
+  seoIntent: string | null;
+  persona: string | null;
+  tones: string[];
+  faq: unknown;
+  jsonLd: unknown;
+  published: boolean;
+  featured: boolean;
+  date: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface MigrationReport {
+  totalArticles: number;
+  migratedArticles: number;
+  skippedArticles: number;
+  imagesTransferred: number;
+  imagesFailed: number;
+  errors: Array<{ slug: string; error: string }>;
+  hardcodedUrls: Array<{ slug: string; urls: string[] }>;
+}
+
+// ============================================
+// Helper: Clean env values (remove quotes)
+// ============================================
+
+function cleanEnv(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.replace(/^["']|["']$/g, '');
+}
+
+// ============================================
+// Database Connections (lazy init)
+// ============================================
+
+let psypnosPool: Pool | null = null;
+let kairnPool: Pool | null = null;
+let supabase: SupabaseClient | null = null;
+
+function initConnections(): void {
+  const psypnosUrl = cleanEnv(process.env.PSYPNOS_DATABASE_URL);
+  const kairnUrl = cleanEnv(process.env.DATABASE_URL);
+  const supabaseUrl = cleanEnv(process.env.SUPABASE_URL);
+  const supabaseKey = cleanEnv(process.env.SUPABASE_SERVICE_KEY);
+
+  if (psypnosUrl) {
+    psypnosPool = new Pool({
+      connectionString: psypnosUrl,
+      ssl: { rejectUnauthorized: false },
+    });
+  }
+
+  if (kairnUrl) {
+    kairnPool = new Pool({
+      connectionString: kairnUrl,
+      ssl: { rejectUnauthorized: false },
+    });
+  }
+
+  if (supabaseUrl && supabaseKey) {
+    supabase = createClient(supabaseUrl, supabaseKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+}
+
+// ============================================
+// Helper Functions
+// ============================================
+
+function generateCuid(): string {
+  // Simple CUID-like ID generator
+  const timestamp = Date.now().toString(36);
+  const random = randomUUID().replace(/-/g, '').substring(0, 12);
+  return `c${timestamp}${random}`;
+}
+
+async function fetchPsypnosArticles(): Promise<BlogPost[]> {
+  if (!psypnosPool) throw new Error('PSYPNOS pool not initialized');
+  const query = `
+    SELECT
+      id, slug, title, description, content, author, category,
+      tags, image, "imagePrompt", "seoIntent", persona, tones,
+      faq, "jsonLd", published, featured, date, "createdAt", "updatedAt"
+    FROM "BlogPostExtended"
+    ORDER BY date DESC
+  `;
+  const result = await psypnosPool.query(query);
+  return result.rows;
+}
+
+async function getExistingKairnSlugs(): Promise<Set<string>> {
+  if (!kairnPool) throw new Error('KAIRN pool not initialized');
+  const result = await kairnPool.query('SELECT slug FROM "BlogPostExtended"');
+  return new Set(result.rows.map((r: { slug: string }) => r.slug));
+}
+
+async function downloadImage(url: string): Promise<Buffer | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'KAIRN-Migration/1.0' },
+    });
+    if (!response.ok) {
+      console.warn(`  ⚠️  Download failed: ${response.status} ${url}`);
+      return null;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  } catch (error) {
+    console.warn(`  ⚠️  Download error: ${error}`);
+    return null;
+  }
+}
+
+async function uploadImage(slug: string, buffer: Buffer): Promise<string | null> {
+  if (!supabase) return null;
+
+  try {
+    const webpBuffer = await sharp(buffer).webp({ quality: 90 }).toBuffer();
+    const filename = `${slug}.webp`;
+
+    const { error } = await supabase.storage
+      .from(KAIRN_BUCKET)
+      .upload(filename, webpBuffer, { contentType: 'image/webp', upsert: true });
+
+    if (error) {
+      console.warn(`  ⚠️  Upload error: ${error.message}`);
+      return null;
+    }
+
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from(KAIRN_BUCKET).getPublicUrl(filename);
+
+    return publicUrl;
+  } catch (error) {
+    console.warn(`  ⚠️  Image processing error: ${error}`);
+    return null;
+  }
+}
+
+async function migrateImage(slug: string, imageUrl: string): Promise<string | null> {
+  if (!supabase) return null;
+  console.log(`  📷 Migrating image for "${slug}"...`);
+
+  const buffer = await downloadImage(imageUrl);
+  if (!buffer) return null;
+
+  const newUrl = await uploadImage(slug, buffer);
+  if (newUrl) {
+    console.log(`  ✅ Image migrated: ${newUrl}`);
+  }
+  return newUrl;
+}
+
+function findHardcodedUrls(content: string): string[] {
+  const patterns = [
+    /https?:\/\/[^"'\s]*psypnos[^"'\s]*/gi,
+    /https?:\/\/[^"'\s]*ukbbkoadbgifnxbcuxbr[^"'\s]*/gi,
+  ];
+  const urls: string[] = [];
+  for (const pattern of patterns) {
+    const matches = content.match(pattern);
+    if (matches) urls.push(...matches);
+  }
+  return [...new Set(urls)];
+}
+
+async function insertArticle(article: BlogPost, newImageUrl: string | null): Promise<boolean> {
+  if (!kairnPool) throw new Error('KAIRN pool not initialized');
+  const query = `
+    INSERT INTO "BlogPostExtended" (
+      id, slug, title, description, content, author, category,
+      tags, image, "imagePrompt", "seoIntent", persona, tones,
+      faq, "jsonLd", published, featured, date, "createdAt", "updatedAt"
+    ) VALUES (
+      $1, $2, $3, $4, $5, $6, $7,
+      $8, $9, $10, $11, $12, $13,
+      $14, $15, $16, $17, $18, $19, $20
+    )
+  `;
+
+  try {
+    await kairnPool.query(query, [
+      generateCuid(),
+      article.slug,
+      article.title,
+      article.description,
+      article.content,
+      article.author,
+      article.category,
+      article.tags || [],
+      newImageUrl || article.image,
+      article.imagePrompt,
+      article.seoIntent,
+      article.persona,
+      article.tones || [],
+      article.faq ? JSON.stringify(article.faq) : null,
+      article.jsonLd ? JSON.stringify(article.jsonLd) : null,
+      article.published,
+      article.featured,
+      article.date,
+      article.createdAt,
+      new Date(),
+    ]);
+    return true;
+  } catch (error) {
+    console.error(`  ❌ Insert failed: ${error}`);
+    return false;
+  }
+}
+
+// ============================================
+// Main Migration
+// ============================================
+
+async function migrate(): Promise<MigrationReport> {
+  console.log('╔════════════════════════════════════════════════════════════╗');
+  console.log('║       MIGRATION DES ARTICLES BLOG PSYPNOS → KAIRN         ║');
+  console.log('╚════════════════════════════════════════════════════════════╝\n');
+
+  // Initialize database connections
+  initConnections();
+
+  const report: MigrationReport = {
+    totalArticles: 0,
+    migratedArticles: 0,
+    skippedArticles: 0,
+    imagesTransferred: 0,
+    imagesFailed: 0,
+    errors: [],
+    hardcodedUrls: [],
+  };
+
+  try {
+    // ÉTAPE 1: Analyse
+    console.log('📋 ÉTAPE 1: Analyse préalable\n');
+
+    console.log('Connexion à PSYPNOS...');
+    const psypnosArticles = await fetchPsypnosArticles();
+    console.log(`✅ ${psypnosArticles.length} articles trouvés dans PSYPNOS\n`);
+    report.totalArticles = psypnosArticles.length;
+
+    const articlesWithImages = psypnosArticles.filter(a => a.image);
+    console.log(`📷 ${articlesWithImages.length} articles avec images`);
+
+    console.log('\nConnexion à KAIRN...');
+    const existingSlugs = await getExistingKairnSlugs();
+    console.log(`✅ ${existingSlugs.size} articles existants dans KAIRN\n`);
+
+    const duplicates = psypnosArticles.filter(a => existingSlugs.has(a.slug));
+    if (duplicates.length > 0) {
+      console.log(`⚠️  ${duplicates.length} slugs déjà présents (ignorés):`);
+      duplicates.forEach(d => console.log(`   - ${d.slug}`));
+      report.skippedArticles = duplicates.length;
+      console.log('');
+    }
+
+    const toMigrate = psypnosArticles.filter(a => !existingSlugs.has(a.slug));
+    console.log(`📦 ${toMigrate.length} articles à migrer\n`);
+
+    if (toMigrate.length === 0) {
+      console.log('✅ Aucun article à migrer.\n');
+      return report;
+    }
+
+    // ÉTAPE 2: Migration
+    console.log('═'.repeat(60));
+    console.log('📦 ÉTAPE 2: Migration des articles\n');
+
+    for (let i = 0; i < toMigrate.length; i += BATCH_SIZE) {
+      const batch = toMigrate.slice(i, i + BATCH_SIZE);
+      const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+      const totalBatches = Math.ceil(toMigrate.length / BATCH_SIZE);
+
+      console.log(`\n── Batch ${batchNum}/${totalBatches} ──\n`);
+
+      for (const article of batch) {
+        console.log(`📝 "${article.title}" (${article.slug})`);
+
+        // Check hardcoded URLs
+        const hardcodedUrls = findHardcodedUrls(article.content);
+        if (hardcodedUrls.length > 0) {
+          console.log(`  ⚠️  URLs PSYPNOS détectées:`);
+          hardcodedUrls.forEach(url => console.log(`     ${url}`));
+          report.hardcodedUrls.push({ slug: article.slug, urls: hardcodedUrls });
+        }
+
+        // Migrate image
+        let newImageUrl: string | null = null;
+        if (article.image && supabase) {
+          newImageUrl = await migrateImage(article.slug, article.image);
+          if (newImageUrl) {
+            report.imagesTransferred++;
+          } else {
+            report.imagesFailed++;
+          }
+        }
+
+        // Insert article
+        const success = await insertArticle(article, newImageUrl);
+        if (success) {
+          console.log(`  ✅ Article créé`);
+          report.migratedArticles++;
+        } else {
+          report.errors.push({ slug: article.slug, error: 'Insert failed' });
+        }
+      }
+    }
+
+    // ÉTAPE 3: Vérification
+    console.log('\n' + '═'.repeat(60));
+    console.log('🔍 ÉTAPE 3: Vérifications\n');
+
+    if (kairnPool) {
+      const countResult = await kairnPool.query('SELECT COUNT(*) FROM "BlogPostExtended"');
+      console.log(`📊 Total articles dans KAIRN: ${countResult.rows[0].count}`);
+    }
+
+    return report;
+  } finally {
+    if (psypnosPool) await psypnosPool.end();
+    if (kairnPool) await kairnPool.end();
+  }
+}
+
+// ============================================
+// Report
+// ============================================
+
+function printReport(report: MigrationReport): void {
+  console.log('\n' + '═'.repeat(60));
+  console.log('📋 RAPPORT DE MIGRATION');
+  console.log('═'.repeat(60) + '\n');
+
+  console.log('┌─────────────────────────────────────┬──────────┐');
+  console.log('│ Métrique                            │ Valeur   │');
+  console.log('├─────────────────────────────────────┼──────────┤');
+  console.log(
+    `│ Articles source (PSYPNOS)           │ ${String(report.totalArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Articles migrés                     │ ${String(report.migratedArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Articles ignorés (doublons)         │ ${String(report.skippedArticles).padStart(8)} │`
+  );
+  console.log(
+    `│ Images transférées                  │ ${String(report.imagesTransferred).padStart(8)} │`
+  );
+  console.log(
+    `│ Images échouées                     │ ${String(report.imagesFailed).padStart(8)} │`
+  );
+  console.log('└─────────────────────────────────────┴──────────┘');
+
+  if (report.errors.length > 0) {
+    console.log('\n⚠️  ERREURS:');
+    report.errors.forEach(e => console.log(`   - ${e.slug}: ${e.error}`));
+  }
+
+  if (report.hardcodedUrls.length > 0) {
+    console.log('\n⚠️  URLs PSYPNOS À CORRIGER:');
+    report.hardcodedUrls.forEach(item => {
+      console.log(`   📝 ${item.slug}:`);
+      item.urls.forEach(url => console.log(`      ${url}`));
+    });
+  }
+
+  console.log('\n' + '═'.repeat(60));
+  console.log(
+    report.errors.length === 0
+      ? '✅ MIGRATION TERMINÉE AVEC SUCCÈS'
+      : '⚠️  MIGRATION AVEC AVERTISSEMENTS'
+  );
+  console.log('═'.repeat(60) + '\n');
+}
+
+// ============================================
+// Main
+// ============================================
+
+async function main(): Promise<void> {
+  if (!process.env.PSYPNOS_DATABASE_URL) {
+    console.error('❌ PSYPNOS_DATABASE_URL is required');
+    console.error(
+      '   Example: postgresql://postgres:password@db.ukbbkoadbgifnxbcuxbr.supabase.co:5432/postgres'
+    );
+    process.exit(1);
+  }
+
+  if (!process.env.DATABASE_URL) {
+    console.error('❌ DATABASE_URL is required (KAIRN database)');
+    process.exit(1);
+  }
+
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
+    console.warn("⚠️  Supabase not configured - images won't be migrated");
+  }
+
+  try {
+    const report = await migrate();
+    printReport(report);
+    process.exit(report.errors.length > 0 ? 1 : 0);
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Add comprehensive migration scripts for transferring blog articles:
- migrate-blog-standalone.ts: Standalone script using pg only
- migrate-blog-from-psypnos.ts: Prisma-based migration with multi-source support
- migrate-blog-from-json.ts: JSON import alternative
- MIGRATION-BLOG.md: Documentation and usage instructions

Scripts support:
- Image migration to KAIRN Supabase Storage
- Duplicate detection by slug
- Hardcoded URL detection in content
- UTF-8 validation
- Batch processing to avoid timeouts
- Detailed migration reports

https://claude.ai/code/session_01SSy4gzXKppkWiY2mW3A2wy