### PR TITLE
Fix Prisma generation in build process and Vercel deployment

### DIFF
--- a/apps/unanima/vercel.json
+++ b/apps/unanima/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "pnpm install",
-  "buildCommand": "cd ../.. && pnpm turbo run build --filter=@kairn/unanima",
+  "buildCommand": "cd ../.. && pnpm --filter @kairn/db exec prisma generate && pnpm turbo run build --filter=@kairn/unanima --env-mode=loose",
   "outputDirectory": ".next",
   "regions": ["cdg1"],
   "functions": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,9 +17,9 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "prisma generate && tsc",
     "dev": "tsc --watch",
-    "type-check": "tsc --noEmit",
+    "type-check": "prisma generate && tsc --noEmit",
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts",
     "db:generate": "prisma generate",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "pnpm install",
-  "buildCommand": "pnpm turbo run build",
+  "buildCommand": "pnpm turbo run build --env-mode=loose",
   "regions": ["cdg1"],
   "functions": {
     "apps/*/app/api/**/*.ts": {


### PR DESCRIPTION
## Description

Ensures Prisma client is generated before TypeScript compilation in all build and type-checking scripts. This fixes build failures on Vercel where the Prisma client may not be available during the build process.

Changes include:
- Adding `prisma generate` to the `build` and `type-check` scripts in `packages/db/package.json`
- Explicitly running `prisma generate` in the Unanima Vercel build command before the turbo build
- Adding `--env-mode=loose` flag to Vercel build commands to handle environment variables more flexibly during deployment

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [x] Tous les sites (packages/)
- [ ] PSYPNOS uniquement
- [ ] Autre : Vercel deployment configuration

https://claude.ai/code/session_01FCLH23Z5Mhrqfb1AcwHf2Y