### PR TITLE
fix: resolve Vercel deployment build failures

### DIFF
--- a/apps/psypnos/components/GeoPage.tsx
+++ b/apps/psypnos/components/GeoPage.tsx
@@ -1,12 +1,13 @@
+'use client';
+
 /**
  * GeoPage wrapper for Psypnos
  *
  * This wrapper adapts the legacy GeoPage interface to use the shared
  * GeoPage component from @kairn/ui while maintaining backwards compatibility.
  */
-import Link from 'next/link';
-
 import { GeoPage as SharedGeoPage } from '@kairn/ui';
+import Link from 'next/link';
 
 import { Footer } from './Footer';
 import { NavigationMenu } from './NavigationMenu';
@@ -71,7 +72,11 @@ const serviceLinks: Record<GeoPageProps['service'], string> = {
 // Default pricing for Psypnos
 const defaultPricing = [
   { label: 'Séance standard', price: '70 €' },
-  { label: 'Tarif solidaire', price: '40-50 €', note: '* Tarif solidaire sur justificatif (étudiant, demandeur d\'emploi, etc.)' },
+  {
+    label: 'Tarif solidaire',
+    price: '40-50 €',
+    note: "* Tarif solidaire sur justificatif (étudiant, demandeur d'emploi, etc.)",
+  },
 ];
 
 // Default hours
@@ -94,10 +99,7 @@ function ResearchStatsSection({
 
       <div className="space-y-6">
         {researchStats.map((research, index) => (
-          <div
-            key={index}
-            className="border-ivory/10 border-b pb-6 last:border-b-0 last:pb-0"
-          >
+          <div key={index} className="border-ivory/10 border-b pb-6 last:border-b-0 last:pb-0">
             <div className="mb-2 flex items-start gap-3">
               <span className="text-gold mt-0.5 flex-shrink-0">
                 <svg
@@ -178,9 +180,7 @@ export function GeoPage({
   schemaData,
 }: GeoPageProps) {
   // Build extended main content with research stats if provided
-  const extendedMainContent = researchStats && researchStats.length > 0
-    ? mainContent
-    : mainContent;
+  const extendedMainContent = researchStats && researchStats.length > 0 ? mainContent : mainContent;
 
   return (
     <>

--- a/apps/psypnos/package.json
+++ b/apps/psypnos/package.json
@@ -17,6 +17,7 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@kairn/admin": "workspace:*",
     "@kairn/ai": "workspace:*",
+    "@kairn/analytics": "workspace:*",
     "@kairn/api": "workspace:*",
     "@kairn/config": "workspace:*",
     "@kairn/core": "workspace:*",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -7,5 +7,11 @@
     "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,12 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts"
+  ]
 }

--- a/packages/ui/src/components/blog/types.ts
+++ b/packages/ui/src/components/blog/types.ts
@@ -75,11 +75,11 @@ export interface CategoryColors {
  * Default category colors
  */
 export const defaultCategoryColors: CategoryColors = {
-  bg: "bg-gold/10",
-  text: "text-gold",
-  border: "border-gold/20",
-  hover: "hover:border-gold/40",
-  gradient: "from-gold to-gold/50",
+  bg: 'bg-gold/10',
+  text: 'text-gold',
+  border: 'border-gold/20',
+  hover: 'hover:border-gold/40',
+  gradient: 'from-gold to-gold/50',
 };
 
 /**
@@ -90,18 +90,19 @@ export type GetCategoryColors = (category: string) => CategoryColors;
 /**
  * Blog list view mode
  */
-export type BlogViewMode = "grid" | "list";
+export type BlogViewMode = 'grid' | 'list';
 
 /**
  * Sort options for blog posts
  */
-export type BlogSortOption = "date-desc" | "date-asc" | "title";
+export type BlogSortOption = 'date-desc' | 'date-asc' | 'title';
 
 /**
  * Props for link components (to support different routing libraries)
+ * Note: href accepts string or URL object for compatibility with Next.js Link
  */
 export interface LinkProps {
-  href: string;
+  href: string | { pathname?: string; query?: Record<string, string | string[]>; hash?: string };
   children: React.ReactNode;
   className?: string;
   target?: string;
@@ -111,8 +112,10 @@ export interface LinkProps {
 
 /**
  * Link component type (for dependency injection)
+ * Compatible with Next.js Link and similar routing libraries
  */
-export type LinkComponent = React.ComponentType<LinkProps>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LinkComponent = React.ComponentType<any>;
 
 /**
  * Image component props (to support different image libraries)

--- a/packages/ui/src/components/navigation/StickyNavigation.tsx
+++ b/packages/ui/src/components/navigation/StickyNavigation.tsx
@@ -197,13 +197,15 @@ export function StickyNavigation({
       href,
       children,
       className: linkClassName,
+      onClick,
       ...props
     }: {
       href: string;
       children: React.ReactNode;
       className?: string;
+      onClick?: () => void;
     }) => (
-      <a href={href} className={linkClassName} {...props}>
+      <a href={href} className={linkClassName} onClick={onClick} {...props}>
         {children}
       </a>
     ));

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -5,5 +5,11 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@kairn/ai':
         specifier: workspace:*
         version: link:../../packages/ai
+      '@kairn/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
       '@kairn/api':
         specifier: workspace:*
         version: link:../../packages/api


### PR DESCRIPTION
- Exclude test files from TypeScript compilation in ui, api, and core packages
- Add missing @kairn/analytics dependency to psypnos
- Fix LinkComponent type to be compatible with Next.js Link
- Add onClick support to StickyNavigation default Link component
- Mark GeoPage wrapper as client component to fix RSC serialization

https://claude.ai/code/session_01LDsbAok6GeLurGV8qHrygh