### PR TITLE
chore: switch package exports from dist to src TypeScript files

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -3,19 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "description": "Analytics tracking system for Kairn platform",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./client": {
-      "types": "./dist/client.d.ts",
-      "import": "./dist/client.mjs",
-      "require": "./dist/client.js"
+      "types": "./src/client/index.ts",
+      "import": "./src/client/index.ts",
+      "default": "./src/client/index.ts"
     }
   },
   "scripts": {

--- a/packages/blog/package.json
+++ b/packages/blog/package.json
@@ -3,14 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "description": "Blog management system for Kairn platform",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "description": "Types et schémas de configuration pour les sites Kairn",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,45 +3,53 @@
   "version": "0.0.1",
   "private": true,
   "description": "Core utilities, database, auth pour les sites Kairn",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./db": {
-      "types": "./dist/db/prisma.d.ts",
-      "import": "./dist/db/prisma.js"
+      "types": "./src/db/prisma.ts",
+      "import": "./src/db/prisma.ts",
+      "default": "./src/db/prisma.ts"
     },
     "./auth": {
-      "types": "./dist/auth/jwt.d.ts",
-      "import": "./dist/auth/jwt.js"
+      "types": "./src/auth/jwt.ts",
+      "import": "./src/auth/jwt.ts",
+      "default": "./src/auth/jwt.ts"
     },
     "./logger": {
-      "types": "./dist/logger/index.d.ts",
-      "import": "./dist/logger/index.js"
+      "types": "./src/logger/index.ts",
+      "import": "./src/logger/index.ts",
+      "default": "./src/logger/index.ts"
     },
     "./utils": {
-      "types": "./dist/utils/cookies.d.ts",
-      "import": "./dist/utils/cookies.js"
+      "types": "./src/utils/cookies.ts",
+      "import": "./src/utils/cookies.ts",
+      "default": "./src/utils/cookies.ts"
     },
     "./errors": {
-      "types": "./dist/errors/index.d.ts",
-      "import": "./dist/errors/index.js"
+      "types": "./src/errors/index.ts",
+      "import": "./src/errors/index.ts",
+      "default": "./src/errors/index.ts"
     },
     "./env": {
-      "types": "./dist/env/index.d.ts",
-      "import": "./dist/env/index.js"
+      "types": "./src/env/index.ts",
+      "import": "./src/env/index.ts",
+      "default": "./src/env/index.ts"
     },
     "./middleware": {
-      "types": "./dist/middleware/rate-limit.d.ts",
-      "import": "./dist/middleware/rate-limit.js"
+      "types": "./src/middleware/rate-limit.ts",
+      "import": "./src/middleware/rate-limit.ts",
+      "default": "./src/middleware/rate-limit.ts"
     },
     "./scheduler": {
-      "types": "./dist/scheduler/index.d.ts",
-      "import": "./dist/scheduler/index.js"
+      "types": "./src/scheduler/index.ts",
+      "import": "./src/scheduler/index.ts",
+      "default": "./src/scheduler/index.ts"
     }
   },
   "scripts": {

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -3,24 +3,28 @@
   "version": "0.0.1",
   "private": true,
   "description": "Social media integration module for Kairn sites - OAuth and publishing",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./oauth": {
-      "types": "./dist/oauth/index.d.ts",
-      "import": "./dist/oauth/index.js"
+      "types": "./src/oauth/index.ts",
+      "import": "./src/oauth/index.ts",
+      "default": "./src/oauth/index.ts"
     },
     "./posting": {
-      "types": "./dist/posting/index.d.ts",
-      "import": "./dist/posting/index.js"
+      "types": "./src/posting/index.ts",
+      "import": "./src/posting/index.ts",
+      "default": "./src/posting/index.ts"
     },
     "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "import": "./dist/utils/index.js"
+      "types": "./src/utils/index.ts",
+      "import": "./src/utils/index.ts",
+      "default": "./src/utils/index.ts"
     }
   },
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,17 +3,18 @@
   "version": "0.0.1",
   "private": true,
   "description": "Composants UI React pour les sites Kairn",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./components/*": {
-      "types": "./dist/components/*.d.ts",
-      "import": "./dist/components/*.js"
+      "types": "./src/components/*.ts",
+      "import": "./src/components/*.ts",
+      "default": "./src/components/*.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description

Mise à jour des configurations `package.json` de tous les packages pour pointer directement vers les fichiers source TypeScript (`src/`) au lieu des fichiers compilés (`dist/`). Cette modification simplifie la configuration des exports et supprime la dépendance à une étape de build préalable.

### Changements détaillés

- **analytics**: Mise à jour des exports principaux et du sous-export `./client`
- **blog**: Mise à jour des exports principaux
- **config**: Mise à jour des exports principaux
- **core**: Mise à jour des exports principaux et de tous les sous-exports (`./db`, `./auth`, `./logger`, `./utils`, `./errors`, `./env`, `./middleware`, `./scheduler`)
- **social**: Mise à jour des exports principaux et des sous-exports (`./oauth`, `./posting`, `./utils`)
- **ui**: Mise à jour des exports principaux et du pattern `./components/*`

### Modifications appliquées à chaque package

- Suppression des champs `"module"` (`.mjs`)
- Remplacement des chemins `./dist/*.js` et `./dist/*.d.ts` par `./src/*.ts`
- Normalisation des exports avec un champ `"default"` cohérent
- Suppression des exports `"require"` redondants

## Type de changement

- [x] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [x] Tous les sites (packages/)

https://claude.ai/code/session_01AhWGbGM2YXXSPPYG8ni6Gg