### PR TITLE
feat: integrate AI ChatWidget on Psypnos site

### DIFF
--- a/apps/psypnos/app/layout.tsx
+++ b/apps/psypnos/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 
+import { PsypnosChatWidget } from '@/components/ChatWidgetWrapper';
 import { PsypnosFloatingContactButton } from '@/components/FloatingContactButtonWrapper';
 import { WebVitalsReporter } from '@/components/WebVitalsReporter';
 import { CustomizationProvider } from '@/lib/customization-context';
@@ -482,6 +483,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ThemeProvider defaultTheme="dark">
             <ToastProvider position="top-right">
               {children}
+              <PsypnosChatWidget />
               <PsypnosFloatingContactButton />
               <WebVitalsReporter />
             </ToastProvider>

--- a/apps/psypnos/components/ChatWidgetWrapper.tsx
+++ b/apps/psypnos/components/ChatWidgetWrapper.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { ChatWidget } from '@kairn/ui';
+
+import { trackConversionEvent } from '../hooks/useAnalytics';
+
+/**
+ * Psypnos-specific wrapper for the AI ChatWidget.
+ *
+ * Positioned bottom-left to avoid overlap with the FloatingContactButton (bottom-right).
+ */
+export function PsypnosChatWidget() {
+  const handleBookAppointment = () => {
+    trackConversionEvent('appointment_request', 'chatbot_suggestion', false);
+    window.location.href = '/contact';
+  };
+
+  const handleConversationEnd = async (satisfied: boolean | null) => {
+    if (satisfied !== null) {
+      await trackConversionEvent('fab_click', 'chatbot_feedback', satisfied);
+    }
+  };
+
+  return (
+    <ChatWidget
+      apiEndpoint="/api/chat"
+      siteName="Psypnos"
+      greeting="Bonjour ! Je suis l'assistant virtuel de Psypnos. Je peux répondre à vos questions sur l'hypnothérapie, la sophrologie et nos services. Comment puis-je vous aider ?"
+      placeholder="Posez votre question..."
+      suggestedQuestions={[
+        'Quels services proposez-vous ?',
+        'Comment se déroule une séance ?',
+        'Quels sont vos tarifs ?',
+        'Comment prendre rendez-vous ?',
+      ]}
+      primaryColor="#c7a962"
+      secondaryColor="#1a1a2e"
+      position="bottom-left"
+      contactUrl="/contact"
+      onBookAppointment={handleBookAppointment}
+      onConversationEnd={handleConversationEnd}
+    />
+  );
+}
+
+export default PsypnosChatWidget;


### PR DESCRIPTION
The ChatWidget component and its API backend (/api/chat) were fully
implemented but never rendered. Add a PsypnosChatWidget wrapper with
Psypnos-specific configuration (colors, greeting, suggested questions)
and include it in the root layout, positioned bottom-left to coexist
with the existing FloatingContactButton (bottom-right).

https://claude.ai/code/session_01BAA2h21NogJgLZLjE5KjnL