### PR TITLE
Add rate limiting configuration for chat endpoint

### DIFF
--- a/apps/psypnos/app/api/common/rate-limiter.ts
+++ b/apps/psypnos/app/api/common/rate-limiter.ts
@@ -28,6 +28,7 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   appointment: { maxAttempts: 5, windowMs: 60 * 1000 }, // 5 demandes/minute
   registration: { maxAttempts: 3, windowMs: 60 * 1000 }, // 3 inscriptions/minute
   assistant: { maxAttempts: 10, windowMs: 60 * 60 * 1000 }, // 10 requêtes/heure
+  chat: { maxAttempts: 20, windowMs: 60 * 60 * 1000 }, // 20 messages/heure
   improveText: { maxAttempts: 20, windowMs: 60 * 60 * 1000 }, // 20 requêtes/heure
   analytics: { maxAttempts: 100, windowMs: 60 * 1000 }, // 100 requêtes/minute
 };


### PR DESCRIPTION
## Description

Ajout d'une configuration de rate limiting pour l'endpoint de chat. Cette limite permet de contrôler le nombre de messages envoyés par les utilisateurs et de prévenir les abus.

La configuration définie autorise **20 messages par heure** par utilisateur, ce qui offre un équilibre entre l'accessibilité et la protection contre les abus.

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

https://claude.ai/code/session_016poSgcdqYcLHAvEwXZazPw