### PR TITLE
fix: display all scheduled posts for the selected calendar month

### DIFF
--- a/apps/psypnos/app/admin/social/_components/SocialCalendar.tsx
+++ b/apps/psypnos/app/admin/social/_components/SocialCalendar.tsx
@@ -57,6 +57,7 @@ interface SocialCalendarProps {
   onEditPost: (post: CalendarPost) => void;
   onDeletePost: (postId: string) => void;
   selectedPostId?: string | null;
+  onMonthChange?: (year: number, month: number) => void;
 }
 
 // ===========================================
@@ -684,6 +685,7 @@ export function SocialCalendar({
   onEditPost,
   onDeletePost,
   selectedPostId,
+  onMonthChange,
 }: SocialCalendarProps) {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [view, setView] = useState<CalendarView>('month');
@@ -720,16 +722,19 @@ export function SocialCalendar({
         } else {
           newDate.setDate(prev.getDate() + (direction === 'next' ? 1 : -1));
         }
+        onMonthChange?.(newDate.getFullYear(), newDate.getMonth());
         return newDate;
       });
     },
-    [view]
+    [view, onMonthChange]
   );
 
   const goToToday = useCallback(() => {
-    setCurrentDate(new Date());
+    const today = new Date();
+    setCurrentDate(today);
     setSelectedDay(null);
-  }, []);
+    onMonthChange?.(today.getFullYear(), today.getMonth());
+  }, [onMonthChange]);
 
   const handleDateSelect = useCallback(
     (date: Date) => {

--- a/apps/psypnos/app/admin/social/page.tsx
+++ b/apps/psypnos/app/admin/social/page.tsx
@@ -66,14 +66,29 @@ export default function SocialPage() {
   const [editingPost, setEditingPost] = useState<SocialPostData | null>(null);
   const [isPublishing, setIsPublishing] = useState(false);
 
+  // Calendar month tracking
+  const [calendarYear, setCalendarYear] = useState(() => new Date().getFullYear());
+  const [calendarMonth, setCalendarMonth] = useState(() => new Date().getMonth());
+
   // ===========================================
   // Data Loading
   // ===========================================
 
-  const loadData = useCallback(async () => {
+  const loadData = useCallback(async (year?: number, month?: number) => {
     try {
-      // Load posts
-      const postsRes = await fetch('/api/social/posts?t=' + Date.now(), {
+      // Build date range for the target month
+      const targetYear = year ?? calendarYear;
+      const targetMonth = month ?? calendarMonth;
+      const from = new Date(targetYear, targetMonth, 1).toISOString();
+      const to = new Date(targetYear, targetMonth + 1, 0, 23, 59, 59, 999).toISOString();
+
+      // Load posts scoped to the calendar month
+      const params = new URLSearchParams({
+        t: Date.now().toString(),
+        from,
+        to,
+      });
+      const postsRes = await fetch(`/api/social/posts?${params}`, {
         cache: 'no-store',
       });
       if (postsRes.ok) {
@@ -104,7 +119,7 @@ export default function SocialPage() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [calendarYear, calendarMonth]);
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
@@ -236,6 +251,19 @@ export default function SocialPage() {
       });
     }
   };
+
+  // ===========================================
+  // Calendar month change handler
+  // ===========================================
+
+  const handleMonthChange = useCallback(
+    (year: number, month: number) => {
+      setCalendarYear(year);
+      setCalendarMonth(month);
+      loadData(year, month);
+    },
+    [loadData]
+  );
 
   // ===========================================
   // Computed Data
@@ -482,6 +510,7 @@ export default function SocialPage() {
                   onEditPost={post => setEditingPost(posts.find(p => p.id === post.id) || null)}
                   onDeletePost={handleDeletePost}
                   selectedPostId={selectedPost?.id}
+                  onMonthChange={handleMonthChange}
                 />
               </motion.div>
             )}

--- a/apps/psypnos/lib/social/store.ts
+++ b/apps/psypnos/lib/social/store.ts
@@ -202,8 +202,8 @@ export async function getSocialPosts(filters: SocialPostFilters = {}): Promise<S
   const posts = await prisma.socialPost.findMany({
     where,
     orderBy: { scheduledAt: 'asc' },
-    take: filters.limit || 500,
-    skip: filters.offset || 0,
+    ...(filters.limit ? { take: filters.limit } : {}),
+    ...(filters.offset ? { skip: filters.offset } : {}),
   });
 
   return posts.map(mapPost);
@@ -239,8 +239,8 @@ export async function getSocialPostsWithRelations(
       analytics: true,
     },
     orderBy: { scheduledAt: 'asc' },
-    take: filters.limit || 100,
-    skip: filters.offset || 0,
+    ...(filters.limit ? { take: filters.limit } : {}),
+    ...(filters.offset ? { skip: filters.offset } : {}),
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
The /admin/social page was silently truncating posts due to hard-coded
pagination limits (100 in getSocialPostsWithRelations, 500 in
getSocialPosts). Posts were fetched without any date filter, so only
the oldest 100 posts by scheduledAt were returned.

- Remove default take/skip limits from store query functions; only
  apply them when explicitly provided via filters
- Scope API fetch to the currently viewed calendar month (from/to)
- Add onMonthChange callback to SocialCalendar so the page re-fetches
  posts when navigating between months

https://claude.ai/code/session_01K57AyVhzbRSwq5yatu3UsM