### PR TITLE
Make sitemap generation async to support async blog data fetching

### DIFF
--- a/apps/psypnos/app/sitemap.ts
+++ b/apps/psypnos/app/sitemap.ts
@@ -1,8 +1,8 @@
 import { MetadataRoute } from 'next'
 
-import { getAllPosts } from '@/lib/blog'
+import { getAllPostsAsync } from '@/lib/blog'
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://psypnos.fr'
 
   // Pages statiques principales
@@ -132,7 +132,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   ]
 
   // Articles de blog
-  const posts = getAllPosts()
+  const posts = await getAllPostsAsync()
   const blogPosts: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${baseUrl}/blog/${post.slug}`,
     lastModified: new Date(post.date),


### PR DESCRIPTION
## Description

Convert the sitemap route handler from synchronous to asynchronous to support the new async `getAllPostsAsync()` function for fetching blog posts. This change ensures the sitemap can properly await blog post data retrieval.

### Changes
- Changed `sitemap()` function to `async function sitemap()`
- Updated return type to `Promise<MetadataRoute.Sitemap>`
- Replaced `getAllPosts()` with `await getAllPostsAsync()`

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

## Test Plan

Next.js supports async route handlers for metadata routes. The sitemap will be generated correctly with blog posts fetched asynchronously. Verify sitemap generation works via `npm run build` and check `/sitemap.xml` output includes blog posts.

https://claude.ai/code/session_015wG8Ys4ZjQ1qoxp6By8Ti3