### PR TITLE
Refactor: Remove dynamic imports for Analytics components

### DIFF
--- a/apps/psypnos/app/layout.tsx
+++ b/apps/psypnos/app/layout.tsx
@@ -1,18 +1,12 @@
 import type { Metadata, Viewport } from 'next';
 
-import dynamic from 'next/dynamic';
-
+import { Analytics, SectionTracker } from '@/components/Analytics';
 import { PsypnosChatWidget } from '@/components/ChatWidgetWrapper';
 import { PsypnosFloatingContactButton } from '@/components/FloatingContactButtonWrapper';
 import { WebVitalsReporter } from '@/components/WebVitalsReporter';
 import { CustomizationProvider } from '@/lib/customization-context';
 import { ThemeProvider } from '@/lib/theme-context';
 import { ToastProvider } from '@/lib/toast-context';
-
-// Global analytics tracking — initialized once, covers ALL pages.
-// Loaded client-only (SSR: false) to avoid hydration issues.
-const Analytics = dynamic(() => import('@/components/Analytics').then(mod => ({ default: mod.Analytics })), { ssr: false });
-const SectionTracker = dynamic(() => import('@/components/Analytics').then(mod => ({ default: mod.SectionTracker })), { ssr: false });
 
 import './globals.css';
 


### PR DESCRIPTION
## Description

Removed dynamic imports for `Analytics` and `SectionTracker` components in the root layout. These components are now imported statically, simplifying the import structure and removing unnecessary SSR configuration.

The components were previously loaded dynamically with `ssr: false` to avoid hydration issues, but this approach is no longer needed with the current implementation.

## Type de changement

- [ ] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

## Notes

This change simplifies the component initialization in the root layout by using standard ES6 imports instead of dynamic imports. The Analytics and SectionTracker components are now loaded synchronously as part of the normal module resolution.

https://claude.ai/code/session_01C1rXNfjM4WsJE5YGueAvKc