### PR TITLE
fix(tracking): resolve 16 tracking issues across client and server

### DIFF
--- a/apps/psypnos/app/api/analytics/dashboard/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/route.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextRequest } from 'next/server';
 
 import { getCached, buildCacheKey, CACHE_KEYS, CACHE_TTL } from '@/lib/cache/redis';
@@ -128,9 +126,10 @@ export async function GET(request: NextRequest) {
     const startISO = startDate.toISOString();
     const endISO = endDate.toISOString();
 
-    // Use Redis cache for the entire dashboard response (except realtime)
+    const siteId = getCurrentSiteId();
     const cacheTTL = isRealtimeMode ? CACHE_TTL.SHORT : CACHE_TTL.MEDIUM;
     const cacheKey = buildCacheKey(CACHE_KEYS.DASHBOARD, {
+      siteId,
       timeRange,
       start: startISO,
       end: endISO,
@@ -159,7 +158,7 @@ export async function GET(request: NextRequest) {
           getAnalyticsSummaryWithComparison(comparisonTimeRange),
           getSectionHeatmap(startISO, endISO),
           isRealtimeMode
-            ? getPageVisits(startISO, endISO)
+            ? getPageVisits(startISO, endISO).then((visits: any[]) => visits.slice(0, 1000))
             : getVisitsByPeriod(comparisonTimeRange, startISO, endISO),
           getTrafficSources(startISO, endISO),
           getDeviceBreakdown(startISO, endISO),

--- a/apps/psypnos/app/api/analytics/store-index.ts
+++ b/apps/psypnos/app/api/analytics/store-index.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Analytics Store Index
  * Phase 4: Scalability & Performance

--- a/apps/psypnos/app/api/analytics/store-postgres/page-visits.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/page-visits.ts
@@ -5,7 +5,7 @@
  * Page visit data is stored in the `data` JSON field.
  */
 
-import { EventType } from "@prisma/client";
+import { EventType, Prisma } from "@prisma/client";
 
 import { invalidateDashboardCache } from "@/lib/cache/redis";
 import { prisma } from "@/lib/db/prisma";
@@ -20,9 +20,8 @@ import {
   getCurrentSiteId,
 } from "./utils";
 
-/**
- * Converts an AnalyticsEvent record to PageVisit type
- */
+const DEFAULT_PAGE_LIMIT = 10_000;
+
 function toPageVisit(record: {
   id: string;
   createdAt: Date;
@@ -30,7 +29,7 @@ function toPageVisit(record: {
   path: string;
   referrer: string | null;
   userAgent: string | null;
-  data: unknown;
+  data: Prisma.JsonValue;
 }): PageVisit {
   const data = (record.data as Record<string, unknown>) || {};
 
@@ -56,9 +55,6 @@ function toPageVisit(record: {
   };
 }
 
-/**
- * Track a page visit
- */
 export async function trackPageVisit(pageVisit: {
   timestamp: string;
   sessionId: string;
@@ -80,7 +76,6 @@ export async function trackPageVisit(pageVisit: {
 }): Promise<PageVisit> {
   const siteId = getCurrentSiteId();
 
-  // Build the data object for JSON storage
   const eventData = buildPageVisitData({
     referrer: pageVisit.referrer,
     utmSource: pageVisit.utmSource,
@@ -97,6 +92,11 @@ export async function trackPageVisit(pageVisit: {
     timeOnPage: pageVisit.timeOnPage,
   });
 
+  const createdAt = new Date(pageVisit.timestamp);
+  if (isNaN(createdAt.getTime())) {
+    throw new Error(`Invalid timestamp: ${pageVisit.timestamp}`);
+  }
+
   const result = await prisma.analyticsEvent.create({
     data: {
       type: EventType.PAGE_VIEW,
@@ -105,7 +105,7 @@ export async function trackPageVisit(pageVisit: {
       userAgent: pageVisit.userAgent,
       referrer: pageVisit.referrer,
       data: toPrismaJson(eventData),
-      createdAt: new Date(pageVisit.timestamp),
+      createdAt,
       siteId,
     },
   });
@@ -116,11 +116,12 @@ export async function trackPageVisit(pageVisit: {
 }
 
 /**
- * Get page visits within a date range
+ * Get page visits within a date range (with pagination)
  */
 export async function getPageVisits(
   startDate?: string,
-  endDate?: string
+  endDate?: string,
+  limit: number = DEFAULT_PAGE_LIMIT
 ): Promise<PageVisit[]> {
   const siteId = getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
@@ -132,14 +133,12 @@ export async function getPageVisits(
       ...dateFilter,
     },
     orderBy: { createdAt: "desc" },
+    take: limit,
   });
 
   return visits.map(toPageVisit);
 }
 
-/**
- * Get page visits for a specific session
- */
 export async function getPageVisitsBySession(sessionId: string): Promise<PageVisit[]> {
   const siteId = getCurrentSiteId();
 
@@ -156,7 +155,7 @@ export async function getPageVisitsBySession(sessionId: string): Promise<PageVis
 }
 
 /**
- * Get unique page paths with visit counts
+ * Get unique page paths with visit counts using SQL aggregation
  */
 export async function getTopPages(
   startDate?: string,
@@ -164,41 +163,42 @@ export async function getTopPages(
   limit: number = 10
 ): Promise<Array<{ page: string; visits: number; uniqueSessions: number }>> {
   const siteId = getCurrentSiteId();
-  const dateFilter = buildDateFilter(startDate, endDate);
 
-  const visits = await prisma.analyticsEvent.findMany({
-    where: {
-      siteId,
-      type: EventType.PAGE_VIEW,
-      ...dateFilter,
-    },
-    select: {
-      path: true,
-      sessionId: true,
-    },
-  });
+  // Build parameterized SQL query for safe aggregation
+  const params: unknown[] = [siteId, 'PAGE_VIEW'];
+  const conditions: string[] = [
+    `"siteId" = $1`,
+    `"type"::"text" = $2`,
+  ];
 
-  // Aggregate by page
-  const pageStats = new Map<string, { visits: number; sessions: Set<string> }>();
-
-  for (const visit of visits) {
-    const stats = pageStats.get(visit.path) || { visits: 0, sessions: new Set<string>() };
-    stats.visits++;
-    if (visit.sessionId) {
-      stats.sessions.add(visit.sessionId);
-    }
-    pageStats.set(visit.path, stats);
+  if (startDate) {
+    params.push(new Date(startDate));
+    conditions.push(`"createdAt" >= $${params.length}`);
+  }
+  if (endDate) {
+    params.push(new Date(endDate));
+    conditions.push(`"createdAt" <= $${params.length}`);
   }
 
-  // Convert to array and sort
-  const result = Array.from(pageStats.entries())
-    .map(([page, stats]) => ({
-      page,
-      visits: stats.visits,
-      uniqueSessions: stats.sessions.size,
-    }))
-    .sort((a, b) => b.visits - a.visits)
-    .slice(0, limit);
+  params.push(limit);
 
-  return result;
+  const result = await prisma.$queryRawUnsafe<
+    Array<{ page: string; visits: bigint; unique_sessions: bigint }>
+  >(
+    `SELECT "path" as page,
+            COUNT(*) as visits,
+            COUNT(DISTINCT "sessionId") as unique_sessions
+     FROM "AnalyticsEvent"
+     WHERE ${conditions.join(' AND ')}
+     GROUP BY "path"
+     ORDER BY visits DESC
+     LIMIT $${params.length}`,
+    ...params
+  );
+
+  return result.map((row) => ({
+    page: row.page,
+    visits: Number(row.visits),
+    uniqueSessions: Number(row.unique_sessions),
+  }));
 }

--- a/apps/psypnos/app/api/analytics/track/route.ts
+++ b/apps/psypnos/app/api/analytics/track/route.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Prisma models may not be available in Kairn schema
 /**
  * API de Tracking Analytics Unifiée
  *
@@ -16,7 +13,7 @@ import { createHmac } from 'crypto';
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
 
-import type { TrackingPayload, TrackingEvent, GeolocationData } from '@/lib/tracking/types';
+import type { TrackingPayload, TrackingEvent, GeolocationData } from '@/lib/tracking';
 
 import { recordAttempt, getClientIP } from '../../common/rate-limiter';
 
@@ -47,11 +44,16 @@ const SessionDataSchema = z.object({
   isReturning: z.boolean(),
 });
 
+const VALID_EVENT_TYPES = [
+  'page_view', 'page_exit', 'scroll_depth', 'section_view',
+  'section_time', 'conversion', 'custom_event', 'session_start', 'session_end',
+] as const;
+
 const BaseEventSchema = z.object({
-  type: z.string(),
-  timestamp: z.string(),
-  sessionId: z.string(),
-  url: z.string(),
+  type: z.enum(VALID_EVENT_TYPES),
+  timestamp: z.string().refine((s) => !isNaN(Date.parse(s)), { message: 'Invalid timestamp' }),
+  sessionId: z.string().min(1),
+  url: z.string().min(1),
 });
 
 const TrackingPayloadSchema = z.object({
@@ -154,7 +156,7 @@ function getCountryName(code: string): string {
  */
 function isBot(userAgent: string): boolean {
   const botPatterns = [
-    /bot/i,
+    /bot\b/i,
     /crawler/i,
     /spider/i,
     /crawling/i,
@@ -163,20 +165,22 @@ function isBot(userAgent: string): boolean {
     /pingdom/i,
     /gtmetrix/i,
     /pagespeed/i,
-    /google/i,
-    /bing/i,
-    /yahoo/i,
-    /yandex/i,
-    /baidu/i,
-    /duckduck/i,
+    /googlebot/i,
+    /google-inspectiontool/i,
+    /bingbot/i,
+    /bingpreview/i,
+    /yahoo!?\s*slurp/i,
+    /yandexbot/i,
+    /baiduspider/i,
+    /duckduckbot/i,
     /facebookexternalhit/i,
     /twitterbot/i,
     /linkedinbot/i,
     /slackbot/i,
     /telegrambot/i,
     /whatsapp/i,
-    /semrush/i,
-    /ahrefs/i,
+    /semrushbot/i,
+    /ahrefsbot/i,
     /mj12bot/i,
     /dotbot/i,
     /petalbot/i,
@@ -198,21 +202,46 @@ function isBot(userAgent: string): boolean {
 /**
  * Traite les événements de tracking et les persiste en base de données
  */
+// Type for event fields that go beyond BaseEventSchema
+// These are validated by the client tracker but passed through BaseEventSchema
+interface EventExtras {
+  referrer?: string;
+  timeOnPage?: number;
+  scrollDepthPercent?: number;
+  engagementScore?: number;
+  depth?: number;
+  sectionId?: string;
+  sectionName?: string;
+  timeSpent?: number;
+  conversionType?: string;
+  stepName?: string;
+  stepOrder?: number;
+  completed?: boolean;
+  value?: number;
+  metadata?: Record<string, unknown>;
+  category?: string;
+  action?: string;
+  label?: string;
+  duration?: number;
+  pageViewCount?: number;
+  exitPage?: string;
+  bounced?: boolean;
+}
+
+type ValidatedEvent = z.infer<typeof BaseEventSchema> & EventExtras;
+
 async function processEvents(
-  events: TrackingEvent[],
-  session: TrackingPayload['session'],
-  clientInfo: TrackingPayload['clientInfo'],
+  events: ValidatedEvent[],
+  session: z.infer<typeof SessionDataSchema>,
+  clientInfo: z.infer<typeof TrackingPayloadSchema>['clientInfo'],
   geolocation: GeolocationData | null,
   clientIP: string
 ): Promise<{ processed: number; errors: string[] }> {
   const errors: string[] = [];
   let processed = 0;
 
-  // Import dynamique du store
   const store = await import('../store-index');
 
-  // IMPORTANT: Enregistrer la géolocalisation au premier événement de chaque session
-  // La fonction trackGeolocation vérifie si une entrée existe déjà pour éviter les doublons
   if (geolocation && events.length > 0) {
     try {
       await trackGeolocation(
@@ -223,7 +252,6 @@ async function processEvents(
       );
     } catch (error) {
       console.error('[Track API] Error tracking geolocation:', error);
-      // Ne pas bloquer le traitement des événements si la géolocalisation échoue
     }
   }
 
@@ -235,7 +263,7 @@ async function processEvents(
             timestamp: event.timestamp,
             sessionId: event.sessionId,
             page: event.url,
-            referrer: (event as { referrer?: string }).referrer || undefined,
+            referrer: event.referrer || undefined,
             userAgent: clientInfo.userAgent,
             utmSource: session.utmSource || undefined,
             utmMedium: session.utmMedium || undefined,
@@ -251,158 +279,114 @@ async function processEvents(
           break;
 
         case 'page_exit':
-          // Mise à jour de la visite de page existante avec le temps et scroll
-          const exitEvent = event as {
-            timeOnPage?: number;
-            scrollDepthPercent?: number;
-          };
-
-          // On enregistre comme un événement personnalisé pour le temps et scroll
           await store.trackCustomEvent({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
             category: 'Engagement',
             action: 'page_exit',
             label: event.url,
-            value: exitEvent.timeOnPage,
+            value: event.timeOnPage,
             metadata: {
-              scrollDepthPercent: exitEvent.scrollDepthPercent,
-              engagementScore: (event as { engagementScore?: number }).engagementScore,
+              scrollDepthPercent: event.scrollDepthPercent,
+              engagementScore: event.engagementScore,
             },
           });
           break;
 
         case 'scroll_depth':
-          const scrollEvent = event as { depth?: number };
           await store.trackCustomEvent({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
             category: 'Engagement',
             action: 'scroll_depth',
             label: event.url,
-            value: scrollEvent.depth,
+            value: event.depth,
           });
           break;
 
         case 'section_view':
-          const sectionViewEvent = event as { sectionId?: string; sectionName?: string };
           await store.trackCustomEvent({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
             category: 'Section',
             action: 'view',
-            label: sectionViewEvent.sectionName || sectionViewEvent.sectionId,
-            metadata: { sectionId: sectionViewEvent.sectionId, page: event.url },
+            label: event.sectionName || event.sectionId,
+            metadata: { sectionId: event.sectionId, page: event.url },
           });
           break;
 
-        case 'section_time':
-          const sectionTimeEvent = event as {
-            sectionId?: string;
-            sectionName?: string;
-            timeSpent?: number;
-          };
-          // Determine section name, skip if unknown or invalid
-          const sectionName = sectionTimeEvent.sectionName || sectionTimeEvent.sectionId;
+        case 'section_time': {
+          const sectionName = event.sectionName || event.sectionId;
           if (sectionName && sectionName.toLowerCase() !== 'unknown') {
             await store.trackSectionTime({
               timestamp: event.timestamp,
               sessionId: event.sessionId,
               section: sectionName,
-              timeSpent: sectionTimeEvent.timeSpent || 0,
+              timeSpent: event.timeSpent || 0,
             });
           }
-          // Skip tracking for 'unknown' sections - they provide no useful data
           break;
+        }
 
-        case 'conversion':
-          const conversionEvent = event as {
-            conversionType?: string;
-            stepName?: string;
-            stepOrder?: number;
-            completed?: boolean;
-            value?: number;
-            metadata?: Record<string, unknown>;
-          };
+        case 'conversion': {
+          const conversionType = event.conversionType || 'contact_form';
+          const stepName = event.stepName || 'unknown';
 
-          // Enregistrer l'événement de conversion
           await store.trackConversionEvent({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
-            eventType: (conversionEvent.conversionType ||
-              'contact_form') as 'appointment_request' | 'seminar_registration' | 'contact_form',
-            stepName: conversionEvent.stepName || 'unknown',
-            completed: conversionEvent.completed || false,
-            metadata: conversionEvent.metadata,
+            eventType: conversionType as 'appointment_request' | 'seminar_registration' | 'contact_form',
+            stepName,
+            completed: event.completed || false,
+            metadata: event.metadata,
           });
 
-          // Enregistrer aussi comme étape de funnel
           await store.trackFunnelStep({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
-            funnelName: conversionEvent.conversionType || 'default',
-            stepName: conversionEvent.stepName || 'unknown',
-            stepOrder: conversionEvent.stepOrder || 0,
-            metadata: conversionEvent.metadata,
+            funnelName: conversionType,
+            stepName,
+            stepOrder: event.stepOrder || 0,
+            metadata: event.metadata,
           });
           break;
+        }
 
         case 'custom_event':
-          const customEvent = event as {
-            category?: string;
-            action?: string;
-            label?: string;
-            value?: number;
-            metadata?: Record<string, unknown>;
-          };
           await store.trackCustomEvent({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
-            category: customEvent.category || 'Unknown',
-            action: customEvent.action || 'unknown',
-            label: customEvent.label,
-            value: customEvent.value,
-            metadata: customEvent.metadata,
+            category: event.category || 'Unknown',
+            action: event.action || 'unknown',
+            label: event.label,
+            value: event.value,
+            metadata: event.metadata,
           });
           break;
 
         case 'session_start':
-          // La géolocalisation est maintenant enregistrée automatiquement au début de processEvents
-          // Ce case est conservé pour compatibilité avec les clients qui envoient cet événement
           break;
 
         case 'session_end':
-          const sessionEndEvent = event as {
-            duration?: number;
-            pageViewCount?: number;
-            exitPage?: string;
-            bounced?: boolean;
-          };
-
-          // Enregistrer comme événement personnalisé
           await store.trackCustomEvent({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
             category: 'Session',
             action: 'end',
-            value: sessionEndEvent.duration,
+            value: event.duration,
             metadata: {
-              pageViewCount: sessionEndEvent.pageViewCount,
-              exitPage: sessionEndEvent.exitPage,
-              bounced: sessionEndEvent.bounced,
+              pageViewCount: event.pageViewCount,
+              exitPage: event.exitPage,
+              bounced: event.bounced,
             },
           });
           break;
-
-        default:
-          // Type d'événement inconnu - logger mais ne pas échouer
-          console.warn(`[Track API] Unknown event type: ${(event as { type: string }).type}`);
       }
 
       processed++;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
-      errors.push(`Event ${(event as { type: string }).type}: ${message}`);
+      errors.push(`Event ${event.type}: ${message}`);
       console.error(`[Track API] Error processing event:`, error);
     }
   }
@@ -420,16 +404,16 @@ async function trackGeolocation(
   ipAddress: string
 ): Promise<void> {
   const { prisma } = await import('@/lib/db/prisma');
+  const { getCurrentSiteId } = await import('../store-postgres/utils');
 
-  // Vérifier si la géolocalisation existe déjà pour cette session
-  const existing = await prisma.visitorGeolocation.findFirst({
+  const siteId = getCurrentSiteId();
+
+  // Use upsert to avoid race conditions between concurrent requests
+  // for the same session (findFirst + create is not atomic)
+  await prisma.visitorGeolocation.upsert({
     where: { sessionId },
-  });
-
-  if (existing) return;
-
-  await prisma.visitorGeolocation.create({
-    data: {
+    update: {}, // No-op if already exists
+    create: {
       timestamp: new Date(timestamp),
       sessionId,
       country: geo.country,
@@ -440,7 +424,8 @@ async function trackGeolocation(
       latitude: geo.latitude,
       longitude: geo.longitude,
       timezone: geo.timezone,
-      ipAddress: hashIP(ipAddress), // Hasher l'IP pour la confidentialité
+      ipAddress: hashIP(ipAddress),
+      siteId,
     },
   });
 }
@@ -450,7 +435,11 @@ async function trackGeolocation(
  * Utilise HMAC-SHA256 avec un secret pour empêcher la réversibilité par force brute
  */
 function hashIP(ip: string): string {
-  const secret = process.env.IP_HASH_SECRET || process.env.JWT_SECRET || 'kairn-ip-hash-fallback';
+  const secret = process.env.IP_HASH_SECRET || process.env.JWT_SECRET;
+  if (!secret) {
+    console.warn('[Track API] No IP_HASH_SECRET or JWT_SECRET configured, IP hashing is insecure');
+    return `ip_${createHmac('sha256', 'kairn-dev-only').update(ip).digest('hex').slice(0, 16)}`;
+  }
   return `ip_${createHmac('sha256', secret).update(ip).digest('hex').slice(0, 16)}`;
 }
 
@@ -514,11 +503,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const payload = validationResult.data as TrackingPayload;
+    const payload = validationResult.data;
 
     // Vérifier si c'est un bot
     if (isBot(payload.clientInfo.userAgent)) {
-      // Ignorer silencieusement les requêtes de bots
       return Response.json({
         success: true,
         processed: 0,
@@ -532,7 +520,7 @@ export async function POST(request: NextRequest) {
 
     // Traiter les événements
     const result = await processEvents(
-      payload.events as TrackingEvent[],
+      payload.events as ValidatedEvent[],
       payload.session,
       payload.clientInfo,
       geolocation,
@@ -562,14 +550,34 @@ export async function POST(request: NextRequest) {
 /**
  * OPTIONS handler pour CORS (si nécessaire)
  */
-export async function OPTIONS() {
+export async function OPTIONS(request: NextRequest) {
+  const origin = request.headers.get('origin') || '';
+  const allowedOrigin = getAllowedOrigin(origin);
+
   return new Response(null, {
     status: 204,
     headers: {
-      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Origin': allowedOrigin,
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
       'Access-Control-Max-Age': '86400',
     },
   });
+}
+
+function getAllowedOrigin(origin: string): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.VERCEL_URL;
+  if (!siteUrl) {
+    // In development, allow localhost origins
+    if (origin.startsWith('http://localhost:')) return origin;
+    return '';
+  }
+
+  const normalizedSiteUrl = siteUrl.startsWith('http') ? siteUrl : `https://${siteUrl}`;
+  if (origin === normalizedSiteUrl) return origin;
+
+  // Allow Vercel preview deployments
+  if (origin.endsWith('.vercel.app')) return origin;
+
+  return '';
 }

--- a/apps/psypnos/app/api/auth/middleware.ts
+++ b/apps/psypnos/app/api/auth/middleware.ts
@@ -1,8 +1,5 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
 import { cookies } from "next/headers";
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
 import { ErrorCode, createApiError } from "../common/error-codes";
 

--- a/apps/psypnos/app/api/blog/analytics/engagement/route.ts
+++ b/apps/psypnos/app/api/blog/analytics/engagement/route.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';

--- a/apps/psypnos/app/api/blog/analytics/route.ts
+++ b/apps/psypnos/app/api/blog/analytics/route.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
+import { createHmac } from 'crypto';
+
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
@@ -10,32 +10,34 @@ import {
   logDataMode
 } from '@/lib/pwaDataMode';
 
-// Type for blog analytics record (workaround for ungenerated Prisma client)
+import { recordAttempt, getClientIP } from '../../common/rate-limiter';
+
 type BlogAnalyticsRecord = {
   id: string;
   articleSlug: string;
   sessionId: string;
   timestamp: Date;
-  scrollDepthPercent?: number | null;
-  timeOnPage?: number | null;
-  completed?: boolean;
+  scrollDepthPercent: number | null;
+  timeOnPage: number | null;
+  completed: boolean;
 };
 
 function hashVisitorId(userAgent: string, ip: string): string {
-  // Simple hash for visitor identification
-  const combined = `${userAgent}-${ip}`;
-  let hash = 0;
-  for (let i = 0; i < combined.length; i++) {
-    const char = combined.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32bit integer
-  }
-  return Math.abs(hash).toString(36);
+  const secret = process.env.IP_HASH_SECRET || process.env.JWT_SECRET || 'blog-visitor-hash';
+  return createHmac('sha256', secret)
+    .update(`${userAgent}-${ip}`)
+    .digest('hex')
+    .slice(0, 16);
 }
 
-// GET - Récupérer les statistiques des articles du blog
+// GET - Récupérer les statistiques des articles du blog (admin only)
 export async function GET(request: NextRequest) {
   try {
+    // Verify admin authentication
+    const { withAdminAuth } = await import('../../auth/middleware');
+    const authResult = await withAdminAuth();
+    if (authResult.error) return authResult.error;
+
     const searchParams = request.nextUrl.searchParams;
     const slug = searchParams.get('slug');
     const startDateParam = searchParams.get('startDate');
@@ -87,6 +89,7 @@ export async function GET(request: NextRequest) {
       const stats = await prisma.blogAnalytics.findMany({
         where: { articleSlug: slug, ...dateFilter },
         orderBy: { timestamp: 'desc' },
+        take: 10_000,
       }) as BlogAnalyticsRecord[];
 
       const views = stats.length;
@@ -127,6 +130,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Retourner toutes les stats triées par nombre de vues (filtrées par période)
+    // Limit to 50,000 records to prevent memory exhaustion
     const allAnalytics = await prisma.blogAnalytics.findMany({
       where: dateFilter,
       select: {
@@ -137,6 +141,8 @@ export async function GET(request: NextRequest) {
         timeOnPage: true,
         completed: true,
       },
+      take: 50_000,
+      orderBy: { timestamp: 'desc' },
     }) as Array<{
       articleSlug: string;
       sessionId: string;
@@ -250,27 +256,45 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// POST - Enregistrer une visite d'article
+// POST - Enregistrer une visite d'article (public, rate-limited)
 export async function POST(request: NextRequest) {
   try {
+    // Rate limiting
+    const clientIP = getClientIP(request);
+    const rateLimitResult = recordAttempt('analytics', clientIP);
+    if (rateLimitResult.limited) {
+      return NextResponse.json(
+        { error: 'Rate limit exceeded' },
+        { status: 429, headers: { 'Retry-After': String(Math.ceil((rateLimitResult.resetTime - Date.now()) / 1000)) } }
+      );
+    }
+
     const body = await request.json();
     const { slug, sessionId } = body;
 
-    if (!slug) {
+    if (!slug || typeof slug !== 'string') {
       return NextResponse.json(
-        { error: 'Slug is required' },
+        { error: 'Slug is required and must be a string' },
         { status: 400 }
       );
     }
 
-    // Générer un sessionId si non fourni
+    // Validate slug format (alphanumeric + hyphens, max 200 chars)
+    if (slug.length > 200 || !/^[a-z0-9][a-z0-9-]*[a-z0-9]$/i.test(slug)) {
+      return NextResponse.json(
+        { error: 'Invalid slug format' },
+        { status: 400 }
+      );
+    }
+
     const userAgent = request.headers.get('user-agent') || '';
     const ip = request.headers.get('x-forwarded-for') ||
                request.headers.get('x-real-ip') ||
                'unknown';
-    const finalSessionId = sessionId || hashVisitorId(userAgent, ip);
+    const finalSessionId = (typeof sessionId === 'string' && sessionId.length > 0)
+      ? sessionId
+      : hashVisitorId(userAgent, ip);
 
-    // Enregistrer la visite dans PostgreSQL
     await prisma.blogAnalytics.create({
       data: {
         articleSlug: slug,
@@ -279,19 +303,22 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // Calculer les stats après insertion
-    const allViews = await prisma.blogAnalytics.findMany({
-      where: { articleSlug: slug },
-      select: { sessionId: true },
-    }) as Array<{ sessionId: string }>;
-
-    const views = allViews.length;
-    const uniqueVisitors = new Set(allViews.map(v => v.sessionId)).size;
+    // Use count() instead of fetching all records
+    const [viewCount, uniqueResult] = await Promise.all([
+      prisma.blogAnalytics.count({
+        where: { articleSlug: slug },
+      }),
+      prisma.blogAnalytics.findMany({
+        where: { articleSlug: slug },
+        select: { sessionId: true },
+        distinct: ['sessionId'],
+      }),
+    ]);
 
     return NextResponse.json({
       slug,
-      views,
-      uniqueVisitors,
+      views: viewCount,
+      uniqueVisitors: uniqueResult.length,
     });
   } catch (error) {
     console.error('Error tracking view:', error);
@@ -302,14 +329,18 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// DELETE - Réinitialiser les stats
+// DELETE - Réinitialiser les stats (admin only)
 export async function DELETE(request: NextRequest) {
   try {
+    // Verify admin authentication
+    const { withAdminAuth } = await import('../../auth/middleware');
+    const authResult = await withAdminAuth();
+    if (authResult.error) return authResult.error;
+
     const searchParams = request.nextUrl.searchParams;
     const slug = searchParams.get('slug');
 
     if (slug) {
-      // Réinitialiser les stats d'un article spécifique
       const result = await prisma.blogAnalytics.deleteMany({
         where: { articleSlug: slug },
       });
@@ -319,8 +350,6 @@ export async function DELETE(request: NextRequest) {
         deletedCount: result.count,
       });
     } else {
-      // Réinitialiser toutes les stats
-      // Cette action devrait être protégée en production
       const result = await prisma.blogAnalytics.deleteMany({});
 
       return NextResponse.json({

--- a/apps/psypnos/components/Analytics.tsx
+++ b/apps/psypnos/components/Analytics.tsx
@@ -1,17 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
 /**
  * Analytics Component - Client-side only analytics tracking
  *
  * Ce composant initialise le système de tracking analytics.
  * Il est chargé dynamiquement avec ssr: false pour éviter les problèmes SSR.
- *
- * Le nouveau système de tracking utilise:
- * - Un tracker singleton avec batching des événements
- * - Une gestion de session robuste
- * - Le tracking automatique des pages, scroll, et temps passé
- * - L'observation des sections via IntersectionObserver
  *
  * @see /lib/tracking pour l'implémentation complète
  */
@@ -31,24 +22,14 @@ export function Analytics() {
   const initialized = useRef(false);
 
   useEffect(() => {
-    // Éviter la double initialisation en mode strict
     if (initialized.current) return;
     initialized.current = true;
 
-    // Initialiser le tracker
-    const tracker = initTracker({
-      // Configuration personnalisée si nécessaire
+    initTracker({
       debug: process.env.NODE_ENV === "development",
     });
-
-    // Cleanup lors du démontage (rarement appelé car composant au niveau layout)
-    return () => {
-      // Note: On ne détruit pas le tracker car il doit persister
-      // pendant toute la durée de vie de la session
-    };
   }, []);
 
-  // Ce composant ne rend rien
   return null;
 }
 
@@ -59,42 +40,39 @@ export function Analytics() {
  * automatiquement les sections avec l'attribut data-track-section.
  */
 export function SectionTracker() {
+  const observedElementsRef = useRef<HTMLElement[]>([]);
+
   useEffect(() => {
-    // Attendre que le tracker soit initialisé
     const timer = setTimeout(() => {
       const tracker = getTracker();
-
-      // Observer toutes les sections avec data-track-section
       const sections = document.querySelectorAll("[data-track-section]");
+      const observed: HTMLElement[] = [];
 
       sections.forEach((section) => {
         const element = section as HTMLElement;
-        // Only track sections with a valid identifier (data-track-section or id)
         const sectionId = element.dataset.trackSection || element.id;
-        if (!sectionId) {
-          // Skip elements without proper identification - don't track as "unknown"
-          return;
-        }
+        if (!sectionId) return;
         const sectionName = element.dataset.trackSectionName || sectionId;
 
         tracker.observeSection(element, sectionId, sectionName);
+        observed.push(element);
       });
 
-      // Cleanup
-      return () => {
-        sections.forEach((section) => {
-          tracker.unobserveSection(section as HTMLElement);
-        });
-      };
-    }, 100); // Petit délai pour s'assurer que le tracker est prêt
+      observedElementsRef.current = observed;
+    }, 100);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      // Cleanup: unobserve all tracked sections to prevent memory leaks
+      const tracker = getTracker();
+      observedElementsRef.current.forEach((element) => {
+        tracker.unobserveSection(element);
+      });
+      observedElementsRef.current = [];
+    };
   }, []);
 
   return null;
 }
 
-/**
- * Export par défaut pour compatibilité
- */
 export default Analytics;

--- a/apps/psypnos/hooks/useAnalytics.ts
+++ b/apps/psypnos/hooks/useAnalytics.ts
@@ -1,94 +1,19 @@
 /**
  * Analytics Tracking Hooks
  *
- * All tracking functions now delegate to the unified @kairn/analytics tracker
+ * All tracking functions delegate to the unified @kairn/analytics tracker
  * which batches events and sends them via /api/analytics/track.
  *
- * Legacy individual endpoints (/page-visit, /scroll-depth, /section-time, etc.)
- * are no longer used directly from client code.
+ * For page/section tracking hooks, use useTracker.ts instead.
+ * This module provides conversion, custom event, and funnel tracking.
  */
 
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { getTracker, type ConversionType } from '@/lib/tracking';
 
-import { initTracker, getTracker, type ConversionType } from '@/lib/tracking';
-
-// ============================================
-// Page Tracking
-// ============================================
-
-/**
- * Track page visits via the unified tracker.
- * The tracker handles UA parsing, UTM extraction, session management,
- * and batched sending automatically.
- */
-export function usePageTracking() {
-  const hasTrackedRef = useRef(false);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (process.env.NEXT_PUBLIC_ANALYTICS_ENABLED === 'false') return;
-    if (hasTrackedRef.current) return;
-    hasTrackedRef.current = true;
-
-    initTracker();
-  }, []);
-}
-
-// ============================================
-// Scroll Tracking
-// ============================================
-
-/**
- * Track scroll depth via the unified tracker.
- * The tracker already has built-in scroll tracking with threshold detection.
- */
-export function useScrollTracking() {
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (process.env.NEXT_PUBLIC_ANALYTICS_ENABLED === 'false') return;
-
-    // The unified tracker handles scroll tracking automatically
-    // when initialized via initTracker() in usePageTracking
-  }, []);
-}
-
-// ============================================
-// Section Time Tracking
-// ============================================
-
-/**
- * Track time spent on a section via the unified tracker's
- * IntersectionObserver-based section tracking.
- */
-export function useSectionTimeTracking(sectionId: string) {
-  const elementRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (process.env.NEXT_PUBLIC_ANALYTICS_ENABLED === 'false') return;
-
-    const sectionElement =
-      document.getElementById(sectionId) ||
-      document.querySelector(`[data-section="${sectionId}"]`) ||
-      elementRef.current;
-
-    if (sectionElement) {
-      const tracker = getTracker();
-      tracker.observeSection(sectionElement as HTMLElement, sectionId);
-      elementRef.current = sectionElement as HTMLElement;
-    }
-
-    return () => {
-      if (elementRef.current) {
-        const tracker = getTracker();
-        tracker.unobserveSection(elementRef.current);
-      }
-    };
-  }, [sectionId]);
-
-  return elementRef;
-}
+// Re-export page/section hooks from useTracker to avoid duplication
+export { usePageTracking, useSectionTracking as useSectionTimeTracking } from './useTracker';
 
 // ============================================
 // Conversion Tracking

--- a/apps/psypnos/hooks/useArticleReadingTracker.ts
+++ b/apps/psypnos/hooks/useArticleReadingTracker.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+
+import { getSessionManager } from '@/lib/tracking';
 
 interface ReadingMetrics {
   slug: string;
@@ -12,25 +11,40 @@ interface ReadingMetrics {
   completed: boolean;
 }
 
-// Generate a simple session ID
+declare global {
+  interface Window {
+    clarity?: (method: string, key: string, value: string) => void;
+  }
+}
+
+/**
+ * Gets session ID from the main analytics tracker for correlation,
+ * with fallback to a blog-specific session ID.
+ */
 function getSessionId(): string {
   if (typeof window === 'undefined') return '';
 
+  try {
+    const sessionManager = getSessionManager();
+    const sessionId = sessionManager.getSessionId();
+    if (sessionId) return sessionId;
+  } catch {
+    // Tracker not initialized yet, use fallback
+  }
+
   let sessionId = sessionStorage.getItem('blog_session_id');
   if (!sessionId) {
-    sessionId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+    sessionId = `blog_${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
     sessionStorage.setItem('blog_session_id', sessionId);
   }
   return sessionId;
 }
 
-// Send data using Beacon API (works even during page unload)
 function sendBeacon(url: string, data: object): void {
   if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
     const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
     navigator.sendBeacon(url, blob);
   } else {
-    // Fallback for browsers without sendBeacon
     fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -40,10 +54,9 @@ function sendBeacon(url: string, data: object): void {
   }
 }
 
-// Send event to Microsoft Clarity
 function sendClarityEvent(eventName: string, value: string): void {
-  if (typeof window !== 'undefined' && (window as any).clarity) {
-    (window as any).clarity('set', eventName, value);
+  if (typeof window !== 'undefined' && window.clarity) {
+    window.clarity('set', eventName, value);
   }
 }
 
@@ -53,16 +66,16 @@ function sendClarityEvent(eventName: string, value: string): void {
  * - Time spent on article
  * - Whether article was completed (90%+ scrolled)
  *
- * Sends data to /api/blog/analytics/engagement on page unload
- * Also sends custom events to Microsoft Clarity
+ * Sends data to /api/blog/analytics/engagement on page unload.
+ * Uses a deduplication flag to prevent multiple beacon sends.
  */
 export function useArticleReadingTracker(slug: string) {
   const startTimeRef = useRef<number>(Date.now());
   const maxScrollDepthRef = useRef<number>(0);
   const hasTrackedViewRef = useRef<boolean>(false);
   const lastSentDepthRef = useRef<number>(0);
+  const hasSentFinalRef = useRef<boolean>(false);
 
-  // Calculate current scroll depth
   const calculateScrollDepth = useCallback((): number => {
     if (typeof window === 'undefined') return 0;
 
@@ -74,8 +87,13 @@ export function useArticleReadingTracker(slug: string) {
     return Math.min(100, Math.round((scrolled / totalHeight) * 100));
   }, []);
 
-  // Send engagement data
   const sendEngagementData = useCallback((isFinal: boolean = false) => {
+    // Deduplicate: only send final data once
+    if (isFinal) {
+      if (hasSentFinalRef.current) return;
+      hasSentFinalRef.current = true;
+    }
+
     const timeOnPage = Date.now() - startTimeRef.current;
     const scrollDepthPercent = maxScrollDepthRef.current;
     const completed = scrollDepthPercent >= 90;
@@ -87,14 +105,12 @@ export function useArticleReadingTracker(slug: string) {
       completed,
     };
 
-    // Send to our API
     sendBeacon('/api/blog/analytics/engagement', {
       ...data,
       sessionId: getSessionId(),
       isFinal,
     });
 
-    // Send to Clarity
     sendClarityEvent('article_read_depth', `${scrollDepthPercent}%`);
     sendClarityEvent('article_time_spent', `${Math.round(timeOnPage / 1000)}s`);
 
@@ -108,7 +124,6 @@ export function useArticleReadingTracker(slug: string) {
     if (hasTrackedViewRef.current) return;
     hasTrackedViewRef.current = true;
 
-    // Track initial view after short delay
     const timer = setTimeout(() => {
       fetch('/api/blog/analytics', {
         method: 'POST',
@@ -119,7 +134,6 @@ export function useArticleReadingTracker(slug: string) {
         }),
       }).catch(console.error);
 
-      // Send to Clarity
       sendClarityEvent('article_view', slug);
     }, 500);
 
@@ -131,11 +145,9 @@ export function useArticleReadingTracker(slug: string) {
     const handleScroll = () => {
       const currentDepth = calculateScrollDepth();
 
-      // Only update if we scrolled further
       if (currentDepth > maxScrollDepthRef.current) {
         maxScrollDepthRef.current = currentDepth;
 
-        // Send milestone events to Clarity (25%, 50%, 75%, 90%, 100%)
         const milestones = [25, 50, 75, 90, 100];
         for (const milestone of milestones) {
           if (currentDepth >= milestone && lastSentDepthRef.current < milestone) {
@@ -146,7 +158,6 @@ export function useArticleReadingTracker(slug: string) {
       }
     };
 
-    // Initial calculation
     handleScroll();
 
     window.addEventListener('scroll', handleScroll, { passive: true });
@@ -154,26 +165,27 @@ export function useArticleReadingTracker(slug: string) {
   }, [calculateScrollDepth]);
 
   // Send data on page unload or visibility change
+  // Use a single handler with deduplication to avoid sending 2-4 beacons
   useEffect(() => {
-    const handleUnload = () => {
+    const handlePageLeave = () => {
       sendEngagementData(true);
     };
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
-        sendEngagementData(false);
+        sendEngagementData(true);
       }
     };
 
-    // Modern browsers prefer visibilitychange over beforeunload
+    // visibilitychange fires reliably on modern browsers
+    // pagehide is the fallback for older browsers
+    // We use the dedup flag in sendEngagementData to prevent multiple sends
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('beforeunload', handleUnload);
-    window.addEventListener('pagehide', handleUnload);
+    window.addEventListener('pagehide', handlePageLeave);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('beforeunload', handleUnload);
-      window.removeEventListener('pagehide', handleUnload);
+      window.removeEventListener('pagehide', handlePageLeave);
     };
   }, [sendEngagementData]);
 

--- a/apps/psypnos/hooks/useBlogAnalytics.ts
+++ b/apps/psypnos/hooks/useBlogAnalytics.ts
@@ -1,30 +1,7 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
 'use client';
 
-import { useEffect } from 'react';
-
-export function useBlogAnalytics(slug: string) {
-  useEffect(() => {
-    // Tracker la visite de l'article
-    const trackView = async () => {
-      try {
-        await fetch('/api/blog/analytics', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ slug }),
-        });
-      } catch (error) {
-        console.error('Error tracking blog view:', error);
-      }
-    };
-
-    // Tracker après un court délai pour s'assurer que la page est bien chargée
-    const timer = setTimeout(() => {
-      trackView();
-    }, 500);
-
-    return () => clearTimeout(timer);
-  }, [slug]);
-}
+/**
+ * @deprecated Use useArticleReadingTracker instead, which handles both
+ * initial view tracking and engagement metrics with correlated session IDs.
+ */
+export { useArticleReadingTracker as useBlogAnalytics } from './useArticleReadingTracker';

--- a/apps/psypnos/hooks/useTracker.ts
+++ b/apps/psypnos/hooks/useTracker.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
 /**
  * Hook React pour le tracking analytics
  *

--- a/packages/analytics/src/client/tracker.ts
+++ b/packages/analytics/src/client/tracker.ts
@@ -128,6 +128,11 @@ export class Tracker {
   private boundHandleScroll: () => void;
   private boundHandleBeforeUnload: () => void;
   private boundHandleVisibilityChange: () => void;
+  private boundHandlePopState: () => void;
+
+  // Original History methods for SPA tracking
+  private originalPushState: typeof history.pushState | null = null;
+  private originalReplaceState: typeof history.replaceState | null = null;
 
   constructor(config: Partial<TrackerConfig> = {}) {
     this.config = { ...DEFAULT_TRACKER_CONFIG, ...config };
@@ -140,6 +145,7 @@ export class Tracker {
     this.boundHandleScroll = debounce(this.handleScroll.bind(this), this.config.scrollDebounce);
     this.boundHandleBeforeUnload = this.handleBeforeUnload.bind(this);
     this.boundHandleVisibilityChange = this.handleVisibilityChange.bind(this);
+    this.boundHandlePopState = this.handleSPANavigation.bind(this);
   }
 
   // ============================================
@@ -614,6 +620,10 @@ export class Tracker {
     window.addEventListener('scroll', this.boundHandleScroll, { passive: true });
     window.addEventListener('beforeunload', this.boundHandleBeforeUnload);
     document.addEventListener('visibilitychange', this.boundHandleVisibilityChange);
+
+    // SPA navigation tracking: intercept History API and popstate
+    window.addEventListener('popstate', this.boundHandlePopState);
+    this.patchHistoryAPI();
   }
 
   /**
@@ -623,6 +633,10 @@ export class Tracker {
     window.removeEventListener('scroll', this.boundHandleScroll);
     window.removeEventListener('beforeunload', this.boundHandleBeforeUnload);
     document.removeEventListener('visibilitychange', this.boundHandleVisibilityChange);
+    window.removeEventListener('popstate', this.boundHandlePopState);
+
+    // Restore original History API methods
+    this.restoreHistoryAPI();
 
     // Cancel debounce
     (this.boundHandleScroll as ReturnType<typeof debounce>).cancel?.();
@@ -671,6 +685,55 @@ export class Tracker {
     } else {
       // Page visible - resume section tracking
       this.resumeSectionTracking();
+    }
+  }
+
+  // ============================================
+  // SPA Navigation
+  // ============================================
+
+  /**
+   * Handles SPA navigation (pushState, replaceState, popstate)
+   * Tracks a new page view when the URL changes
+   */
+  private handleSPANavigation(): void {
+    const newUrl = window.location.pathname;
+    if (newUrl !== this.currentPage) {
+      this.trackPageView();
+    }
+  }
+
+  /**
+   * Patches History.pushState and History.replaceState to detect SPA navigations
+   */
+  private patchHistoryAPI(): void {
+    this.originalPushState = history.pushState.bind(history);
+    this.originalReplaceState = history.replaceState.bind(history);
+
+    const tracker = this;
+
+    history.pushState = function (...args: Parameters<typeof history.pushState>) {
+      tracker.originalPushState!(...args);
+      tracker.handleSPANavigation();
+    };
+
+    history.replaceState = function (...args: Parameters<typeof history.replaceState>) {
+      tracker.originalReplaceState!(...args);
+      tracker.handleSPANavigation();
+    };
+  }
+
+  /**
+   * Restores original History API methods
+   */
+  private restoreHistoryAPI(): void {
+    if (this.originalPushState) {
+      history.pushState = this.originalPushState;
+      this.originalPushState = null;
+    }
+    if (this.originalReplaceState) {
+      history.replaceState = this.originalReplaceState;
+      this.originalReplaceState = null;
     }
   }
 


### PR DESCRIPTION
Critical fixes:
- Add SPA navigation tracking (pushState/replaceState/popstate listeners)
  so all page views are tracked, not just the first one
- Add missing siteId to geolocation tracking (was causing silent Prisma errors)
- Use upsert instead of findFirst+create for geolocation dedup (race condition fix)

Security fixes:
- Add admin auth to blog analytics GET/DELETE endpoints
- Add rate limiting to blog analytics POST endpoint
- Replace CORS wildcard (*) with origin-based allowlist
- Replace weak 32-bit visitor hash with HMAC-SHA256
- Parameterize SQL queries to prevent injection
- Add slug validation (format + length) on blog analytics POST
- Warn when IP hash secret is not configured

Type safety:
- Remove @ts-nocheck from 8 files (track/route, store-index, dashboard,
  blog/analytics, engagement, auth/middleware, useTracker, Analytics.tsx)
- Add typed EventExtras interface replacing unsafe 'as' casts
- Add event type enum validation (z.enum instead of z.string)
- Add timestamp format validation

Performance:
- Replace in-memory JS aggregation with SQL GROUP BY for getTopPages
- Add pagination limits to getPageVisits (10k default) and blog queries
- Use prisma.count() + distinct instead of fetching all records for blog POST
- Limit dashboard realtime visits to 1000 records
- Add siteId to dashboard cache key for multi-tenant correctness

Client fixes:
- Fix SectionTracker memory leak (cleanup now properly unobserves elements)
- Fix duplicate beacons on blog page close (dedup flag prevents 2-4 sends)
- Correlate blog tracker session IDs with main analytics session
- Deduplicate usePageTracking (useAnalytics re-exports from useTracker)
- Deprecate unused useBlogAnalytics hook
- Fix bot detection false positives (/google/i → /googlebot/i etc.)

https://claude.ai/code/session_01D2cLtw4T4eZk5cqFSQKYqw