### PR TITLE
fix(api): resolve AI API timeouts and production issues on Vercel

### DIFF
--- a/apps/psypnos/app/api/admin/deployment/analyze/route.ts
+++ b/apps/psypnos/app/api/admin/deployment/analyze/route.ts
@@ -1,13 +1,16 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Deployment model not available in Kairn schema
-import Anthropic from "@anthropic-ai/sdk";
-import { NextResponse } from "next/server";
+import Anthropic from '@anthropic-ai/sdk';
+import { NextResponse } from 'next/server';
 
-import { withAdminAuth } from "@/app/api/auth/middleware";
-import { prisma } from "@/lib/db/prisma";
+import { withAdminAuth } from '@/app/api/auth/middleware';
+import { prisma } from '@/lib/db/prisma';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
+
+// Vercel serverless function timeout — single Claude API call
+export const maxDuration = 60;
 
 /**
  * Prompt système pour l'analyse des logs de déploiement
@@ -59,7 +62,7 @@ interface AnalysisResponse {
       title: string;
       description: string;
       commands?: string[];
-      priority: "high" | "medium" | "low";
+      priority: 'high' | 'medium' | 'low';
     }>;
     prevention: string[];
     additionalNotes?: string;
@@ -82,7 +85,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     if (!deploymentId) {
       return NextResponse.json(
-        { success: false, error: "ID de déploiement requis" },
+        { success: false, error: 'ID de déploiement requis' },
         { status: 400 }
       );
     }
@@ -94,17 +97,17 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     if (!deployment) {
       return NextResponse.json(
-        { success: false, error: "Déploiement non trouvé" },
+        { success: false, error: 'Déploiement non trouvé' },
         { status: 404 }
       );
     }
 
     // Vérifier que c'est un déploiement échoué ou rollback
-    if (!["failed", "rolled_back"].includes(deployment.status)) {
+    if (!['failed', 'rolled_back'].includes(deployment.status)) {
       return NextResponse.json(
         {
           success: false,
-          error: "L'analyse n'est disponible que pour les déploiements échoués"
+          error: "L'analyse n'est disponible que pour les déploiements échoués",
         },
         { status: 400 }
       );
@@ -115,7 +118,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json(
         {
           success: false,
-          error: "Aucun log disponible pour l'analyse"
+          error: "Aucun log disponible pour l'analyse",
         },
         { status: 400 }
       );
@@ -124,11 +127,11 @@ export async function POST(request: Request): Promise<NextResponse> {
     // Vérifier la clé API Anthropic
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
-      console.error("[Deployment Analysis] ANTHROPIC_API_KEY non configurée");
+      console.error('[Deployment Analysis] ANTHROPIC_API_KEY non configurée');
       return NextResponse.json(
         {
           success: false,
-          error: "Configuration API Claude manquante"
+          error: 'Configuration API Claude manquante',
         },
         { status: 500 }
       );
@@ -141,25 +144,23 @@ export async function POST(request: Request): Promise<NextResponse> {
     const anthropic = new Anthropic({ apiKey });
 
     const message = await anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
+      model: 'claude-sonnet-4-5-20250929',
       max_tokens: 4000,
       temperature: 0.3, // Plus déterministe pour les analyses techniques
       system: DEPLOYMENT_ANALYSIS_SYSTEM_PROMPT,
       messages: [
         {
-          role: "user",
+          role: 'user',
           content: analysisPrompt,
         },
       ],
     });
 
     // Extraire la réponse
-    const responseContent = message.content[0].type === "text"
-      ? message.content[0].text
-      : "";
+    const responseContent = message.content[0].type === 'text' ? message.content[0].text : '';
 
     if (!responseContent) {
-      throw new Error("Aucune réponse de Claude");
+      throw new Error('Aucune réponse de Claude');
     }
 
     // Parser la réponse structurée
@@ -172,7 +173,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     return NextResponse.json(response);
   } catch (error) {
-    console.error("[Deployment Analysis] Error:", error);
+    console.error('[Deployment Analysis] Error:', error);
     return NextResponse.json(
       {
         success: false,
@@ -198,9 +199,10 @@ function buildAnalysisPrompt(deployment: {
   startedAt: Date | null;
   completedAt: Date | null;
 }): string {
-  const duration = deployment.startedAt && deployment.completedAt
-    ? Math.round((deployment.completedAt.getTime() - deployment.startedAt.getTime()) / 1000)
-    : null;
+  const duration =
+    deployment.startedAt && deployment.completedAt
+      ? Math.round((deployment.completedAt.getTime() - deployment.startedAt.getTime()) / 1000)
+      : null;
 
   return `Analyse ce déploiement échoué et fournis un diagnostic détaillé avec des solutions.
 
@@ -209,10 +211,10 @@ function buildAnalysisPrompt(deployment: {
 - **ID**: ${deployment.id}
 - **Statut**: ${deployment.status}
 - **Branche/Tag**: ${deployment.targetRef}
-- **Commit**: ${deployment.targetCommit || "Non disponible"}
-- **Phase d'échec**: ${deployment.currentPhase || "Non déterminée"}
+- **Commit**: ${deployment.targetCommit || 'Non disponible'}
+- **Phase d'échec**: ${deployment.currentPhase || 'Non déterminée'}
 - **Date**: ${deployment.triggeredAt.toISOString()}
-- **Durée avant échec**: ${duration ? `${duration}s` : "Non disponible"}
+- **Durée avant échec**: ${duration ? `${duration}s` : 'Non disponible'}
 
 ## Message d'erreur
 
@@ -221,7 +223,7 @@ ${deployment.errorMessage || "Aucun message d'erreur spécifique"}
 ## Logs complets
 
 \`\`\`
-${deployment.logs || "Aucun log disponible"}
+${deployment.logs || 'Aucun log disponible'}
 \`\`\`
 
 ---
@@ -256,7 +258,7 @@ commande2
 /**
  * Parse la réponse XML de Claude en objet structuré
  */
-function parseAnalysisResponse(response: string): AnalysisResponse["analysis"] {
+function parseAnalysisResponse(response: string): AnalysisResponse['analysis'] {
   // Extraire les différentes sections
   const summaryMatch = response.match(/<SUMMARY>([\s\S]*?)<\/SUMMARY>/);
   const errorTypeMatch = response.match(/<ERROR_TYPE>([\s\S]*?)<\/ERROR_TYPE>/);
@@ -265,17 +267,22 @@ function parseAnalysisResponse(response: string): AnalysisResponse["analysis"] {
   const notesMatch = response.match(/<NOTES>([\s\S]*?)<\/NOTES>/);
 
   // Extraire les solutions
-  const solutionsRegex = /<SOLUTION\s+priority="(high|medium|low)">\s*<TITLE>([\s\S]*?)<\/TITLE>\s*<DESCRIPTION>([\s\S]*?)<\/DESCRIPTION>\s*(?:<COMMANDS>([\s\S]*?)<\/COMMANDS>)?\s*<\/SOLUTION>/g;
-  const solutions: NonNullable<AnalysisResponse["analysis"]>["solutions"] = [];
+  const solutionsRegex =
+    /<SOLUTION\s+priority="(high|medium|low)">\s*<TITLE>([\s\S]*?)<\/TITLE>\s*<DESCRIPTION>([\s\S]*?)<\/DESCRIPTION>\s*(?:<COMMANDS>([\s\S]*?)<\/COMMANDS>)?\s*<\/SOLUTION>/g;
+  const solutions: NonNullable<AnalysisResponse['analysis']>['solutions'] = [];
 
   let solutionMatch;
   while ((solutionMatch = solutionsRegex.exec(response)) !== null) {
     const commands = solutionMatch[4]
-      ? solutionMatch[4].trim().split("\n").map(c => c.trim()).filter(c => c)
+      ? solutionMatch[4]
+          .trim()
+          .split('\n')
+          .map(c => c.trim())
+          .filter(c => c)
       : undefined;
 
     solutions.push({
-      priority: solutionMatch[1] as "high" | "medium" | "low",
+      priority: solutionMatch[1] as 'high' | 'medium' | 'low',
       title: solutionMatch[2].trim(),
       description: solutionMatch[3].trim(),
       commands: commands?.length ? commands : undefined,
@@ -292,19 +299,25 @@ function parseAnalysisResponse(response: string): AnalysisResponse["analysis"] {
   }
 
   return {
-    summary: summaryMatch?.[1]?.trim() || "Analyse non disponible",
-    errorType: errorTypeMatch?.[1]?.trim() || "Unknown",
-    phase: phaseMatch?.[1]?.trim() || "Unknown",
-    rootCause: rootCauseMatch?.[1]?.trim() || "Cause non déterminée",
-    solutions: solutions.length > 0 ? solutions : [{
-      title: "Vérification manuelle requise",
-      description: "Les logs ne permettent pas d'identifier clairement le problème. Une investigation manuelle est recommandée.",
-      priority: "high",
-    }],
-    prevention: prevention.length > 0 ? prevention : [
-      "Effectuer des tests avant le déploiement",
-      "Monitorer les ressources système",
-    ],
+    summary: summaryMatch?.[1]?.trim() || 'Analyse non disponible',
+    errorType: errorTypeMatch?.[1]?.trim() || 'Unknown',
+    phase: phaseMatch?.[1]?.trim() || 'Unknown',
+    rootCause: rootCauseMatch?.[1]?.trim() || 'Cause non déterminée',
+    solutions:
+      solutions.length > 0
+        ? solutions
+        : [
+            {
+              title: 'Vérification manuelle requise',
+              description:
+                "Les logs ne permettent pas d'identifier clairement le problème. Une investigation manuelle est recommandée.",
+              priority: 'high',
+            },
+          ],
+    prevention:
+      prevention.length > 0
+        ? prevention
+        : ['Effectuer des tests avant le déploiement', 'Monitorer les ressources système'],
     additionalNotes: notesMatch?.[1]?.trim() || undefined,
   };
 }

--- a/apps/psypnos/app/api/analytics/insights/route.ts
+++ b/apps/psypnos/app/api/analytics/insights/route.ts
@@ -9,6 +9,9 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+// Vercel serverless function timeout — single Claude API call
+export const maxDuration = 60;
+
 interface Insight {
   type: 'positive' | 'negative' | 'neutral' | 'warning';
   title: string;

--- a/apps/psypnos/app/api/assistant/route.ts
+++ b/apps/psypnos/app/api/assistant/route.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 
 import { validateCSRFMiddleware } from '../common/csrf-middleware';
 import { sendToAssistant } from '../common/openai-assistant';
-import { recordAttempt, getClientIP } from '../common/rate-limiter';
+import { recordAttemptAsync, getClientIP } from '../common/rate-limiter';
+
+// Vercel serverless function timeout — OpenAI Assistant with polling
+export const maxDuration = 120;
 
 const assistantSchema = z.object({
   message: z.string().trim().min(1).max(10000),
@@ -22,7 +25,7 @@ type AssistantPayload = z.infer<typeof assistantSchema>;
 export async function POST(request: Request) {
   // PROTECTION : Rate limiting - 10 requêtes par heure par IP (API coûteuse)
   const clientIP = getClientIP(request);
-  const rateLimitResult = recordAttempt('assistant', clientIP);
+  const rateLimitResult = await recordAttemptAsync('assistant', clientIP);
 
   if (rateLimitResult.limited) {
     return NextResponse.json(

--- a/apps/psypnos/app/api/blog/generate-image/route.ts
+++ b/apps/psypnos/app/api/blog/generate-image/route.ts
@@ -6,6 +6,9 @@ import { uploadImage, BUCKETS } from '@/lib/supabase/storage';
 
 import { withAdminAuth } from '../../auth/middleware';
 
+// Vercel serverless function timeout — 3 parallel DALL-E calls + download + upload
+export const maxDuration = 120;
+
 const generateImageSchema = z.object({
   imagePrompt: z.string().trim().min(1, 'Le prompt image est requis'),
   slug: z.string().trim().min(1, 'Le slug est requis'),

--- a/apps/psypnos/app/api/blog/generate-multi-step/route.ts
+++ b/apps/psypnos/app/api/blog/generate-multi-step/route.ts
@@ -17,23 +17,26 @@
  * 6. Génération du prompt image
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import {
   generateArticleMultiStep,
   type GenerationStep,
   type MultiStepGenerationOptions,
-} from "../../common/claude-article-generator-multi-step";
+} from '../../common/claude-article-generator-multi-step';
+
+// Vercel serverless function timeout — 6 sequential Claude API calls
+export const maxDuration = 300;
 
 /**
  * Schéma de validation pour les requêtes de génération
  */
 const generateArticleSchema = z.object({
-  topic: z.string().trim().min(1, "Le sujet est requis"),
-  category: z.enum(["Comprendre", "Traverser", "Découvrir", "Cheminer"]),
-  targetLength: z.enum(["short", "medium", "long"]).optional().default("medium"),
-  editorialCategory: z.enum(["Comprendre", "Traverser", "Découvrir", "Cheminer"]).optional(),
+  topic: z.string().trim().min(1, 'Le sujet est requis'),
+  category: z.enum(['Comprendre', 'Traverser', 'Découvrir', 'Cheminer']),
+  targetLength: z.enum(['short', 'medium', 'long']).optional().default('medium'),
+  editorialCategory: z.enum(['Comprendre', 'Traverser', 'Découvrir', 'Cheminer']).optional(),
   preferredTones: z.array(z.string()).optional(),
   tones: z.array(z.string()).optional(), // Alias
   seoQuery: z.string().trim().optional(),
@@ -76,13 +79,13 @@ export async function POST(request: NextRequest) {
 
     if (!parsed.success) {
       const firstError = parsed.error.issues[0];
-      const message = firstError?.message ?? "Données invalides.";
+      const message = firstError?.message ?? 'Données invalides.';
       return NextResponse.json({ message }, { status: 400 });
     }
 
     payload = parsed.data;
   } catch (error) {
-    return NextResponse.json({ message: "Données invalides." }, { status: 400 });
+    return NextResponse.json({ message: 'Données invalides.' }, { status: 400 });
   }
 
   // Récupérer la clé API Anthropic
@@ -90,23 +93,20 @@ export async function POST(request: NextRequest) {
 
   if (!apiKey) {
     console.error("ANTHROPIC_API_KEY n'est pas configurée");
-    return NextResponse.json(
-      { message: "Le service n'est pas configuré." },
-      { status: 500 }
-    );
+    return NextResponse.json({ message: "Le service n'est pas configuré." }, { status: 500 });
   }
 
   // Fusionner les champs pour rétrocompatibilité
   const allTones = payload.preferredTones || payload.tones || [];
 
   const options: MultiStepGenerationOptions = {
-    topic: payload.topic || payload.subject || "",
+    topic: payload.topic || payload.subject || '',
     category: payload.category,
     editorialCategory: payload.editorialCategory || payload.category,
     targetLength: payload.targetLength,
-    seoQuery: payload.seoQuery || payload.seoKeyword || "",
-    searchIntent: payload.searchIntent || payload.searchIntention || "",
-    readerPersona: payload.readerPersona || payload.persona || "",
+    seoQuery: payload.seoQuery || payload.seoKeyword || '',
+    searchIntent: payload.searchIntent || payload.searchIntention || '',
+    readerPersona: payload.readerPersona || payload.persona || '',
     preferredTones: allTones,
     usePsypnosStyle: payload.usePsypnosStyle,
   };
@@ -122,35 +122,39 @@ export async function POST(request: NextRequest) {
       try {
         // Callback de progression
         const onProgress = async (step: GenerationStep) => {
-          await writer.write(encoder.encode(encodeSSE("progress", step)));
+          await writer.write(encoder.encode(encodeSSE('progress', step)));
         };
 
-        const result = await generateArticleMultiStep(
-          { ...options, onProgress },
-          apiKey
-        );
+        const result = await generateArticleMultiStep({ ...options, onProgress }, apiKey);
 
         // Envoyer le résultat final
-        await writer.write(encoder.encode(encodeSSE("complete", {
-          success: result.success,
-          article: {
-            title: result.title,
-            description: result.description,
-            content: result.content,
-            category: result.category,
-            tags: result.tags,
-            faq: result.faq,
-            imagePrompt: result.imagePrompt,
-          },
-          generationMetadata: result.generationMetadata,
-          error: result.error,
-        })));
-
+        await writer.write(
+          encoder.encode(
+            encodeSSE('complete', {
+              success: result.success,
+              article: {
+                title: result.title,
+                description: result.description,
+                content: result.content,
+                category: result.category,
+                tags: result.tags,
+                faq: result.faq,
+                imagePrompt: result.imagePrompt,
+              },
+              generationMetadata: result.generationMetadata,
+              error: result.error,
+            })
+          )
+        );
       } catch (error) {
-        console.error("Erreur lors de la génération streaming:", error);
-        await writer.write(encoder.encode(encodeSSE("error", {
-          message: error instanceof Error ? error.message : "Erreur inconnue",
-        })));
+        console.error('Erreur lors de la génération streaming:', error);
+        await writer.write(
+          encoder.encode(
+            encodeSSE('error', {
+              message: error instanceof Error ? error.message : 'Erreur inconnue',
+            })
+          )
+        );
       } finally {
         await writer.close();
       }
@@ -158,9 +162,9 @@ export async function POST(request: NextRequest) {
 
     return new Response(stream.readable, {
       headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
       },
     });
   }
@@ -174,7 +178,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          message: result.error || "Erreur lors de la génération",
+          message: result.error || 'Erreur lors de la génération',
           generationMetadata: result.generationMetadata,
         },
         { status: 500 }
@@ -204,19 +208,19 @@ export async function POST(request: NextRequest) {
       // Métadonnées de génération
       generationMetadata: result.generationMetadata,
       // Avertissement si génération partielle
-      ...(result.success === false && result.content && {
-        warning: "Génération partielle - certaines étapes ont échoué",
-        error: result.error,
-      }),
+      ...(result.success === false &&
+        result.content && {
+          warning: 'Génération partielle - certaines étapes ont échoué',
+          error: result.error,
+        }),
     });
-
   } catch (error) {
     console.error("Erreur lors de la génération de l'article:", error);
     return NextResponse.json(
       {
         success: false,
-        message: "Une erreur est survenue lors de la génération. Veuillez réessayer.",
-        error: error instanceof Error ? error.message : "Erreur inconnue",
+        message: 'Une erreur est survenue lors de la génération. Veuillez réessayer.',
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
       },
       { status: 500 }
     );

--- a/apps/psypnos/app/api/blog/generate-prompt/route.ts
+++ b/apps/psypnos/app/api/blog/generate-prompt/route.ts
@@ -17,6 +17,9 @@ import {
 
 import { withAdminAuth } from '../../auth/middleware';
 
+// Vercel serverless function timeout — call + correction loop
+export const maxDuration = 180;
+
 // Configuration timeout et retry
 // Délais augmentés pour mieux gérer les erreurs 529 (overloaded) de l'API Anthropic
 const API_TIMEOUT_MS = 60000; // 60 secondes

--- a/apps/psypnos/app/api/blog/generate-sectional/route.ts
+++ b/apps/psypnos/app/api/blog/generate-sectional/route.ts
@@ -20,23 +20,26 @@
  * 9. Génération du prompt image
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import {
   generateArticleSectional,
   type GenerationProgress,
   type SectionalGenerationOptions,
-} from "../../common/claude-article-generator-sectional";
+} from '../../common/claude-article-generator-sectional';
+
+// Vercel serverless function timeout — 8-12 sequential Claude API calls
+export const maxDuration = 300;
 
 /**
  * Schéma de validation pour les requêtes de génération
  */
 const generateArticleSchema = z.object({
-  topic: z.string().trim().min(1, "Le sujet est requis"),
-  category: z.enum(["Comprendre", "Traverser", "Découvrir", "Cheminer"]),
-  targetLength: z.enum(["short", "medium", "long"]).optional().default("medium"),
-  editorialCategory: z.enum(["Comprendre", "Traverser", "Découvrir", "Cheminer"]).optional(),
+  topic: z.string().trim().min(1, 'Le sujet est requis'),
+  category: z.enum(['Comprendre', 'Traverser', 'Découvrir', 'Cheminer']),
+  targetLength: z.enum(['short', 'medium', 'long']).optional().default('medium'),
+  editorialCategory: z.enum(['Comprendre', 'Traverser', 'Découvrir', 'Cheminer']).optional(),
   preferredTones: z.array(z.string()).optional(),
   tones: z.array(z.string()).optional(), // Alias
   seoQuery: z.string().trim().optional(),
@@ -85,13 +88,13 @@ export async function POST(request: NextRequest) {
 
     if (!parsed.success) {
       const firstError = parsed.error.issues[0];
-      const message = firstError?.message ?? "Données invalides.";
+      const message = firstError?.message ?? 'Données invalides.';
       return NextResponse.json({ message }, { status: 400 });
     }
 
     payload = parsed.data;
   } catch (error) {
-    return NextResponse.json({ message: "Données invalides." }, { status: 400 });
+    return NextResponse.json({ message: 'Données invalides.' }, { status: 400 });
   }
 
   // Récupérer la clé API Anthropic
@@ -99,23 +102,20 @@ export async function POST(request: NextRequest) {
 
   if (!apiKey) {
     console.error("ANTHROPIC_API_KEY n'est pas configurée");
-    return NextResponse.json(
-      { message: "Le service n'est pas configuré." },
-      { status: 500 }
-    );
+    return NextResponse.json({ message: "Le service n'est pas configuré." }, { status: 500 });
   }
 
   // Fusionner les champs pour rétrocompatibilité
   const allTones = payload.preferredTones || payload.tones || [];
 
   const options: SectionalGenerationOptions = {
-    topic: payload.topic || payload.subject || "",
+    topic: payload.topic || payload.subject || '',
     category: payload.category,
     editorialCategory: payload.editorialCategory || payload.category,
     targetLength: payload.targetLength,
-    seoQuery: payload.seoQuery || payload.seoKeyword || "",
-    searchIntent: payload.searchIntent || payload.searchIntention || "",
-    readerPersona: payload.readerPersona || payload.persona || "",
+    seoQuery: payload.seoQuery || payload.seoKeyword || '',
+    searchIntent: payload.searchIntent || payload.searchIntention || '',
+    readerPersona: payload.readerPersona || payload.persona || '',
     preferredTones: allTones,
     usePsypnosStyle: payload.usePsypnosStyle,
   };
@@ -131,35 +131,39 @@ export async function POST(request: NextRequest) {
       try {
         // Callback de progression
         const onProgress = async (progress: GenerationProgress) => {
-          await writer.write(encoder.encode(encodeSSE("progress", progress)));
+          await writer.write(encoder.encode(encodeSSE('progress', progress)));
         };
 
-        const result = await generateArticleSectional(
-          { ...options, onProgress },
-          apiKey
-        );
+        const result = await generateArticleSectional({ ...options, onProgress }, apiKey);
 
         // Envoyer le résultat final
-        await writer.write(encoder.encode(encodeSSE("complete", {
-          success: result.success,
-          article: {
-            title: result.title,
-            description: result.description,
-            content: result.content,
-            category: result.category,
-            tags: result.tags,
-            faq: result.faq,
-            imagePrompt: result.imagePrompt,
-          },
-          generationMetadata: result.generationMetadata,
-          error: result.error,
-        })));
-
+        await writer.write(
+          encoder.encode(
+            encodeSSE('complete', {
+              success: result.success,
+              article: {
+                title: result.title,
+                description: result.description,
+                content: result.content,
+                category: result.category,
+                tags: result.tags,
+                faq: result.faq,
+                imagePrompt: result.imagePrompt,
+              },
+              generationMetadata: result.generationMetadata,
+              error: result.error,
+            })
+          )
+        );
       } catch (error) {
-        console.error("Erreur lors de la génération streaming:", error);
-        await writer.write(encoder.encode(encodeSSE("error", {
-          message: error instanceof Error ? error.message : "Erreur inconnue",
-        })));
+        console.error('Erreur lors de la génération streaming:', error);
+        await writer.write(
+          encoder.encode(
+            encodeSSE('error', {
+              message: error instanceof Error ? error.message : 'Erreur inconnue',
+            })
+          )
+        );
       } finally {
         await writer.close();
       }
@@ -167,9 +171,9 @@ export async function POST(request: NextRequest) {
 
     return new Response(stream.readable, {
       headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
       },
     });
   }
@@ -183,7 +187,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          message: result.error || "Erreur lors de la génération",
+          message: result.error || 'Erreur lors de la génération',
           generationMetadata: result.generationMetadata,
         },
         { status: 500 }
@@ -213,19 +217,19 @@ export async function POST(request: NextRequest) {
       // Métadonnées de génération
       generationMetadata: result.generationMetadata,
       // Avertissement si génération partielle
-      ...(result.success === false && result.content && {
-        warning: "Génération partielle - certaines étapes ont échoué",
-        error: result.error,
-      }),
+      ...(result.success === false &&
+        result.content && {
+          warning: 'Génération partielle - certaines étapes ont échoué',
+          error: result.error,
+        }),
     });
-
   } catch (error) {
     console.error("Erreur lors de la génération de l'article:", error);
     return NextResponse.json(
       {
         success: false,
-        message: "Une erreur est survenue lors de la génération. Veuillez réessayer.",
-        error: error instanceof Error ? error.message : "Erreur inconnue",
+        message: 'Une erreur est survenue lors de la génération. Veuillez réessayer.',
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
       },
       { status: 500 }
     );

--- a/apps/psypnos/app/api/blog/generate/route.ts
+++ b/apps/psypnos/app/api/blog/generate/route.ts
@@ -18,6 +18,9 @@ import {
   type ArticleGenerationOptions,
 } from '../../common/claude-article-generator';
 
+// Vercel serverless function timeout — single-step article generation with retries
+export const maxDuration = 300;
+
 /**
  * Zod schema for validating article generation requests
  *

--- a/apps/psypnos/app/api/blog/improve-text/route.ts
+++ b/apps/psypnos/app/api/blog/improve-text/route.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 
 import { validateCSRFMiddleware } from '../../common/csrf-middleware';
 import { PSYPNOS_STYLE_SYSTEM_PROMPT } from '../../common/psypnos-system-prompt';
-import { recordAttempt, getClientIP } from '../../common/rate-limiter';
+import { recordAttemptAsync, getClientIP } from '../../common/rate-limiter';
+
+// Vercel serverless function timeout — single Claude API call
+export const maxDuration = 60;
 
 const improveTextSchema = z.object({
   selectedText: z.string().trim().min(1).max(10000),
@@ -25,7 +28,7 @@ type ImproveTextPayload = z.infer<typeof improveTextSchema>;
 export async function POST(request: Request) {
   // PROTECTION : Rate limiting - 20 requêtes par heure par IP (API coûteuse)
   const clientIP = getClientIP(request);
-  const rateLimitResult = recordAttempt('improveText', clientIP);
+  const rateLimitResult = await recordAttemptAsync('improveText', clientIP);
 
   if (rateLimitResult.limited) {
     return NextResponse.json(

--- a/apps/psypnos/app/api/chat/route.ts
+++ b/apps/psypnos/app/api/chat/route.ts
@@ -6,7 +6,10 @@ import { z } from 'zod';
 
 import { prisma } from '@/lib/db/prisma';
 
-import { recordAttempt, getClientIP } from '../common/rate-limiter';
+import { recordAttemptAsync, getClientIP } from '../common/rate-limiter';
+
+// Vercel serverless function timeout (Pro plan: max 300s)
+export const maxDuration = 60;
 
 // Validate API key at module load
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
@@ -139,9 +142,9 @@ export async function POST(request: Request) {
     );
   }
 
-  // Rate limiting
+  // Rate limiting (async for Redis support in serverless)
   const clientIP = getClientIP(request);
-  const rateLimitResult = recordAttempt('chat', clientIP);
+  const rateLimitResult = await recordAttemptAsync('chat', clientIP);
 
   if (rateLimitResult.limited) {
     const retryAfter = Math.ceil((rateLimitResult.resetTime - Date.now()) / 1000);

--- a/apps/psypnos/app/api/common/claude-article-generator.ts
+++ b/apps/psypnos/app/api/common/claude-article-generator.ts
@@ -15,12 +15,13 @@ import {
 import { PSYPNOS_STYLE_SYSTEM_PROMPT } from './psypnos-system-prompt';
 
 // Configuration des timeouts et retries
-const API_TIMEOUT_MS = 120000; // 2 minutes par appel
+// Per-call timeout aligned with Vercel maxDuration (300s for this route)
+const API_TIMEOUT_MS = 90000; // 90 secondes par appel
 const RETRY_OPTIONS = {
-  maxRetries: 3,
+  maxRetries: 2,
   initialDelayMs: 2000,
   backoffMultiplier: 2,
-  maxDelayMs: 30000,
+  maxDelayMs: 15000,
 };
 
 export interface ArticleGenerationOptions {

--- a/apps/psypnos/next.config.mjs
+++ b/apps/psypnos/next.config.mjs
@@ -13,7 +13,7 @@ const ContentSecurityPolicy = `
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
   img-src 'self' data: https: blob:;
   font-src 'self' https://fonts.gstatic.com;
-  connect-src 'self' https://api.resend.com https://*.supabase.co https://www.google-analytics.com;
+  connect-src 'self' https://api.resend.com https://*.supabase.co https://www.google-analytics.com https://api.anthropic.com https://api.openai.com;
   frame-src 'self' https://www.google.com;
   frame-ancestors 'none';
   form-action 'self';


### PR DESCRIPTION
- Add route-level maxDuration exports to all AI routes (60-300s based on complexity)
- Align SDK per-call timeout (90s) with Vercel function limits
- Reduce retry config to fit within maxDuration budget
- Upgrade rate limiter from sync (memory-only) to async (Redis-first) in chat, assistant, improve-text routes
- Add Anthropic and OpenAI API domains to CSP connect-src

https://claude.ai/code/session_01EVMxdvRPqBw5DxSdU28ePR