### PR TITLE
Fix mobile nav z-index and stacking context with React portals

### DIFF
--- a/packages/admin/src/components/layout/AdminHeader.tsx
+++ b/packages/admin/src/components/layout/AdminHeader.tsx
@@ -54,7 +54,7 @@ export function AdminHeader({
   return (
     <header
       className={cn(
-        "border-b border-night/50 bg-night/80 px-4 py-3 backdrop-blur sm:px-6 sm:py-4",
+        "sticky top-0 z-40 border-b border-night/50 bg-night/80 px-4 py-3 backdrop-blur sm:px-6 sm:py-4",
         className
       )}
     >

--- a/packages/admin/src/components/layout/AdminMobileNav.tsx
+++ b/packages/admin/src/components/layout/AdminMobileNav.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
 import { Menu, X, LucideIcon } from "lucide-react";
 import { cn } from "@kairn/ui";
 import type { NavItem } from "./AdminSidebar";
@@ -27,15 +28,8 @@ export interface AdminMobileNavProps {
 /**
  * AdminMobileNav - Mobile drawer navigation for admin dashboard
  *
- * @example
- * ```tsx
- * const navigation = [
- *   { href: "/admin/analytics", label: "Analytics", icon: "📊" },
- *   { href: "/admin/blog", label: "Blog", icon: "📝" },
- * ];
- *
- * <AdminMobileNav siteName="MyApp" navigation={navigation} />
- * ```
+ * Uses a React portal to render the overlay and drawer at document.body level,
+ * escaping any parent stacking contexts (backdrop-blur, transform, etc.).
  */
 export function AdminMobileNav({
   siteName,
@@ -48,9 +42,16 @@ export function AdminMobileNav({
 }: AdminMobileNavProps) {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const closeMenu = useCallback(() => {
     setIsOpen(false);
+  }, []);
+
+  // Ensure portal only renders on the client
+  useEffect(() => {
+    setMounted(true);
   }, []);
 
   // Close menu when route changes
@@ -63,6 +64,7 @@ export function AdminMobileNav({
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         closeMenu();
+        triggerRef.current?.focus();
       }
     };
 
@@ -85,10 +87,117 @@ export function AdminMobileNav({
     return <IconComponent className="h-5 w-5 flex-shrink-0" />;
   };
 
+  // Render overlay + drawer via portal to escape any parent stacking context
+  const drawerContent = mounted
+    ? createPortal(
+        <div
+          className={cn("lg:hidden", isOpen ? "pointer-events-auto" : "pointer-events-none")}
+          aria-hidden={!isOpen}
+        >
+          {/* Overlay backdrop */}
+          <div
+            className={cn(
+              "fixed inset-0 z-[9998] bg-night/80 backdrop-blur-sm transition-opacity duration-300",
+              isOpen ? "opacity-100" : "opacity-0"
+            )}
+            onClick={closeMenu}
+            aria-hidden="true"
+          />
+
+          {/* Drawer */}
+          <aside
+            id="mobile-nav-drawer"
+            className={cn(
+              "fixed inset-y-0 left-0 z-[9999] w-72 bg-night/95 shadow-2xl transition-transform duration-300 ease-in-out",
+              isOpen ? "translate-x-0" : "-translate-x-full"
+            )}
+            aria-label="Mobile navigation menu"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="flex h-full flex-col">
+              {/* Header */}
+              <div className="flex items-center justify-between border-b border-night/40 p-4">
+                <div>
+                  <p
+                    className={cn(
+                      "text-xs uppercase tracking-[0.3em]",
+                      `text-${accentColor}`
+                    )}
+                  >
+                    {siteName}
+                  </p>
+                  <p className="mt-1 text-lg font-semibold text-ivory">{headerSubtitle}</p>
+                </div>
+                <button
+                  onClick={closeMenu}
+                  className={cn(
+                    "rounded-md p-2 text-ivory/70 transition",
+                    "hover:bg-night/60 hover:text-ivory",
+                    `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${accentColor}/70`
+                  )}
+                  aria-label="Close menu"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+
+              {/* Navigation */}
+              <nav className="flex-1 overflow-y-auto p-4" role="navigation">
+                <ul className="space-y-1">
+                  {navigation.map((item) => {
+                    const isActive = pathname?.startsWith(item.href);
+                    return (
+                      <li key={item.href}>
+                        <Link
+                          href={item.href}
+                          className={cn(
+                            "flex items-center gap-3 rounded-md px-4 py-3 text-base transition",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-night",
+                            `focus-visible:ring-${accentColor}/70`,
+                            isActive
+                              ? `bg-${accentColor}/20 text-${accentColor}`
+                              : "text-ivory/70 hover:bg-night/60 hover:text-ivory"
+                          )}
+                          onClick={closeMenu}
+                          aria-current={isActive ? "page" : undefined}
+                        >
+                          {renderIcon(item.icon)}
+                          <span>{item.label}</span>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </nav>
+
+              {/* Footer */}
+              <div className="border-t border-night/40 p-4">
+                <Link
+                  href={siteUrl}
+                  className={cn(
+                    "flex w-full items-center justify-center gap-2 rounded-md px-4 py-3 text-sm font-medium transition",
+                    `border border-${accentColor}/60 text-${accentColor} hover:bg-${accentColor}/10`,
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-night",
+                    `focus-visible:ring-${accentColor}/70`
+                  )}
+                  onClick={closeMenu}
+                >
+                  <span>{siteReturnLabel}</span>
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </div>,
+        document.body
+      )
+    : null;
+
   return (
     <div className={cn("lg:hidden", className)}>
-      {/* Hamburger button */}
+      {/* Hamburger button - stays in the DOM flow */}
       <button
+        ref={triggerRef}
         onClick={() => setIsOpen(true)}
         className={cn(
           "rounded-md p-2 text-ivory/70 transition",
@@ -102,95 +211,8 @@ export function AdminMobileNav({
         <Menu className="h-6 w-6" />
       </button>
 
-      {/* Overlay backdrop */}
-      <div
-        className={cn(
-          "fixed inset-0 z-[70] bg-night/80 backdrop-blur-sm transition-opacity duration-300",
-          isOpen ? "opacity-100" : "pointer-events-none opacity-0"
-        )}
-        onClick={closeMenu}
-        aria-hidden="true"
-      />
-
-      {/* Drawer */}
-      <aside
-        id="mobile-nav-drawer"
-        className={cn(
-          "fixed inset-y-0 left-0 z-[80] w-72 bg-night/95 shadow-xl transition-transform duration-300 ease-in-out",
-          isOpen ? "translate-x-0" : "-translate-x-full"
-        )}
-        aria-label="Mobile navigation menu"
-        role="dialog"
-        aria-modal="true"
-      >
-        <div className="flex h-full flex-col">
-          {/* Header */}
-          <div className="flex items-center justify-between border-b border-night/40 p-4">
-            <div>
-              <p className={cn("text-xs uppercase tracking-[0.3em]", `text-${accentColor}`)}>
-                {siteName}
-              </p>
-              <p className="mt-1 text-lg font-semibold text-ivory">{headerSubtitle}</p>
-            </div>
-            <button
-              onClick={closeMenu}
-              className={cn(
-                "rounded-md p-2 text-ivory/70 transition",
-                "hover:bg-night/60 hover:text-ivory",
-                `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${accentColor}/70`
-              )}
-              aria-label="Close menu"
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
-
-          {/* Navigation */}
-          <nav className="flex-1 overflow-y-auto p-4" role="navigation">
-            <ul className="space-y-1">
-              {navigation.map((item) => {
-                const isActive = pathname?.startsWith(item.href);
-                return (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      className={cn(
-                        "flex items-center gap-3 rounded-md px-4 py-3 text-base transition",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-night",
-                        `focus-visible:ring-${accentColor}/70`,
-                        isActive
-                          ? `bg-${accentColor}/20 text-${accentColor}`
-                          : "text-ivory/70 hover:bg-night/60 hover:text-ivory"
-                      )}
-                      onClick={closeMenu}
-                      aria-current={isActive ? "page" : undefined}
-                    >
-                      {renderIcon(item.icon)}
-                      <span>{item.label}</span>
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </nav>
-
-          {/* Footer */}
-          <div className="border-t border-night/40 p-4">
-            <Link
-              href={siteUrl}
-              className={cn(
-                "flex w-full items-center justify-center gap-2 rounded-md px-4 py-3 text-sm font-medium transition",
-                `border border-${accentColor}/60 text-${accentColor} hover:bg-${accentColor}/10`,
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-night",
-                `focus-visible:ring-${accentColor}/70`
-              )}
-              onClick={closeMenu}
-            >
-              <span>{siteReturnLabel}</span>
-            </Link>
-          </div>
-        </div>
-      </aside>
+      {/* Overlay + Drawer rendered via portal at document.body level */}
+      {drawerContent}
     </div>
   );
 }

--- a/packages/ui/src/components/mobile-nav.tsx
+++ b/packages/ui/src/components/mobile-nav.tsx
@@ -3,7 +3,8 @@
 import { Menu, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
 
 import { cn } from "../utils/cn";
 
@@ -42,6 +43,8 @@ export function MobileNav({
 }: MobileNavProps) {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const {
     primary = "gold",
@@ -54,6 +57,11 @@ export function MobileNav({
     setIsOpen(false);
   }, []);
 
+  // Ensure portal only renders on the client
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   // Close menu when route changes
   useEffect(() => {
     closeMenu();
@@ -64,12 +72,12 @@ export function MobileNav({
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         closeMenu();
+        triggerRef.current?.focus();
       }
     };
 
     if (isOpen) {
       document.addEventListener("keydown", handleEscape);
-      // Prevent body scroll when menu is open
       document.body.style.overflow = "hidden";
     }
 
@@ -79,10 +87,104 @@ export function MobileNav({
     };
   }, [isOpen, closeMenu]);
 
+  // Render overlay + drawer via portal to escape any parent stacking context
+  // (backdrop-blur, transform, etc. on ancestors create containing blocks for fixed elements)
+  const drawerContent = mounted
+    ? createPortal(
+        <div
+          className={cn("lg:hidden", isOpen ? "pointer-events-auto" : "pointer-events-none")}
+          aria-hidden={!isOpen}
+        >
+          {/* Overlay backdrop */}
+          <div
+            className={cn(
+              `fixed inset-0 z-[9998] bg-${background}/80 backdrop-blur-sm transition-opacity duration-300`,
+              isOpen ? "opacity-100" : "opacity-0"
+            )}
+            onClick={closeMenu}
+            aria-hidden="true"
+          />
+
+          {/* Drawer */}
+          <aside
+            className={cn(
+              `fixed inset-y-0 left-0 z-[9999] w-72 bg-${background}/95 shadow-2xl transition-transform duration-300 ease-in-out`,
+              isOpen ? "translate-x-0" : "-translate-x-full"
+            )}
+            aria-label="Menu de navigation"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="flex h-full flex-col">
+              {/* Header */}
+              <div
+                className={`flex items-center justify-between border-b border-${border}/40 p-4`}
+              >
+                <div>
+                  <p className={`text-xs uppercase tracking-[0.3em] text-${primary}`}>
+                    {siteName}
+                  </p>
+                  <p className={`mt-1 text-lg font-semibold text-${text}`}>{title}</p>
+                </div>
+                <button
+                  onClick={closeMenu}
+                  className={`rounded-md p-2 text-${text}/70 transition hover:bg-${background}/60 hover:text-${text} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${primary}/70`}
+                  aria-label="Fermer le menu"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+
+              {/* Navigation */}
+              <nav className="flex-1 overflow-y-auto p-4">
+                <ul className="space-y-1">
+                  {navigation.map((item) => {
+                    const isActive = pathname?.startsWith(item.href);
+                    return (
+                      <li key={item.href}>
+                        <Link
+                          href={item.href}
+                          className={cn(
+                            `flex items-center gap-3 rounded-md px-4 py-3 text-base transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${primary}/70 focus-visible:ring-offset-2 focus-visible:ring-offset-${background}`,
+                            isActive
+                              ? `bg-${primary}/20 text-${primary}`
+                              : `text-${text}/70 hover:bg-${background}/60 hover:text-${text}`
+                          )}
+                          onClick={closeMenu}
+                        >
+                          <span className="flex-shrink-0 text-xl">
+                            {typeof item.icon === "string" ? item.icon : item.icon}
+                          </span>
+                          <span>{item.label}</span>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </nav>
+
+              {/* Footer */}
+              <div className={`border-t border-${border}/40 p-4`}>
+                <Link
+                  href={backToSiteHref}
+                  className={`flex w-full items-center justify-center gap-2 rounded-md border border-${primary}/60 px-4 py-3 text-sm font-medium text-${primary} transition hover:bg-${primary}/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${primary}/70`}
+                  onClick={closeMenu}
+                >
+                  <span>{backToSiteLabel}</span>
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </div>,
+        document.body
+      )
+    : null;
+
   return (
     <div className={cn("lg:hidden", className)}>
-      {/* Hamburger button */}
+      {/* Hamburger button - stays in the DOM flow */}
       <button
+        ref={triggerRef}
         onClick={() => setIsOpen(true)}
         className={`rounded-md p-2 text-${text}/70 transition hover:bg-${background}/60 hover:text-${text} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${primary}/70`}
         aria-label="Ouvrir le menu de navigation"
@@ -91,82 +193,8 @@ export function MobileNav({
         <Menu className="h-6 w-6" />
       </button>
 
-      {/* Overlay backdrop */}
-      <div
-        className={cn(
-          `fixed inset-0 z-[70] bg-${background}/80 backdrop-blur-sm transition-opacity duration-300`,
-          isOpen ? "opacity-100" : "pointer-events-none opacity-0"
-        )}
-        onClick={closeMenu}
-        aria-hidden="true"
-      />
-
-      {/* Drawer */}
-      <aside
-        className={cn(
-          `fixed inset-y-0 left-0 z-[80] w-72 bg-${background}/95 shadow-xl transition-transform duration-300 ease-in-out`,
-          isOpen ? "translate-x-0" : "-translate-x-full"
-        )}
-        aria-label="Menu de navigation"
-      >
-        <div className="flex h-full flex-col">
-          {/* Header */}
-          <div className={`flex items-center justify-between border-b border-${border}/40 p-4`}>
-            <div>
-              <p className={`text-xs uppercase tracking-[0.3em] text-${primary}`}>
-                {siteName}
-              </p>
-              <p className={`mt-1 text-lg font-semibold text-${text}`}>{title}</p>
-            </div>
-            <button
-              onClick={closeMenu}
-              className={`rounded-md p-2 text-${text}/70 transition hover:bg-${background}/60 hover:text-${text} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${primary}/70`}
-              aria-label="Fermer le menu"
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
-
-          {/* Navigation */}
-          <nav className="flex-1 overflow-y-auto p-4">
-            <ul className="space-y-1">
-              {navigation.map((item) => {
-                const isActive = pathname?.startsWith(item.href);
-                return (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      className={cn(
-                        `flex items-center gap-3 rounded-md px-4 py-3 text-base transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${primary}/70 focus-visible:ring-offset-2 focus-visible:ring-offset-${background}`,
-                        isActive
-                          ? `bg-${primary}/20 text-${primary}`
-                          : `text-${text}/70 hover:bg-${background}/60 hover:text-${text}`
-                      )}
-                      onClick={closeMenu}
-                    >
-                      <span className="flex-shrink-0 text-xl">
-                        {typeof item.icon === "string" ? item.icon : item.icon}
-                      </span>
-                      <span>{item.label}</span>
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </nav>
-
-          {/* Footer */}
-          <div className={`border-t border-${border}/40 p-4`}>
-            <Link
-              href={backToSiteHref}
-              className={`flex w-full items-center justify-center gap-2 rounded-md border border-${primary}/60 px-4 py-3 text-sm font-medium text-${primary} transition hover:bg-${primary}/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-${primary}/70`}
-              onClick={closeMenu}
-            >
-              <span>{backToSiteLabel}</span>
-            </Link>
-          </div>
-        </div>
-      </aside>
+      {/* Overlay + Drawer rendered via portal at document.body level */}
+      {drawerContent}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Refactors mobile navigation components (`AdminMobileNav` and `MobileNav`) to use React portals for rendering the overlay and drawer at the document.body level. This resolves z-index and stacking context issues that occur when parent elements have CSS properties like `backdrop-blur` or `transform` that create new stacking contexts, preventing fixed positioned elements from appearing above them.

### Key Changes

- **Portal Implementation**: Overlay and drawer are now rendered via `createPortal()` at `document.body` level, escaping parent stacking contexts
- **Z-index Updates**: Increased z-index values (9998 for overlay, 9999 for drawer) to ensure proper layering at document root level
- **Client-side Rendering**: Added `mounted` state to ensure portals only render on the client, preventing hydration mismatches
- **Focus Management**: Added `triggerRef` to restore focus to the hamburger button when the menu is closed via Escape key
- **Header Sticky Positioning**: Updated `AdminHeader` to use `sticky top-0 z-40` for proper positioning above page content
- **Accessibility**: Maintained all ARIA attributes and semantic HTML structure

### Files Modified

- `packages/admin/src/components/layout/AdminMobileNav.tsx`
- `packages/ui/src/components/mobile-nav.tsx`
- `packages/admin/src/components/layout/AdminHeader.tsx`

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [x] Tous les sites (packages/)

## Test Plan

- Verify mobile navigation drawer opens/closes correctly on mobile viewports
- Confirm drawer appears above all page content including elements with backdrop-blur or transform
- Test keyboard navigation (Escape key closes menu and returns focus to trigger button)
- Verify no hydration warnings in console
- Test on pages with various parent element styles (backdrop-blur, transform, etc.)

https://claude.ai/code/session_01D7tTq6CeqMx3CcqHjohqGH