### PR TITLE
Add chatbot admin dashboard with conversation management

### DIFF
--- a/apps/psypnos/app/admin/chatbot/_components/ChatbotSkeleton.tsx
+++ b/apps/psypnos/app/admin/chatbot/_components/ChatbotSkeleton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+export function ChatbotSkeleton() {
+  return (
+    <section className="space-y-6">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <div className="h-7 w-40 animate-pulse rounded bg-gold/10" />
+          <div className="h-4 w-64 animate-pulse rounded bg-gold/5" />
+        </div>
+        <div className="h-9 w-28 animate-pulse rounded-lg bg-gold/10" />
+      </div>
+
+      {/* Toggle skeleton */}
+      <div className="h-16 animate-pulse rounded-xl border border-gold/20 bg-night/60" />
+
+      {/* Stats skeleton */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {[...Array(5)].map((_, i) => (
+          <div
+            key={i}
+            className="h-20 animate-pulse rounded-xl border border-gold/20 bg-night/60"
+          />
+        ))}
+      </div>
+
+      {/* Table skeleton */}
+      <div className="space-y-3">
+        <div className="flex gap-3">
+          <div className="h-10 flex-1 animate-pulse rounded-lg bg-gold/5" />
+          <div className="h-10 w-32 animate-pulse rounded-lg bg-gold/5" />
+          <div className="h-10 w-32 animate-pulse rounded-lg bg-gold/5" />
+        </div>
+        <div className="rounded-xl border border-gold/20 bg-night/60 p-4">
+          <div className="animate-pulse space-y-4">
+            <div className="h-4 w-1/4 rounded bg-gold/20" />
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-12 rounded bg-gold/10" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/psypnos/app/admin/chatbot/_components/ChatbotStats.tsx
+++ b/apps/psypnos/app/admin/chatbot/_components/ChatbotStats.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { ChatbotStats } from "../types";
+
+interface ChatbotStatsCardsProps {
+  stats: ChatbotStats;
+  loading?: boolean;
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  accent,
+  loading,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  accent?: "gold" | "green" | "rose" | "blue";
+  loading?: boolean;
+}) {
+  const accentColors = {
+    gold: "border-gold/30 bg-gold/5",
+    green: "border-emerald-400/30 bg-emerald-400/5",
+    rose: "border-rose-400/30 bg-rose-400/5",
+    blue: "border-blue-400/30 bg-blue-400/5",
+  };
+
+  const valueColors = {
+    gold: "text-gold",
+    green: "text-emerald-400",
+    rose: "text-rose-400",
+    blue: "text-blue-400",
+  };
+
+  const color = accent || "gold";
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-gold/20 bg-night/60 p-4">
+        <div className="animate-pulse space-y-2">
+          <div className="h-3 w-20 rounded bg-gold/20" />
+          <div className="h-7 w-16 rounded bg-gold/10" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`rounded-xl border p-4 ${accentColors[color]}`}>
+      <p className="text-xs font-medium uppercase tracking-wide text-ivory/50">{label}</p>
+      <p className={`mt-1 text-2xl font-bold ${valueColors[color]}`}>{value}</p>
+      {sub && <p className="mt-0.5 text-xs text-ivory/40">{sub}</p>}
+    </div>
+  );
+}
+
+export function ChatbotStatsCards({ stats, loading }: ChatbotStatsCardsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+      <StatCard
+        label="Total conversations"
+        value={stats.totalConversations}
+        sub={`${stats.todayConversations} aujourd'hui`}
+        accent="gold"
+        loading={loading}
+      />
+      <StatCard
+        label="En cours"
+        value={stats.activeConversations}
+        accent="blue"
+        loading={loading}
+      />
+      <StatCard
+        label="Messages"
+        value={stats.totalMessages}
+        sub={`~${stats.avgMessagesPerConversation} / conv.`}
+        accent="gold"
+        loading={loading}
+      />
+      <StatCard
+        label="Satisfaction"
+        value={stats.satisfactionRate !== null ? `${stats.satisfactionRate}%` : "—"}
+        sub={`${stats.satisfiedCount} positifs / ${stats.unsatisfiedCount} négatifs`}
+        accent={
+          stats.satisfactionRate !== null && stats.satisfactionRate >= 70
+            ? "green"
+            : stats.satisfactionRate !== null && stats.satisfactionRate < 50
+              ? "rose"
+              : "gold"
+        }
+        loading={loading}
+      />
+      <StatCard
+        label="Cette semaine"
+        value={stats.weekConversations}
+        accent="blue"
+        loading={loading}
+      />
+    </div>
+  );
+}

--- a/apps/psypnos/app/admin/chatbot/_components/ChatbotToggle.tsx
+++ b/apps/psypnos/app/admin/chatbot/_components/ChatbotToggle.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Loader2 } from "lucide-react";
+
+interface ChatbotToggleProps {
+  onStatusChange?: (enabled: boolean) => void;
+}
+
+export function ChatbotToggle({ onStatusChange }: ChatbotToggleProps) {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState(false);
+
+  const fetchSettings = useCallback(async () => {
+    try {
+      const response = await fetch("/api/admin/chatbot/settings");
+      if (response.ok) {
+        const data = await response.json();
+        setEnabled(data.chatbotEnabled);
+      }
+    } catch {
+      // Silently fail — default to enabled
+      setEnabled(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchSettings();
+  }, [fetchSettings]);
+
+  async function handleToggle() {
+    if (toggling || enabled === null) return;
+
+    const newValue = !enabled;
+    setToggling(true);
+
+    try {
+      const response = await fetch("/api/admin/chatbot/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chatbotEnabled: newValue }),
+      });
+
+      if (response.ok) {
+        setEnabled(newValue);
+        onStatusChange?.(newValue);
+      }
+    } catch {
+      // Revert on error
+    } finally {
+      setToggling(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-3 rounded-xl border border-gold/20 bg-night/60 px-4 py-3">
+        <Loader2 className="h-4 w-4 animate-spin text-gold/50" />
+        <span className="text-sm text-ivory/50">Chargement...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`flex items-center justify-between gap-4 rounded-xl border px-4 py-3 transition-colors ${
+        enabled
+          ? "border-emerald-400/30 bg-emerald-400/5"
+          : "border-rose-400/30 bg-rose-400/5"
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <div
+          className={`flex h-8 w-8 items-center justify-center rounded-lg text-lg ${
+            enabled ? "bg-emerald-400/15" : "bg-rose-400/15"
+          }`}
+        >
+          {enabled ? "✅" : "⛔"}
+        </div>
+        <div>
+          <p className="text-sm font-medium text-ivory">
+            ChatBot IA {enabled ? "activé" : "désactivé"}
+          </p>
+          <p className="text-xs text-ivory/40">
+            {enabled
+              ? "Le chatbot est visible sur toutes les pages du site"
+              : "Le chatbot est masqué pour les visiteurs"}
+          </p>
+        </div>
+      </div>
+
+      <button
+        onClick={handleToggle}
+        disabled={toggling}
+        className="relative flex h-7 w-12 flex-shrink-0 cursor-pointer items-center rounded-full transition-colors disabled:cursor-wait"
+        style={{
+          backgroundColor: enabled ? "rgba(52, 211, 153, 0.4)" : "rgba(107, 114, 128, 0.4)",
+        }}
+        role="switch"
+        aria-checked={enabled ?? false}
+        aria-label={enabled ? "Désactiver le ChatBot" : "Activer le ChatBot"}
+      >
+        <span
+          className={`inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+            enabled ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+        {toggling && (
+          <Loader2 className="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 animate-spin text-ivory/60" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/apps/psypnos/app/admin/chatbot/_components/ConversationDrawer.tsx
+++ b/apps/psypnos/app/admin/chatbot/_components/ConversationDrawer.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { X, Loader2 } from "lucide-react";
+
+import type { ConversationDetail, ConversationPreview } from "../types";
+
+interface ConversationDrawerProps {
+  conversation: ConversationPreview | null;
+  open: boolean;
+  onClose: () => void;
+  onDelete: (conversation: ConversationPreview) => void;
+}
+
+function formatFullDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleTimeString("fr-FR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function ConversationDrawer({
+  conversation,
+  open,
+  onClose,
+  onDelete,
+}: ConversationDrawerProps) {
+  const [detail, setDetail] = useState<ConversationDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(async (id: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/chatbot/conversations/${id}`);
+      if (!response.ok) throw new Error("Erreur de chargement");
+      const data = await response.json();
+      setDetail(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open && conversation) {
+      void fetchDetail(conversation.id);
+    } else {
+      setDetail(null);
+      setError(null);
+    }
+  }, [open, conversation, fetchDetail]);
+
+  // Handle escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [open, onClose]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm transition-opacity duration-300 ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer */}
+      <div
+        className={`fixed inset-0 z-[70] flex justify-end transition-opacity duration-300 ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Détail de la conversation"
+      >
+        <div
+          className={`flex h-full w-full flex-col bg-night/95 shadow-xl transition-transform duration-300 ease-in-out sm:w-[32rem] lg:w-[40rem] ${
+            open ? "translate-x-0" : "translate-x-full"
+          }`}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-night/40 px-4 py-3">
+            <div>
+              <h2 className="text-lg font-semibold text-gold">
+                Conversation
+              </h2>
+              {detail && (
+                <p className="text-xs text-ivory/40">
+                  {formatFullDate(detail.createdAt)} &middot;{" "}
+                  {detail.messageCount} messages
+                </p>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {conversation && (
+                <button
+                  onClick={() => onDelete(conversation)}
+                  className="rounded-md px-3 py-1.5 text-xs font-medium text-rose-400 transition hover:bg-rose-400/10"
+                >
+                  Supprimer
+                </button>
+              )}
+              <button
+                onClick={onClose}
+                className="rounded-md p-2 text-ivory/70 transition hover:bg-night/60 hover:text-ivory"
+                aria-label="Fermer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+
+          {/* Meta info bar */}
+          {detail && (
+            <div className="flex flex-wrap gap-3 border-b border-night/40 px-4 py-2">
+              <MetaTag label="Statut" value={statusLabel(detail.status)} />
+              <MetaTag
+                label="Satisfaction"
+                value={
+                  detail.satisfied === true
+                    ? "👍 Satisfait"
+                    : detail.satisfied === false
+                      ? "👎 Insatisfait"
+                      : "Pas de retour"
+                }
+              />
+              {detail.totalTokens > 0 && (
+                <MetaTag label="Tokens" value={detail.totalTokens.toLocaleString("fr-FR")} />
+              )}
+              {detail.avgProcessingTime !== null && (
+                <MetaTag label="Temps moyen" value={`${detail.avgProcessingTime} ms`} />
+              )}
+              {detail.referrer && (
+                <MetaTag label="Page" value={detail.referrer} />
+              )}
+              {detail.deviceType && (
+                <MetaTag label="Appareil" value={detail.deviceType} />
+              )}
+            </div>
+          )}
+
+          {/* Messages */}
+          <div className="flex-1 overflow-y-auto px-4 py-4">
+            {loading && (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="h-6 w-6 animate-spin text-gold" />
+              </div>
+            )}
+
+            {error && (
+              <div className="rounded-lg border border-rose-400/30 bg-rose-400/5 p-4 text-center text-sm text-rose-400">
+                {error}
+              </div>
+            )}
+
+            {detail && !loading && (
+              <div className="space-y-3">
+                {detail.messages.map((msg) => (
+                  <div
+                    key={msg.id}
+                    className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+                  >
+                    <div
+                      className={`max-w-[85%] rounded-2xl px-4 py-2.5 ${
+                        msg.role === "user"
+                          ? "rounded-br-md bg-gold/20 text-ivory"
+                          : msg.role === "system"
+                            ? "rounded-bl-md border border-blue-400/20 bg-blue-400/5 text-blue-300"
+                            : "rounded-bl-md bg-night/80 text-ivory/90"
+                      }`}
+                    >
+                      <div className="mb-1 flex items-center gap-2">
+                        <span className="text-[10px] font-semibold uppercase tracking-wider text-ivory/40">
+                          {msg.role === "user"
+                            ? "Visiteur"
+                            : msg.role === "assistant"
+                              ? "ChatBot IA"
+                              : "Système"}
+                        </span>
+                        <span className="text-[10px] text-ivory/30">
+                          {formatTime(msg.createdAt)}
+                        </span>
+                      </div>
+                      <p className="whitespace-pre-wrap text-sm leading-relaxed">
+                        {msg.content}
+                      </p>
+                      {(msg.tokensUsed || msg.processingTime) && (
+                        <div className="mt-1.5 flex gap-3 text-[10px] text-ivory/25">
+                          {msg.tokensUsed && (
+                            <span>{msg.tokensUsed} tokens</span>
+                          )}
+                          {msg.processingTime && (
+                            <span>{msg.processingTime} ms</span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function MetaTag({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs">
+      <span className="text-ivory/40">{label}:</span>
+      <span className="font-medium text-ivory/70">{value}</span>
+    </div>
+  );
+}
+
+function statusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    active: "En cours",
+    ended: "Terminée",
+    transferred: "Transférée",
+  };
+  return labels[status] || status;
+}

--- a/apps/psypnos/app/admin/chatbot/_components/ConversationFilters.tsx
+++ b/apps/psypnos/app/admin/chatbot/_components/ConversationFilters.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+interface ConversationFiltersProps {
+  search: string;
+  onSearchChange: (value: string) => void;
+  statusFilter: string;
+  onStatusFilterChange: (value: string) => void;
+  satisfactionFilter: string;
+  onSatisfactionFilterChange: (value: string) => void;
+}
+
+export function ConversationFilters({
+  search,
+  onSearchChange,
+  statusFilter,
+  onStatusFilterChange,
+  satisfactionFilter,
+  onSatisfactionFilterChange,
+}: ConversationFiltersProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      {/* Search */}
+      <div className="flex-1">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Rechercher dans les conversations..."
+          className="w-full rounded-lg border border-gold/20 bg-night/60 px-3 py-2 text-sm text-ivory placeholder:text-ivory/30 focus:border-gold/50 focus:outline-none focus:ring-1 focus:ring-gold/30"
+        />
+      </div>
+
+      {/* Status filter */}
+      <select
+        value={statusFilter}
+        onChange={(e) => onStatusFilterChange(e.target.value)}
+        className="rounded-lg border border-gold/20 bg-night/60 px-3 py-2 text-sm text-ivory focus:border-gold/50 focus:outline-none focus:ring-1 focus:ring-gold/30"
+      >
+        <option value="">Tous les statuts</option>
+        <option value="active">En cours</option>
+        <option value="ended">Terminée</option>
+        <option value="transferred">Transférée</option>
+      </select>
+
+      {/* Satisfaction filter */}
+      <select
+        value={satisfactionFilter}
+        onChange={(e) => onSatisfactionFilterChange(e.target.value)}
+        className="rounded-lg border border-gold/20 bg-night/60 px-3 py-2 text-sm text-ivory focus:border-gold/50 focus:outline-none focus:ring-1 focus:ring-gold/30"
+      >
+        <option value="">Toute satisfaction</option>
+        <option value="satisfied">Satisfait</option>
+        <option value="unsatisfied">Insatisfait</option>
+        <option value="no_feedback">Pas de retour</option>
+      </select>
+    </div>
+  );
+}

--- a/apps/psypnos/app/admin/chatbot/_components/ConversationsTable.tsx
+++ b/apps/psypnos/app/admin/chatbot/_components/ConversationsTable.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import type { ConversationPreview } from "../types";
+
+interface ConversationsTableProps {
+  conversations: ConversationPreview[];
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+  onToggleSelectAll: () => void;
+  onView: (conversation: ConversationPreview) => void;
+  onDelete: (conversation: ConversationPreview) => void;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffH = Math.floor(diffMs / 3600000);
+  const diffD = Math.floor(diffMs / 86400000);
+
+  if (diffMin < 1) return "À l'instant";
+  if (diffMin < 60) return `Il y a ${diffMin} min`;
+  if (diffH < 24) return `Il y a ${diffH}h`;
+  if (diffD < 7) return `Il y a ${diffD}j`;
+
+  return d.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: d.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
+  });
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    active: "bg-emerald-400/15 text-emerald-400 border-emerald-400/30",
+    ended: "bg-ivory/10 text-ivory/60 border-ivory/20",
+    transferred: "bg-blue-400/15 text-blue-400 border-blue-400/30",
+  };
+
+  const labels: Record<string, string> = {
+    active: "En cours",
+    ended: "Terminée",
+    transferred: "Transférée",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${styles[status] || styles.ended}`}
+    >
+      {labels[status] || status}
+    </span>
+  );
+}
+
+function SatisfactionBadge({ satisfied }: { satisfied: boolean | null }) {
+  if (satisfied === null) {
+    return (
+      <span className="inline-flex items-center text-xs text-ivory/30">—</span>
+    );
+  }
+
+  return satisfied ? (
+    <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
+      <span className="text-sm">👍</span> Satisfait
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 text-xs text-rose-400">
+      <span className="text-sm">👎</span> Insatisfait
+    </span>
+  );
+}
+
+export function ConversationsTable({
+  conversations,
+  selectedIds,
+  onToggleSelect,
+  onToggleSelectAll,
+  onView,
+  onDelete,
+}: ConversationsTableProps) {
+  const allSelected =
+    conversations.length > 0 && conversations.every((c) => selectedIds.has(c.id));
+
+  if (conversations.length === 0) {
+    return (
+      <div className="rounded-xl border border-gold/20 bg-night/60 p-12 text-center">
+        <p className="text-4xl">💬</p>
+        <p className="mt-3 text-lg font-medium text-ivory/70">
+          Aucune conversation trouvée
+        </p>
+        <p className="mt-1 text-sm text-ivory/40">
+          Les conversations du ChatBot IA apparaîtront ici.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-gold/20 bg-night/60">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gold/20">
+            <th className="px-3 py-3 text-left">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                onChange={onToggleSelectAll}
+                className="h-4 w-4 rounded border-gold/40 bg-night/60 accent-gold"
+              />
+            </th>
+            <th className="px-3 py-3 text-left font-semibold text-ivory/70">
+              Aperçu
+            </th>
+            <th className="hidden px-3 py-3 text-left font-semibold text-ivory/70 sm:table-cell">
+              Statut
+            </th>
+            <th className="hidden px-3 py-3 text-center font-semibold text-ivory/70 md:table-cell">
+              Messages
+            </th>
+            <th className="hidden px-3 py-3 text-left font-semibold text-ivory/70 lg:table-cell">
+              Satisfaction
+            </th>
+            <th className="px-3 py-3 text-left font-semibold text-ivory/70">Date</th>
+            <th className="px-3 py-3 text-right font-semibold text-ivory/70">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {conversations.map((conv) => (
+            <tr
+              key={conv.id}
+              className="border-b border-gold/10 transition hover:bg-gold/5"
+            >
+              <td className="px-3 py-3">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(conv.id)}
+                  onChange={() => onToggleSelect(conv.id)}
+                  className="h-4 w-4 rounded border-gold/40 bg-night/60 accent-gold"
+                />
+              </td>
+              <td className="max-w-xs px-3 py-3">
+                <button
+                  onClick={() => onView(conv)}
+                  className="block w-full text-left transition hover:text-gold"
+                >
+                  <p className="truncate font-medium text-ivory/90">
+                    {conv.firstUserMessage || conv.preview || "Conversation vide"}
+                  </p>
+                  {conv.referrer && (
+                    <p className="mt-0.5 truncate text-xs text-ivory/40">
+                      depuis {conv.referrer}
+                    </p>
+                  )}
+                </button>
+              </td>
+              <td className="hidden px-3 py-3 sm:table-cell">
+                <StatusBadge status={conv.status} />
+              </td>
+              <td className="hidden px-3 py-3 text-center text-ivory/60 md:table-cell">
+                {conv.messageCount}
+              </td>
+              <td className="hidden px-3 py-3 lg:table-cell">
+                <SatisfactionBadge satisfied={conv.satisfied} />
+              </td>
+              <td className="whitespace-nowrap px-3 py-3 text-ivory/50">
+                {formatDate(conv.createdAt)}
+              </td>
+              <td className="px-3 py-3 text-right">
+                <div className="flex items-center justify-end gap-1">
+                  <button
+                    onClick={() => onView(conv)}
+                    className="rounded-md px-2 py-1 text-xs text-ivory/60 transition hover:bg-gold/10 hover:text-gold"
+                    title="Voir le détail"
+                  >
+                    Voir
+                  </button>
+                  <button
+                    onClick={() => onDelete(conv)}
+                    className="rounded-md px-2 py-1 text-xs text-ivory/60 transition hover:bg-rose-400/10 hover:text-rose-400"
+                    title="Supprimer"
+                  >
+                    Suppr.
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/psypnos/app/admin/chatbot/_components/Pagination.tsx
+++ b/apps/psypnos/app/admin/chatbot/_components/Pagination.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { PaginationInfo } from "../types";
+
+interface PaginationProps {
+  pagination: PaginationInfo;
+  onPageChange: (page: number) => void;
+}
+
+export function Pagination({ pagination, onPageChange }: PaginationProps) {
+  const { page, totalPages, total } = pagination;
+
+  if (totalPages <= 1) return null;
+
+  const pages: (number | "...")[] = [];
+
+  if (totalPages <= 7) {
+    for (let i = 1; i <= totalPages; i++) pages.push(i);
+  } else {
+    pages.push(1);
+    if (page > 3) pages.push("...");
+    for (let i = Math.max(2, page - 1); i <= Math.min(totalPages - 1, page + 1); i++) {
+      pages.push(i);
+    }
+    if (page < totalPages - 2) pages.push("...");
+    pages.push(totalPages);
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-between gap-3 sm:flex-row">
+      <p className="text-xs text-ivory/40">
+        {total} conversation{total > 1 ? "s" : ""} au total
+      </p>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+          className="rounded-md px-2 py-1 text-xs text-ivory/60 transition hover:bg-gold/10 hover:text-gold disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-ivory/60"
+        >
+          ← Préc.
+        </button>
+        {pages.map((p, i) =>
+          p === "..." ? (
+            <span key={`dots-${i}`} className="px-1 text-xs text-ivory/30">
+              ...
+            </span>
+          ) : (
+            <button
+              key={p}
+              onClick={() => onPageChange(p)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition ${
+                p === page
+                  ? "bg-gold/20 text-gold"
+                  : "text-ivory/60 hover:bg-gold/10 hover:text-gold"
+              }`}
+            >
+              {p}
+            </button>
+          )
+        )}
+        <button
+          onClick={() => onPageChange(page + 1)}
+          disabled={page >= totalPages}
+          className="rounded-md px-2 py-1 text-xs text-ivory/60 transition hover:bg-gold/10 hover:text-gold disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-ivory/60"
+        >
+          Suiv. →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/psypnos/app/admin/chatbot/page.tsx
+++ b/apps/psypnos/app/admin/chatbot/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+export const dynamic = "force-dynamic";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { useToast } from "@/lib/toast-context";
+
+import { DeleteConfirmation } from "../_components/DeleteConfirmation";
+
+import { ChatbotStatsCards } from "./_components/ChatbotStats";
+import { ChatbotToggle } from "./_components/ChatbotToggle";
+import { ChatbotSkeleton } from "./_components/ChatbotSkeleton";
+import { ConversationFilters } from "./_components/ConversationFilters";
+import { ConversationsTable } from "./_components/ConversationsTable";
+import { ConversationDrawer } from "./_components/ConversationDrawer";
+import { Pagination } from "./_components/Pagination";
+import type {
+  ConversationPreview,
+  ConversationsResponse,
+  ChatbotStats,
+  PaginationInfo,
+} from "./types";
+
+const DEFAULT_STATS: ChatbotStats = {
+  totalConversations: 0,
+  activeConversations: 0,
+  satisfiedCount: 0,
+  unsatisfiedCount: 0,
+  satisfactionRate: null,
+  totalMessages: 0,
+  avgMessagesPerConversation: 0,
+  todayConversations: 0,
+  weekConversations: 0,
+};
+
+const DEFAULT_PAGINATION: PaginationInfo = {
+  page: 1,
+  limit: 20,
+  total: 0,
+  totalPages: 0,
+};
+
+export default function ChatbotAdminPage() {
+  const { addToast } = useToast();
+
+  // Data state
+  const [conversations, setConversations] = useState<ConversationPreview[]>([]);
+  const [stats, setStats] = useState<ChatbotStats>(DEFAULT_STATS);
+  const [pagination, setPagination] = useState<PaginationInfo>(DEFAULT_PAGINATION);
+
+  // UI state
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [drawerConversation, setDrawerConversation] = useState<ConversationPreview | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ConversationPreview | null>(null);
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Filters
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [satisfactionFilter, setSatisfactionFilter] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Debounced search
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 400);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Reset to page 1 on filter change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [debouncedSearch, statusFilter, satisfactionFilter]);
+
+  // Fetch conversations
+  const fetchConversations = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("page", String(currentPage));
+      params.set("limit", "20");
+      if (debouncedSearch) params.set("search", debouncedSearch);
+      if (statusFilter) params.set("status", statusFilter);
+      if (satisfactionFilter) params.set("satisfaction", satisfactionFilter);
+
+      const response = await fetch(`/api/admin/chatbot/conversations?${params}`);
+      if (!response.ok) throw new Error("Erreur lors du chargement");
+
+      const data: ConversationsResponse = await response.json();
+      setConversations(data.conversations);
+      setStats(data.stats);
+      setPagination(data.pagination);
+    } catch (error) {
+      addToast({
+        title: "Erreur de chargement",
+        description:
+          error instanceof Error ? error.message : "Impossible de charger les conversations",
+        variant: "error",
+      });
+    } finally {
+      setIsInitialLoading(false);
+      setIsRefreshing(false);
+    }
+  }, [currentPage, debouncedSearch, statusFilter, satisfactionFilter, addToast]);
+
+  useEffect(() => {
+    void fetchConversations();
+  }, [fetchConversations]);
+
+  // Selection handlers
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    if (conversations.every((c) => selectedIds.has(c.id))) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(conversations.map((c) => c.id)));
+    }
+  }
+
+  // Delete single conversation
+  async function handleDelete(id: string) {
+    setIsDeleting(true);
+    try {
+      const response = await fetch(`/api/admin/chatbot/conversations/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) throw new Error("Erreur lors de la suppression");
+
+      setConversations((prev) => prev.filter((c) => c.id !== id));
+      selectedIds.delete(id);
+      setSelectedIds(new Set(selectedIds));
+      setDeleteTarget(null);
+      setDrawerConversation(null);
+
+      addToast({
+        title: "Conversation supprimée",
+        description: "La conversation a été supprimée avec succès",
+        variant: "success",
+      });
+
+      // Refresh stats
+      void fetchConversations();
+    } catch (error) {
+      addToast({
+        title: "Erreur de suppression",
+        description:
+          error instanceof Error ? error.message : "Impossible de supprimer la conversation",
+        variant: "error",
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  // Bulk delete
+  async function handleBulkDelete() {
+    if (selectedIds.size === 0) return;
+
+    setIsDeleting(true);
+    try {
+      const response = await fetch("/api/admin/chatbot/conversations/bulk", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: Array.from(selectedIds) }),
+      });
+      if (!response.ok) throw new Error("Erreur lors de la suppression");
+
+      const data = await response.json();
+      setSelectedIds(new Set());
+      setBulkDeleteConfirm(false);
+
+      addToast({
+        title: "Conversations supprimées",
+        description: `${data.deleted} conversation(s) supprimée(s)`,
+        variant: "success",
+      });
+
+      void fetchConversations();
+    } catch (error) {
+      addToast({
+        title: "Erreur de suppression",
+        description:
+          error instanceof Error ? error.message : "Impossible de supprimer les conversations",
+        variant: "error",
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  if (isInitialLoading) {
+    return <ChatbotSkeleton />;
+  }
+
+  return (
+    <section className="space-y-6">
+      {/* Page header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-ivory">ChatBot IA</h2>
+          <p className="text-sm text-ivory/60">
+            Historique des conversations et gestion du chatbot.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void fetchConversations()}
+          disabled={isRefreshing}
+          className="inline-flex items-center justify-center rounded-md border border-gold/40 px-4 py-2 text-sm font-medium text-gold transition hover:bg-gold/10 disabled:opacity-50"
+        >
+          {isRefreshing ? "Actualisation..." : "Actualiser"}
+        </button>
+      </div>
+
+      {/* Chatbot toggle */}
+      <ChatbotToggle
+        onStatusChange={(enabled) => {
+          addToast({
+            title: enabled ? "ChatBot IA activé" : "ChatBot IA désactivé",
+            description: enabled
+              ? "Le chatbot est maintenant visible sur le site"
+              : "Le chatbot est masqué pour les visiteurs",
+            variant: "success",
+          });
+        }}
+      />
+
+      {/* Stats */}
+      <ChatbotStatsCards stats={stats} loading={isRefreshing} />
+
+      {/* Filters */}
+      <ConversationFilters
+        search={search}
+        onSearchChange={setSearch}
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        satisfactionFilter={satisfactionFilter}
+        onSatisfactionFilterChange={setSatisfactionFilter}
+      />
+
+      {/* Bulk actions */}
+      {selectedIds.size > 0 && (
+        <div className="flex items-center gap-3 rounded-lg border border-gold/20 bg-gold/5 px-4 py-2">
+          <span className="text-sm text-gold">
+            {selectedIds.size} conversation{selectedIds.size > 1 ? "s" : ""} sélectionnée
+            {selectedIds.size > 1 ? "s" : ""}
+          </span>
+          <button
+            onClick={() => setBulkDeleteConfirm(true)}
+            className="rounded-md bg-rose-500/80 px-3 py-1 text-xs font-semibold text-ivory transition hover:bg-rose-500"
+          >
+            Supprimer la sélection
+          </button>
+          <button
+            onClick={() => setSelectedIds(new Set())}
+            className="text-xs text-ivory/50 transition hover:text-ivory"
+          >
+            Tout désélectionner
+          </button>
+        </div>
+      )}
+
+      {/* Conversations table */}
+      <ConversationsTable
+        conversations={conversations}
+        selectedIds={selectedIds}
+        onToggleSelect={toggleSelect}
+        onToggleSelectAll={toggleSelectAll}
+        onView={setDrawerConversation}
+        onDelete={setDeleteTarget}
+      />
+
+      {/* Pagination */}
+      <Pagination pagination={pagination} onPageChange={setCurrentPage} />
+
+      {/* Conversation detail drawer */}
+      <ConversationDrawer
+        conversation={drawerConversation}
+        open={Boolean(drawerConversation)}
+        onClose={() => setDrawerConversation(null)}
+        onDelete={(conv) => {
+          setDrawerConversation(null);
+          setDeleteTarget(conv);
+        }}
+      />
+
+      {/* Single delete confirmation */}
+      <DeleteConfirmation
+        open={Boolean(deleteTarget)}
+        title="Supprimer la conversation"
+        description={
+          deleteTarget
+            ? `Êtes-vous sûr de vouloir supprimer cette conversation (${deleteTarget.messageCount} messages) ? Cette action est irréversible.`
+            : ""
+        }
+        loading={isDeleting}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={() => {
+          if (deleteTarget) {
+            void handleDelete(deleteTarget.id);
+          }
+        }}
+      />
+
+      {/* Bulk delete confirmation */}
+      <DeleteConfirmation
+        open={bulkDeleteConfirm}
+        title="Supprimer les conversations sélectionnées"
+        description={`Êtes-vous sûr de vouloir supprimer ${selectedIds.size} conversation${selectedIds.size > 1 ? "s" : ""} ? Cette action est irréversible.`}
+        loading={isDeleting}
+        onCancel={() => setBulkDeleteConfirm(false)}
+        onConfirm={() => void handleBulkDelete()}
+      />
+    </section>
+  );
+}

--- a/apps/psypnos/app/admin/chatbot/types.ts
+++ b/apps/psypnos/app/admin/chatbot/types.ts
@@ -1,0 +1,66 @@
+export interface ConversationPreview {
+  id: string;
+  sessionId: string;
+  status: string;
+  messageCount: number;
+  satisfied: boolean | null;
+  deviceType: string | null;
+  referrer: string | null;
+  createdAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  preview: string;
+  firstUserMessage: string;
+}
+
+export interface ConversationMessage {
+  id: string;
+  role: string;
+  content: string;
+  tokensUsed: number | null;
+  processingTime: number | null;
+  suggestedActions: unknown | null;
+  createdAt: string;
+}
+
+export interface ConversationDetail {
+  id: string;
+  sessionId: string;
+  ipHash: string | null;
+  status: string;
+  messageCount: number;
+  satisfied: boolean | null;
+  referrer: string | null;
+  deviceType: string | null;
+  createdAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  messages: ConversationMessage[];
+  totalTokens: number;
+  avgProcessingTime: number | null;
+}
+
+export interface ChatbotStats {
+  totalConversations: number;
+  activeConversations: number;
+  satisfiedCount: number;
+  unsatisfiedCount: number;
+  satisfactionRate: number | null;
+  totalMessages: number;
+  avgMessagesPerConversation: number;
+  todayConversations: number;
+  weekConversations: number;
+}
+
+export interface PaginationInfo {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface ConversationsResponse {
+  conversations: ConversationPreview[];
+  pagination: PaginationInfo;
+  stats: ChatbotStats;
+}

--- a/apps/psypnos/app/admin/layout.tsx
+++ b/apps/psypnos/app/admin/layout.tsx
@@ -13,6 +13,7 @@ const psypnosAdminNavigation: NavigationItem[] = [
   { href: '/admin/customization', label: 'Personnalisation', icon: '🎨' },
   { href: '/admin/configuration', label: 'Configuration', icon: '⚙️' },
   { href: '/admin/blog', label: 'Blog', icon: '📝' },
+  { href: '/admin/chatbot', label: 'ChatBot IA', icon: '🤖' },
   { href: '/admin/social', label: 'Réseaux sociaux', icon: '📱' },
   { href: '/admin/seminars', label: 'Séminaires', icon: '🎓' },
   { href: '/admin/testimonials', label: 'Témoignages', icon: '⭐' },

--- a/apps/psypnos/app/api/admin/chatbot/conversations/[id]/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/[id]/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from 'next/server';
+
+import { withAdminAuth } from '../../../../auth/middleware';
+import { prisma } from '@/lib/db/prisma';
+
+/**
+ * GET /api/admin/chatbot/conversations/[id]
+ * Get full conversation detail with all messages
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
+  const { id } = await params;
+
+  try {
+    const conversation = await prisma.chatConversation.findUnique({
+      where: { id },
+      include: {
+        messages: {
+          orderBy: { createdAt: 'asc' },
+          select: {
+            id: true,
+            role: true,
+            content: true,
+            tokensUsed: true,
+            processingTime: true,
+            suggestedActions: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: 'Conversation introuvable' }, { status: 404 });
+    }
+
+    // Compute total tokens used
+    const totalTokens = conversation.messages.reduce(
+      (sum, msg) => sum + (msg.tokensUsed || 0),
+      0
+    );
+    const avgProcessingTime =
+      conversation.messages.filter((m) => m.processingTime).length > 0
+        ? Math.round(
+            conversation.messages.reduce((sum, m) => sum + (m.processingTime || 0), 0) /
+              conversation.messages.filter((m) => m.processingTime).length
+          )
+        : null;
+
+    return NextResponse.json({
+      ...conversation,
+      totalTokens,
+      avgProcessingTime,
+    });
+  } catch (error) {
+    console.error('[Admin Chatbot] Error fetching conversation:', error);
+    return NextResponse.json(
+      { error: 'Erreur lors de la récupération de la conversation' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/chatbot/conversations/[id]
+ * Delete a conversation and all its messages
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
+  const { id } = await params;
+
+  try {
+    const conversation = await prisma.chatConversation.findUnique({
+      where: { id },
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: 'Conversation introuvable' }, { status: 404 });
+    }
+
+    // Delete conversation (cascades to messages)
+    await prisma.chatConversation.delete({
+      where: { id },
+    });
+
+    return NextResponse.json({ success: true, message: 'Conversation supprimée' });
+  } catch (error) {
+    console.error('[Admin Chatbot] Error deleting conversation:', error);
+    return NextResponse.json(
+      { error: 'Erreur lors de la suppression de la conversation' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/psypnos/app/api/admin/chatbot/conversations/bulk/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/bulk/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { withAdminAuth } from '../../../../auth/middleware';
+import { prisma } from '@/lib/db/prisma';
+
+const bulkDeleteSchema = z.object({
+  ids: z.array(z.string()).min(1).max(100),
+});
+
+/**
+ * DELETE /api/admin/chatbot/conversations/bulk
+ * Bulk delete conversations
+ */
+export async function DELETE(request: Request) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
+  try {
+    const body = await request.json();
+    const parsed = bulkDeleteSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+    }
+
+    const { ids } = parsed.data;
+
+    const result = await prisma.chatConversation.deleteMany({
+      where: { id: { in: ids } },
+    });
+
+    return NextResponse.json({
+      success: true,
+      deleted: result.count,
+      message: `${result.count} conversation(s) supprimée(s)`,
+    });
+  } catch (error) {
+    console.error('[Admin Chatbot] Error bulk deleting conversations:', error);
+    return NextResponse.json(
+      { error: 'Erreur lors de la suppression des conversations' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/psypnos/app/api/admin/chatbot/conversations/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+
+import { withAdminAuth } from '../../../auth/middleware';
+import { prisma } from '@/lib/db/prisma';
+
+/**
+ * GET /api/admin/chatbot/conversations
+ * List all chatbot conversations with pagination, search, and stats
+ */
+export async function GET(request: Request) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
+  const { searchParams } = new URL(request.url);
+  const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+  const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '20', 10)));
+  const search = searchParams.get('search')?.trim() || '';
+  const status = searchParams.get('status') || '';
+  const satisfaction = searchParams.get('satisfaction') || '';
+  const sortBy = searchParams.get('sortBy') || 'createdAt';
+  const sortOrder = searchParams.get('sortOrder') === 'asc' ? 'asc' : 'desc';
+
+  try {
+    // Build where clause
+    const where: Record<string, unknown> = {};
+
+    if (status && ['active', 'ended', 'transferred'].includes(status)) {
+      where.status = status;
+    }
+
+    if (satisfaction === 'satisfied') {
+      where.satisfied = true;
+    } else if (satisfaction === 'unsatisfied') {
+      where.satisfied = false;
+    } else if (satisfaction === 'no_feedback') {
+      where.satisfied = null;
+    }
+
+    if (search) {
+      where.messages = {
+        some: {
+          content: {
+            contains: search,
+            mode: 'insensitive',
+          },
+        },
+      };
+    }
+
+    // Get conversations with message preview
+    const [conversations, total] = await Promise.all([
+      prisma.chatConversation.findMany({
+        where,
+        include: {
+          messages: {
+            orderBy: { createdAt: 'asc' },
+            take: 2,
+            select: {
+              id: true,
+              role: true,
+              content: true,
+              createdAt: true,
+            },
+          },
+        },
+        orderBy: {
+          [sortBy === 'messageCount' ? 'messageCount' : 'createdAt']: sortOrder,
+        },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      prisma.chatConversation.count({ where }),
+    ]);
+
+    // Get overall stats
+    const [
+      totalConversations,
+      activeConversations,
+      satisfiedCount,
+      unsatisfiedCount,
+      totalMessages,
+      avgMessages,
+      todayConversations,
+      weekConversations,
+    ] = await Promise.all([
+      prisma.chatConversation.count(),
+      prisma.chatConversation.count({ where: { status: 'active' } }),
+      prisma.chatConversation.count({ where: { satisfied: true } }),
+      prisma.chatConversation.count({ where: { satisfied: false } }),
+      prisma.chatMessage.count(),
+      prisma.chatConversation.aggregate({ _avg: { messageCount: true } }),
+      prisma.chatConversation.count({
+        where: {
+          createdAt: {
+            gte: new Date(new Date().setHours(0, 0, 0, 0)),
+          },
+        },
+      }),
+      prisma.chatConversation.count({
+        where: {
+          createdAt: {
+            gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+          },
+        },
+      }),
+    ]);
+
+    const feedbackTotal = satisfiedCount + unsatisfiedCount;
+    const satisfactionRate =
+      feedbackTotal > 0 ? Math.round((satisfiedCount / feedbackTotal) * 1000) / 10 : null;
+
+    return NextResponse.json({
+      conversations: conversations.map((conv) => ({
+        id: conv.id,
+        sessionId: conv.sessionId,
+        status: conv.status,
+        messageCount: conv.messageCount,
+        satisfied: conv.satisfied,
+        deviceType: conv.deviceType,
+        referrer: conv.referrer,
+        createdAt: conv.createdAt,
+        updatedAt: conv.updatedAt,
+        endedAt: conv.endedAt,
+        preview: conv.messages[0]?.content?.slice(0, 120) || '',
+        firstUserMessage:
+          conv.messages.find((m) => m.role === 'user')?.content?.slice(0, 150) || '',
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+      stats: {
+        totalConversations,
+        activeConversations,
+        satisfiedCount,
+        unsatisfiedCount,
+        satisfactionRate,
+        totalMessages,
+        avgMessagesPerConversation: Math.round((avgMessages._avg.messageCount || 0) * 10) / 10,
+        todayConversations,
+        weekConversations,
+      },
+    });
+  } catch (error) {
+    console.error('[Admin Chatbot] Error fetching conversations:', error);
+    return NextResponse.json(
+      { error: 'Erreur lors de la récupération des conversations' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/psypnos/app/api/admin/chatbot/settings/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/settings/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { withAdminAuth } from '../../../auth/middleware';
+import { prisma } from '@/lib/db/prisma';
+
+const SITE_SLUG = 'psypnos';
+
+const settingsSchema = z.object({
+  chatbotEnabled: z.boolean(),
+});
+
+/**
+ * GET /api/admin/chatbot/settings
+ * Get chatbot settings (enabled/disabled status)
+ */
+export async function GET() {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
+  try {
+    const site = await prisma.site.findUnique({
+      where: { slug: SITE_SLUG },
+      select: { config: true },
+    });
+
+    const config = (site?.config as Record<string, unknown>) || {};
+    const chatbotEnabled = config.chatbotEnabled !== false; // Enabled by default
+
+    return NextResponse.json({ chatbotEnabled });
+  } catch (error) {
+    console.error('[Admin Chatbot] Error fetching settings:', error);
+    return NextResponse.json(
+      { error: 'Erreur lors de la récupération des paramètres' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PUT /api/admin/chatbot/settings
+ * Update chatbot settings (enable/disable)
+ */
+export async function PUT(request: Request) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
+  try {
+    const body = await request.json();
+    const parsed = settingsSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Données invalides' }, { status: 400 });
+    }
+
+    const { chatbotEnabled } = parsed.data;
+
+    // Get current config
+    const site = await prisma.site.findUnique({
+      where: { slug: SITE_SLUG },
+      select: { config: true },
+    });
+
+    const currentConfig = (site?.config as Record<string, unknown>) || {};
+
+    // Update config with chatbot setting
+    await prisma.site.update({
+      where: { slug: SITE_SLUG },
+      data: {
+        config: {
+          ...currentConfig,
+          chatbotEnabled,
+        },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      chatbotEnabled,
+      message: chatbotEnabled ? 'ChatBot IA activé' : 'ChatBot IA désactivé',
+    });
+  } catch (error) {
+    console.error('[Admin Chatbot] Error updating settings:', error);
+    return NextResponse.json(
+      { error: 'Erreur lors de la mise à jour des paramètres' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/psypnos/app/api/chatbot-status/route.ts
+++ b/apps/psypnos/app/api/chatbot-status/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/db/prisma';
+
+const SITE_SLUG = 'psypnos';
+
+/**
+ * GET /api/chatbot-status
+ * Public endpoint to check if chatbot is enabled (no auth required)
+ * Cached for 60 seconds to reduce DB hits
+ */
+export async function GET() {
+  try {
+    const site = await prisma.site.findUnique({
+      where: { slug: SITE_SLUG },
+      select: { config: true },
+    });
+
+    const config = (site?.config as Record<string, unknown>) || {};
+    const enabled = config.chatbotEnabled !== false;
+
+    return NextResponse.json(
+      { enabled },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=60, max-age=60, stale-while-revalidate=300',
+        },
+      }
+    );
+  } catch {
+    // On error, default to enabled
+    return NextResponse.json({ enabled: true });
+  }
+}

--- a/apps/psypnos/components/ChatWidgetWrapper.tsx
+++ b/apps/psypnos/components/ChatWidgetWrapper.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { ChatWidget } from '@kairn/ui';
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 
 import { trackConversionEvent } from '../hooks/useAnalytics';
 
@@ -8,8 +10,33 @@ import { trackConversionEvent } from '../hooks/useAnalytics';
  * Psypnos-specific wrapper for the AI ChatWidget.
  *
  * Positioned bottom-left to avoid overlap with the FloatingContactButton (bottom-right).
+ * Respects the admin chatbot toggle setting and hides on admin pages.
  */
 export function PsypnosChatWidget() {
+  const pathname = usePathname();
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    async function checkStatus() {
+      try {
+        const response = await fetch('/api/chatbot-status');
+        if (response.ok) {
+          const data = await response.json();
+          setEnabled(data.enabled);
+        } else {
+          setEnabled(true);
+        }
+      } catch {
+        setEnabled(true);
+      }
+    }
+    void checkStatus();
+  }, []);
+
+  // Don't render on admin pages or while checking status
+  if (pathname?.startsWith('/admin') || pathname?.startsWith('/login')) return null;
+  if (enabled === null || !enabled) return null;
+
   const handleBookAppointment = () => {
     trackConversionEvent('appointment_request', 'chatbot_suggestion', false);
     window.location.href = '/contact';


### PR DESCRIPTION
## Description

Adds a comprehensive admin dashboard for managing AI chatbot conversations. This includes:

- **Admin Dashboard Page** (`/admin/chatbot`): Main interface displaying chatbot statistics, conversation history, and management tools
- **Conversation Management**: View detailed conversation transcripts, filter by status/satisfaction, search messages, and delete conversations (single or bulk)
- **Chatbot Toggle**: Enable/disable the chatbot widget globally from the admin panel
- **Statistics Cards**: Display key metrics including total conversations, active sessions, message counts, satisfaction rates, and time-based analytics
- **Conversation Drawer**: Side panel showing full conversation details with message history, metadata, and token usage
- **Filtering & Pagination**: Search conversations, filter by status (active/ended/transferred) and satisfaction feedback, with paginated results
- **API Endpoints**:
  - `GET /api/admin/chatbot/conversations` - List conversations with stats and pagination
  - `GET /api/admin/chatbot/conversations/[id]` - Get full conversation details
  - `DELETE /api/admin/chatbot/conversations/[id]` - Delete single conversation
  - `DELETE /api/admin/chatbot/conversations/bulk` - Bulk delete conversations
  - `GET/PUT /api/admin/chatbot/settings` - Manage chatbot enabled/disabled status
  - `GET /api/chatbot-status` - Public endpoint to check if chatbot is enabled (cached)

- **UI Components**: Reusable components for stats cards, conversation table, filters, pagination, and drawer with proper loading states and error handling
- **Chat Widget Integration**: Updated `ChatWidgetWrapper` to respect admin toggle setting and hide on admin pages

## Type de changement

- [x] ✨ Nouvelle fonctionnalité
- [x] 🔧 Configuration

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [x] PSYPNOS uniquement

https://claude.ai/code/session_017HGc7c5KRGeQyaCuXWEvDc