### PR TITLE
fix(social): add type annotations to response.json() calls to fix TypeScript strict mode errors

### DIFF
--- a/packages/social/src/posting/facebook.ts
+++ b/packages/social/src/posting/facebook.ts
@@ -272,10 +272,10 @@ export class FacebookPublisher implements SocialPublisher {
       if (!response.ok) {
         return { success: false, error: `Facebook API error: ${response.status}` };
       }
-      const data = await response.json();
+      const data = (await response.json()) as Record<string, unknown>;
       return {
         success: true,
-        followers: data.followers_count || data.fan_count || 0,
+        followers: (data.followers_count as number) || (data.fan_count as number) || 0,
         following: 0, // Pages don't have a "following" count
         postsCount: 0, // Requires separate paginated call
         rawData: data,

--- a/packages/social/src/posting/instagram.ts
+++ b/packages/social/src/posting/instagram.ts
@@ -269,12 +269,12 @@ export class InstagramPublisher implements SocialPublisher {
       if (!response.ok) {
         return { success: false, error: `Instagram API error: ${response.status}` };
       }
-      const data = await response.json();
+      const data = (await response.json()) as Record<string, unknown>;
       return {
         success: true,
-        followers: data.followers_count || 0,
-        following: data.follows_count || 0,
-        postsCount: data.media_count || 0,
+        followers: (data.followers_count as number) || 0,
+        following: (data.follows_count as number) || 0,
+        postsCount: (data.media_count as number) || 0,
         rawData: data,
       };
     } catch (error) {

--- a/packages/social/src/posting/linkedin.ts
+++ b/packages/social/src/posting/linkedin.ts
@@ -280,7 +280,7 @@ export class LinkedInPublisher implements SocialPublisher {
   async getAccountMetrics(input: GetAccountMetricsInput): Promise<AccountMetricsResult> {
     const { accessToken, accountMetadata } = input;
     try {
-      const isOrganization = accountMetadata?.type === 'ORGANIZATION';
+      const isOrganization = !!accountMetadata?.organizationId;
 
       if (isOrganization) {
         const orgId = accountMetadata?.organizationId;
@@ -298,11 +298,13 @@ export class LinkedInPublisher implements SocialPublisher {
         if (!response.ok) {
           return { success: false, error: `LinkedIn API error: ${response.status}` };
         }
-        const data = await response.json();
-        const followerStats = data.elements?.[0] || {};
+        const data = (await response.json()) as Record<string, unknown>;
+        const elements = data.elements as Array<Record<string, unknown>> | undefined;
+        const followerStats = elements?.[0] || {};
+        const followerCounts = followerStats.followerCounts as Record<string, unknown> | undefined;
         return {
           success: true,
-          followers: followerStats.followerCounts?.organicFollowerCount || 0,
+          followers: (followerCounts?.organicFollowerCount as number) || 0,
           following: 0,
           postsCount: 0,
           rawData: data,
@@ -317,7 +319,7 @@ export class LinkedInPublisher implements SocialPublisher {
       if (!response.ok) {
         return { success: false, error: `LinkedIn API error: ${response.status}` };
       }
-      const data = await response.json();
+      const data = (await response.json()) as Record<string, unknown>;
       return {
         success: true,
         followers: 0, // Personal profile follower count not available via API

--- a/packages/social/src/posting/threads.ts
+++ b/packages/social/src/posting/threads.ts
@@ -254,10 +254,10 @@ export class ThreadsPublisher implements SocialPublisher {
       if (!response.ok) {
         return { success: false, error: `Threads API error: ${response.status}` };
       }
-      const data = await response.json();
+      const data = (await response.json()) as Record<string, unknown>;
       return {
         success: true,
-        followers: data.followers_count || 0,
+        followers: (data.followers_count as number) || 0,
         following: 0, // Threads API doesn't expose following count
         postsCount: 0,
         rawData: data,

--- a/packages/social/src/posting/twitter.ts
+++ b/packages/social/src/posting/twitter.ts
@@ -231,13 +231,14 @@ export class TwitterPublisher implements SocialPublisher {
       if (!response.ok) {
         return { success: false, error: `Twitter API error: ${response.status}` };
       }
-      const data = await response.json();
-      const metrics = data.data?.public_metrics || {};
+      const data = (await response.json()) as Record<string, unknown>;
+      const innerData = data.data as Record<string, unknown> | undefined;
+      const metrics = (innerData?.public_metrics as Record<string, unknown>) || {};
       return {
         success: true,
-        followers: metrics.followers_count || 0,
-        following: metrics.following_count || 0,
-        postsCount: metrics.tweet_count || 0,
+        followers: (metrics.followers_count as number) || 0,
+        following: (metrics.following_count as number) || 0,
+        postsCount: (metrics.tweet_count as number) || 0,
         rawData: data,
       };
     } catch (error) {


### PR DESCRIPTION
The getAccountMetrics methods in all 5 social publishers used untyped
response.json() results, causing TS18046/TS2322/TS2339 errors under
strict mode. Also fix LinkedIn's incorrect accountMetadata.type check
(property doesn't exist on SocialAccountMetadata) by using organizationId.

https://claude.ai/code/session_01RJTZXroiffeViuHsk7HKHm