### PR TITLE
fix(analytics): route all tracking data through PostgreSQL instead of JSON files

### DIFF
--- a/apps/psypnos/app/api/admin/chatbot/conversations/[id]/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/[id]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import { withAdminAuth } from '../../../../auth/middleware';
 import { prisma } from '@/lib/db/prisma';
+
+import { withAdminAuth } from '../../../../auth/middleware';
 
 /**
  * GET /api/admin/chatbot/conversations/[id]
@@ -37,15 +38,14 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
     }
 
     // Compute total tokens used
-    const totalTokens = conversation.messages.reduce(
-      (sum, msg) => sum + (msg.tokensUsed || 0),
-      0
-    );
+    type Msg = { tokensUsed?: number | null; processingTime?: number | null };
+    const msgs = conversation.messages as Msg[];
+    const totalTokens = msgs.reduce((sum: number, msg: Msg) => sum + (msg.tokensUsed || 0), 0);
     const avgProcessingTime =
-      conversation.messages.filter((m) => m.processingTime).length > 0
+      msgs.filter((m: Msg) => m.processingTime).length > 0
         ? Math.round(
-            conversation.messages.reduce((sum, m) => sum + (m.processingTime || 0), 0) /
-              conversation.messages.filter((m) => m.processingTime).length
+            msgs.reduce((sum: number, m: Msg) => sum + (m.processingTime || 0), 0) /
+              msgs.filter((m: Msg) => m.processingTime).length
           )
         : null;
 
@@ -67,10 +67,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
  * DELETE /api/admin/chatbot/conversations/[id]
  * Delete a conversation and all its messages
  */
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const authResult = await withAdminAuth();
   if (authResult.error) return authResult.error;
 

--- a/apps/psypnos/app/api/admin/chatbot/conversations/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import { withAdminAuth } from '../../../auth/middleware';
 import { prisma } from '@/lib/db/prisma';
+
+import { withAdminAuth } from '../../../auth/middleware';
 
 /**
  * GET /api/admin/chatbot/conversations
@@ -110,7 +111,8 @@ export async function GET(request: Request) {
       feedbackTotal > 0 ? Math.round((satisfiedCount / feedbackTotal) * 1000) / 10 : null;
 
     return NextResponse.json({
-      conversations: conversations.map((conv) => ({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      conversations: conversations.map((conv: any) => ({
         id: conv.id,
         sessionId: conv.sessionId,
         status: conv.status,
@@ -123,7 +125,9 @@ export async function GET(request: Request) {
         endedAt: conv.endedAt,
         preview: conv.messages[0]?.content?.slice(0, 120) || '',
         firstUserMessage:
-          conv.messages.find((m) => m.role === 'user')?.content?.slice(0, 150) || '',
+          conv.messages
+            .find((m: { role: string; content?: string }) => m.role === 'user')
+            ?.content?.slice(0, 150) || '',
       })),
       pagination: {
         page,

--- a/apps/psypnos/app/api/admin/deployment/diagnostic/route.ts
+++ b/apps/psypnos/app/api/admin/deployment/diagnostic/route.ts
@@ -1,23 +1,22 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Deployment model not available in Kairn schema
-import { exec } from "child_process";
-import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
-import { promisify } from "util";
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
 
-import Anthropic from "@anthropic-ai/sdk";
-import { NextResponse } from "next/server";
+import Anthropic from '@anthropic-ai/sdk';
+import { NextResponse } from 'next/server';
 
-import { withAdminAuth } from "@/app/api/auth/middleware";
-import { checkRedisHealth, getRedisClient } from "@/lib/cache/redis";
-import { isDatabaseConnected, prisma } from "@/lib/db/prisma";
-
+import { withAdminAuth } from '@/app/api/auth/middleware';
+import { checkRedisHealth, getRedisClient } from '@/lib/cache/redis';
+import { isDatabaseConnected, prisma } from '@/lib/db/prisma';
 
 const execAsync = promisify(exec);
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 /**
  * Prompt système pour le diagnostic serveur
@@ -93,7 +92,7 @@ interface ExtendedSystemMetrics {
     };
   };
   database: {
-    status: "up" | "down";
+    status: 'up' | 'down';
     latencyMs?: number;
     error?: string;
     extended?: {
@@ -106,7 +105,7 @@ interface ExtendedSystemMetrics {
     };
   };
   redis: {
-    status: "up" | "down" | "disabled";
+    status: 'up' | 'down' | 'disabled';
     latencyMs?: number;
     error?: string;
     extended?: {
@@ -194,16 +193,16 @@ interface DiagnosticResponse {
   success: boolean;
   metrics?: ExtendedSystemMetrics;
   analysis?: {
-    overallHealth: "excellent" | "good" | "warning" | "critical";
+    overallHealth: 'excellent' | 'good' | 'warning' | 'critical';
     summary: string;
     findings: Array<{
       category: string;
-      status: "ok" | "warning" | "critical";
+      status: 'ok' | 'warning' | 'critical';
       message: string;
       details?: string;
     }>;
     recommendations: Array<{
-      priority: "high" | "medium" | "low";
+      priority: 'high' | 'medium' | 'low';
       title: string;
       description: string;
       commands?: string[];
@@ -226,35 +225,35 @@ async function safeExec(command: string, timeoutMs = 5000): Promise<string> {
     const { stdout } = await execAsync(command, { timeout: timeoutMs });
     return stdout.trim();
   } catch {
-    return "";
+    return '';
   }
 }
 
 /**
  * Collecte les métriques de disque
  */
-async function collectDiskMetrics(): Promise<ExtendedSystemMetrics["disk"]> {
+async function collectDiskMetrics(): Promise<ExtendedSystemMetrics['disk']> {
   const defaultDisk = {
     total: 0,
     used: 0,
     free: 0,
     percentUsed: 0,
-    mountPoint: "/",
+    mountPoint: '/',
   };
 
   try {
     // Utiliser df pour obtenir les infos de disque
-    const dfOutput = await safeExec("df -k / | tail -1");
+    const dfOutput = await safeExec('df -k / | tail -1');
     if (dfOutput) {
       const parts = dfOutput.split(/\s+/);
       if (parts.length >= 5) {
         const total = parseInt(parts[1]) * 1024; // Convert KB to bytes
         const used = parseInt(parts[2]) * 1024;
         const free = parseInt(parts[3]) * 1024;
-        const percentUsed = parseInt(parts[4].replace("%", ""));
+        const percentUsed = parseInt(parts[4].replace('%', ''));
 
         // Récupérer les inodes
-        const inodeOutput = await safeExec("df -i / | tail -1");
+        const inodeOutput = await safeExec('df -i / | tail -1');
         let inodes;
         if (inodeOutput) {
           const inodeParts = inodeOutput.split(/\s+/);
@@ -262,7 +261,7 @@ async function collectDiskMetrics(): Promise<ExtendedSystemMetrics["disk"]> {
             inodes = {
               total: parseInt(inodeParts[1]),
               used: parseInt(inodeParts[2]),
-              percentUsed: parseInt(inodeParts[4].replace("%", "")),
+              percentUsed: parseInt(inodeParts[4].replace('%', '')),
             };
           }
         }
@@ -272,7 +271,7 @@ async function collectDiskMetrics(): Promise<ExtendedSystemMetrics["disk"]> {
           used: Math.round(used / 1024 / 1024 / 1024),
           free: Math.round(free / 1024 / 1024 / 1024),
           percentUsed,
-          mountPoint: parts[5] || "/",
+          mountPoint: parts[5] || '/',
           inodes,
         };
       }
@@ -287,11 +286,11 @@ async function collectDiskMetrics(): Promise<ExtendedSystemMetrics["disk"]> {
 /**
  * Collecte les métriques PM2
  */
-async function collectPM2Metrics(): Promise<ExtendedSystemMetrics["pm2"]> {
+async function collectPM2Metrics(): Promise<ExtendedSystemMetrics['pm2']> {
   try {
-    const pm2Output = await safeExec("pm2 jlist 2>/dev/null");
+    const pm2Output = await safeExec('pm2 jlist 2>/dev/null');
     if (!pm2Output) {
-      return { available: false, error: "PM2 non disponible ou aucun processus" };
+      return { available: false, error: 'PM2 non disponible ou aucun processus' };
     }
 
     const processes = JSON.parse(pm2Output);
@@ -301,27 +300,29 @@ async function collectPM2Metrics(): Promise<ExtendedSystemMetrics["pm2"]> {
 
     return {
       available: true,
-      processes: processes.map((p: {
-        name: string;
-        pm2_env?: { status?: string };
-        monit?: { cpu?: number; memory?: number };
-        pm2_env_restart_time?: number;
-        pm2_env_pm_uptime?: number;
-        pid?: number;
-      }) => ({
-        name: p.name,
-        status: p.pm2_env?.status || "unknown",
-        cpu: p.monit?.cpu || 0,
-        memory: Math.round((p.monit?.memory || 0) / 1024 / 1024), // MB
-        restarts: p.pm2_env_restart_time || 0,
-        uptime: p.pm2_env_pm_uptime ? Math.floor((Date.now() - p.pm2_env_pm_uptime) / 1000) : 0,
-        pid: p.pid,
-      })),
+      processes: processes.map(
+        (p: {
+          name: string;
+          pm2_env?: { status?: string };
+          monit?: { cpu?: number; memory?: number };
+          pm2_env_restart_time?: number;
+          pm2_env_pm_uptime?: number;
+          pid?: number;
+        }) => ({
+          name: p.name,
+          status: p.pm2_env?.status || 'unknown',
+          cpu: p.monit?.cpu || 0,
+          memory: Math.round((p.monit?.memory || 0) / 1024 / 1024), // MB
+          restarts: p.pm2_env_restart_time || 0,
+          uptime: p.pm2_env_pm_uptime ? Math.floor((Date.now() - p.pm2_env_pm_uptime) / 1000) : 0,
+          pid: p.pid,
+        })
+      ),
     };
   } catch (error) {
     return {
       available: false,
-      error: error instanceof Error ? error.message : "Erreur PM2",
+      error: error instanceof Error ? error.message : 'Erreur PM2',
     };
   }
 }
@@ -329,13 +330,15 @@ async function collectPM2Metrics(): Promise<ExtendedSystemMetrics["pm2"]> {
 /**
  * Collecte les métriques réseau
  */
-async function collectNetworkMetrics(): Promise<ExtendedSystemMetrics["network"]> {
+async function collectNetworkMetrics(): Promise<ExtendedSystemMetrics['network']> {
   try {
     // Compter les connexions par état
-    const netstatOutput = await safeExec("netstat -an 2>/dev/null | grep -E 'ESTABLISHED|TIME_WAIT|CLOSE_WAIT' | wc -l");
-    const establishedOutput = await safeExec("netstat -an 2>/dev/null | grep ESTABLISHED | wc -l");
-    const timeWaitOutput = await safeExec("netstat -an 2>/dev/null | grep TIME_WAIT | wc -l");
-    const closeWaitOutput = await safeExec("netstat -an 2>/dev/null | grep CLOSE_WAIT | wc -l");
+    const netstatOutput = await safeExec(
+      "netstat -an 2>/dev/null | grep -E 'ESTABLISHED|TIME_WAIT|CLOSE_WAIT' | wc -l"
+    );
+    const establishedOutput = await safeExec('netstat -an 2>/dev/null | grep ESTABLISHED | wc -l');
+    const timeWaitOutput = await safeExec('netstat -an 2>/dev/null | grep TIME_WAIT | wc -l');
+    const closeWaitOutput = await safeExec('netstat -an 2>/dev/null | grep CLOSE_WAIT | wc -l');
 
     return {
       connections: {
@@ -345,17 +348,17 @@ async function collectNetworkMetrics(): Promise<ExtendedSystemMetrics["network"]
       },
     };
   } catch {
-    return { error: "Impossible de collecter les métriques réseau" };
+    return { error: 'Impossible de collecter les métriques réseau' };
   }
 }
 
 /**
  * Collecte les informations SSL
  */
-async function collectSSLMetrics(): Promise<ExtendedSystemMetrics["ssl"]> {
+async function collectSSLMetrics(): Promise<ExtendedSystemMetrics['ssl']> {
   try {
-    const domain = process.env.NEXT_PUBLIC_BASE_URL?.replace(/^https?:\/\//, "").split("/")[0];
-    if (!domain || domain.includes("localhost")) {
+    const domain = process.env.NEXT_PUBLIC_BASE_URL?.replace(/^https?:\/\//, '').split('/')[0];
+    if (!domain || domain.includes('localhost')) {
       return { available: false };
     }
 
@@ -371,7 +374,9 @@ async function collectSSLMetrics(): Promise<ExtendedSystemMetrics["ssl"]> {
       if (notAfterMatch) {
         const expiresAt = new Date(notAfterMatch[1]);
         const now = new Date();
-        const daysUntilExpiry = Math.floor((expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+        const daysUntilExpiry = Math.floor(
+          (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+        );
 
         return {
           available: true,
@@ -383,16 +388,18 @@ async function collectSSLMetrics(): Promise<ExtendedSystemMetrics["ssl"]> {
       }
     }
 
-    return { available: false, domain, error: "Impossible de lire le certificat" };
+    return { available: false, domain, error: 'Impossible de lire le certificat' };
   } catch {
-    return { available: false, error: "Erreur lors de la vérification SSL" };
+    return { available: false, error: 'Erreur lors de la vérification SSL' };
   }
 }
 
 /**
  * Collecte les métriques PostgreSQL étendues
  */
-async function collectExtendedDatabaseMetrics(): Promise<ExtendedSystemMetrics["database"]["extended"]> {
+async function collectExtendedDatabaseMetrics(): Promise<
+  ExtendedSystemMetrics['database']['extended']
+> {
   try {
     const isConnected = await isDatabaseConnected();
     if (!isConnected) return undefined;
@@ -419,13 +426,13 @@ async function collectExtendedDatabaseMetrics(): Promise<ExtendedSystemMetrics["
     const sizeResult = await prisma.$queryRaw<Array<{ size: string }>>`
       SELECT pg_size_pretty(pg_database_size(current_database())) as size
     `;
-    const databaseSize = sizeResult[0]?.size || "N/A";
+    const databaseSize = sizeResult[0]?.size || 'N/A';
 
     // Max connections
     const maxConnResult = await prisma.$queryRaw<Array<{ setting: string }>>`
       SELECT setting FROM pg_settings WHERE name = 'max_connections'
     `;
-    const maxConnections = parseInt(maxConnResult[0]?.setting || "100");
+    const maxConnections = parseInt(maxConnResult[0]?.setting || '100');
 
     return {
       connectionCount,
@@ -443,25 +450,25 @@ async function collectExtendedDatabaseMetrics(): Promise<ExtendedSystemMetrics["
 /**
  * Collecte les métriques Redis étendues
  */
-async function collectExtendedRedisMetrics(): Promise<ExtendedSystemMetrics["redis"]["extended"]> {
+async function collectExtendedRedisMetrics(): Promise<ExtendedSystemMetrics['redis']['extended']> {
   try {
     const redis = getRedisClient();
     if (!redis) return undefined;
 
     const info = await redis.info();
-    const lines = info.split("\r\n");
+    const lines = info.split('\r\n');
     const metrics: Record<string, string> = {};
 
     for (const line of lines) {
-      const [key, value] = line.split(":");
+      const [key, value] = line.split(':');
       if (key && value) {
         metrics[key] = value;
       }
     }
 
     // Calculer le hit rate
-    const hits = parseInt(metrics["keyspace_hits"] || "0");
-    const misses = parseInt(metrics["keyspace_misses"] || "0");
+    const hits = parseInt(metrics['keyspace_hits'] || '0');
+    const misses = parseInt(metrics['keyspace_misses'] || '0');
     const hitRate = hits + misses > 0 ? Math.round((hits / (hits + misses)) * 100) : 0;
 
     // Compter les clés
@@ -469,13 +476,13 @@ async function collectExtendedRedisMetrics(): Promise<ExtendedSystemMetrics["red
     const totalKeys = dbKeysMatch ? parseInt(dbKeysMatch[1]) : 0;
 
     return {
-      usedMemory: metrics["used_memory_human"],
-      usedMemoryPeak: metrics["used_memory_peak_human"],
-      connectedClients: parseInt(metrics["connected_clients"] || "0"),
+      usedMemory: metrics['used_memory_human'],
+      usedMemoryPeak: metrics['used_memory_peak_human'],
+      connectedClients: parseInt(metrics['connected_clients'] || '0'),
       totalKeys,
       hitRate,
-      evictedKeys: parseInt(metrics["evicted_keys"] || "0"),
-      uptimeSeconds: parseInt(metrics["uptime_in_seconds"] || "0"),
+      evictedKeys: parseInt(metrics['evicted_keys'] || '0'),
+      uptimeSeconds: parseInt(metrics['uptime_in_seconds'] || '0'),
     };
   } catch {
     return undefined;
@@ -485,41 +492,41 @@ async function collectExtendedRedisMetrics(): Promise<ExtendedSystemMetrics["red
 /**
  * Collecte les informations de déploiement
  */
-async function collectDeploymentInfo(): Promise<ExtendedSystemMetrics["deployment"]> {
+async function collectDeploymentInfo(): Promise<ExtendedSystemMetrics['deployment']> {
   // Lire la version depuis package.json
-  let version = "unknown";
+  let version = 'unknown';
   try {
-    const packagePath = path.join(process.cwd(), "package.json");
-    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf-8"));
-    version = packageJson.version || "unknown";
+    const packagePath = path.join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
+    version = packageJson.version || 'unknown';
   } catch {
     // Ignore
   }
 
   // Git commit et branch
-  const gitCommit = await safeExec("git rev-parse --short HEAD 2>/dev/null");
-  const gitBranch = await safeExec("git rev-parse --abbrev-ref HEAD 2>/dev/null");
+  const gitCommit = await safeExec('git rev-parse --short HEAD 2>/dev/null');
+  const gitBranch = await safeExec('git rev-parse --abbrev-ref HEAD 2>/dev/null');
 
   // Date du dernier commit
-  const lastCommitDate = await safeExec("git log -1 --format=%ci 2>/dev/null");
+  const lastCommitDate = await safeExec('git log -1 --format=%ci 2>/dev/null');
 
   return {
     version,
     gitCommit: gitCommit || undefined,
     gitBranch: gitBranch || undefined,
     lastDeployedAt: lastCommitDate || undefined,
-    nodeEnv: process.env.NODE_ENV || "development",
-    analyticsMode: process.env.ANALYTICS_STORAGE_MODE || "json",
+    nodeEnv: process.env.NODE_ENV || 'development',
+    analyticsMode: 'postgres',
   };
 }
 
 /**
  * Collecte les informations de sécurité (npm audit)
  */
-async function collectSecurityInfo(): Promise<ExtendedSystemMetrics["security"]> {
+async function collectSecurityInfo(): Promise<ExtendedSystemMetrics['security']> {
   try {
     // Exécuter npm audit en mode JSON (avec timeout court car peut être lent)
-    const auditOutput = await safeExec("pnpm audit --json 2>/dev/null", 15000);
+    const auditOutput = await safeExec('pnpm audit --json 2>/dev/null', 15000);
 
     if (auditOutput) {
       try {
@@ -541,7 +548,7 @@ async function collectSecurityInfo(): Promise<ExtendedSystemMetrics["security"]>
     }
 
     // Vérifier les packages obsolètes
-    const outdatedOutput = await safeExec("pnpm outdated --json 2>/dev/null | wc -l", 10000);
+    const outdatedOutput = await safeExec('pnpm outdated --json 2>/dev/null | wc -l', 10000);
     const outdatedCount = parseInt(outdatedOutput) || 0;
 
     return {
@@ -555,23 +562,23 @@ async function collectSecurityInfo(): Promise<ExtendedSystemMetrics["security"]>
 /**
  * Collecte la configuration PM2 (ecosystem.config.js)
  */
-async function collectPM2Config(): Promise<ExtendedSystemMetrics["pm2Config"]> {
+async function collectPM2Config(): Promise<ExtendedSystemMetrics['pm2Config']> {
   try {
-    const configPath = path.join(process.cwd(), "ecosystem.config.js");
+    const configPath = path.join(process.cwd(), 'ecosystem.config.js');
 
     if (fs.existsSync(configPath)) {
-      const content = fs.readFileSync(configPath, "utf-8");
+      const content = fs.readFileSync(configPath, 'utf-8');
       return {
         available: true,
         content,
       };
     }
 
-    return { available: false, error: "Fichier ecosystem.config.js non trouvé" };
+    return { available: false, error: 'Fichier ecosystem.config.js non trouvé' };
   } catch (error) {
     return {
       available: false,
-      error: error instanceof Error ? error.message : "Erreur de lecture",
+      error: error instanceof Error ? error.message : 'Erreur de lecture',
     };
   }
 }
@@ -579,24 +586,30 @@ async function collectPM2Config(): Promise<ExtendedSystemMetrics["pm2Config"]> {
 /**
  * Collecte les logs récents (erreurs)
  */
-async function collectRecentLogs(): Promise<ExtendedSystemMetrics["logs"]> {
+async function collectRecentLogs(): Promise<ExtendedSystemMetrics['logs']> {
   const recentErrors: string[] = [];
 
   try {
     // Essayer de lire les logs PM2
-    const pm2LogPath = await safeExec("pm2 info psypnos 2>/dev/null | grep 'err log path' | awk '{print $NF}'");
+    const pm2LogPath = await safeExec(
+      "pm2 info psypnos 2>/dev/null | grep 'err log path' | awk '{print $NF}'"
+    );
 
     if (pm2LogPath && fs.existsSync(pm2LogPath)) {
-      const logContent = await safeExec(`tail -100 "${pm2LogPath}" 2>/dev/null | grep -i "error\\|exception\\|fatal" | tail -10`);
+      const logContent = await safeExec(
+        `tail -100 "${pm2LogPath}" 2>/dev/null | grep -i "error\\|exception\\|fatal" | tail -10`
+      );
       if (logContent) {
-        recentErrors.push(...logContent.split("\n").filter(Boolean).slice(-10));
+        recentErrors.push(...logContent.split('\n').filter(Boolean).slice(-10));
       }
     }
 
     // Compter les erreurs des dernières 24h
     let errorCount24h = 0;
     if (pm2LogPath && fs.existsSync(pm2LogPath)) {
-      const countOutput = await safeExec(`grep -c -i "error" "${pm2LogPath}" 2>/dev/null || echo "0"`);
+      const countOutput = await safeExec(
+        `grep -c -i "error" "${pm2LogPath}" 2>/dev/null || echo "0"`
+      );
       errorCount24h = parseInt(countOutput) || 0;
     }
 
@@ -641,39 +654,39 @@ async function collectSystemMetrics(): Promise<ExtendedSystemMetrics> {
   const loadAverage = os.loadavg();
   const cpu = {
     cores: cpus.length,
-    model: cpus[0]?.model || "Unknown",
+    model: cpus[0]?.model || 'Unknown',
     loadAverage,
     loadPerCore: Math.round((loadAverage[0] / cpus.length) * 100) / 100,
   };
 
   // Database check
-  let dbStatus: ExtendedSystemMetrics["database"];
+  let dbStatus: ExtendedSystemMetrics['database'];
   const dbStart = Date.now();
   try {
     const connected = await isDatabaseConnected();
     const extended = connected ? await collectExtendedDatabaseMetrics() : undefined;
     dbStatus = {
-      status: connected ? "up" : "down",
+      status: connected ? 'up' : 'down',
       latencyMs: Date.now() - dbStart,
       extended,
     };
   } catch (error) {
     dbStatus = {
-      status: "down",
+      status: 'down',
       latencyMs: Date.now() - dbStart,
-      error: error instanceof Error ? error.message : "Unknown error",
+      error: error instanceof Error ? error.message : 'Unknown error',
     };
   }
 
   // Redis check
-  let redisStatus: ExtendedSystemMetrics["redis"];
+  let redisStatus: ExtendedSystemMetrics['redis'];
   if (!process.env.REDIS_URL) {
-    redisStatus = { status: "disabled" };
+    redisStatus = { status: 'disabled' };
   } else {
     const redisHealth = await checkRedisHealth();
     const extended = redisHealth.available ? await collectExtendedRedisMetrics() : undefined;
     redisStatus = {
-      status: redisHealth.available ? "up" : "down",
+      status: redisHealth.available ? 'up' : 'down',
       latencyMs: redisHealth.latencyMs,
       error: redisHealth.error,
       extended,
@@ -681,17 +694,18 @@ async function collectSystemMetrics(): Promise<ExtendedSystemMetrics> {
   }
 
   // Collect additional metrics in parallel
-  const [disk, pm2, network, ssl, deployment, security, logs, pm2Config, kernelVersion] = await Promise.all([
-    collectDiskMetrics(),
-    collectPM2Metrics(),
-    collectNetworkMetrics(),
-    collectSSLMetrics(),
-    collectDeploymentInfo(),
-    collectSecurityInfo(),
-    collectRecentLogs(),
-    collectPM2Config(),
-    safeExec("uname -r 2>/dev/null"),
-  ]);
+  const [disk, pm2, network, ssl, deployment, security, logs, pm2Config, kernelVersion] =
+    await Promise.all([
+      collectDiskMetrics(),
+      collectPM2Metrics(),
+      collectNetworkMetrics(),
+      collectSSLMetrics(),
+      collectDeploymentInfo(),
+      collectSecurityInfo(),
+      collectRecentLogs(),
+      collectPM2Config(),
+      safeExec('uname -r 2>/dev/null'),
+    ]);
 
   return {
     timestamp,
@@ -744,9 +758,9 @@ function buildDiagnosticPrompt(metrics: ExtendedSystemMetrics): string {
 
 ### Déploiement & Version
 - **Version application**: ${metrics.deployment.version}
-- **Commit Git**: ${metrics.deployment.gitCommit || "N/A"}
-- **Branche**: ${metrics.deployment.gitBranch || "N/A"}
-- **Dernier déploiement**: ${metrics.deployment.lastDeployedAt || "N/A"}
+- **Commit Git**: ${metrics.deployment.gitCommit || 'N/A'}
+- **Branche**: ${metrics.deployment.gitBranch || 'N/A'}
+- **Dernier déploiement**: ${metrics.deployment.lastDeployedAt || 'N/A'}
 - **NODE_ENV**: ${metrics.deployment.nodeEnv}
 - **Mode analytics**: ${metrics.deployment.analyticsMode}
 
@@ -767,7 +781,7 @@ function buildDiagnosticPrompt(metrics: ExtendedSystemMetrics): string {
 ### CPU
 - **Coeurs**: ${metrics.cpu.cores}
 - **Modèle**: ${metrics.cpu.model}
-- **Load average (1m, 5m, 15m)**: ${metrics.cpu.loadAverage.map(l => l.toFixed(2)).join(", ")}
+- **Load average (1m, 5m, 15m)**: ${metrics.cpu.loadAverage.map(l => l.toFixed(2)).join(', ')}
 - **Load par coeur**: ${metrics.cpu.loadPerCore}
 
 ### Stockage disque
@@ -785,7 +799,7 @@ function buildDiagnosticPrompt(metrics: ExtendedSystemMetrics): string {
 
 ### Base de données PostgreSQL
 - **Statut**: ${metrics.database.status}
-- **Latence**: ${metrics.database.latencyMs !== undefined ? `${metrics.database.latencyMs}ms` : "N/A"}`;
+- **Latence**: ${metrics.database.latencyMs !== undefined ? `${metrics.database.latencyMs}ms` : 'N/A'}`;
 
   if (metrics.database.error) {
     prompt += `
@@ -805,7 +819,7 @@ function buildDiagnosticPrompt(metrics: ExtendedSystemMetrics): string {
 
 ### Redis`;
 
-  if (metrics.redis.status === "disabled") {
+  if (metrics.redis.status === 'disabled') {
     prompt += `
 - **Statut**: Désactivé (non configuré)`;
   } else {
@@ -863,7 +877,7 @@ function buildDiagnosticPrompt(metrics: ExtendedSystemMetrics): string {
 - **Domaine**: ${metrics.ssl.domain}
 - **Expiration**: ${metrics.ssl.expiresAt}
 - **Jours restants**: ${metrics.ssl.daysUntilExpiry}
-- **Émetteur**: ${metrics.ssl.issuer || "N/A"}`;
+- **Émetteur**: ${metrics.ssl.issuer || 'N/A'}`;
   } else if (metrics.ssl?.error) {
     prompt += `
 
@@ -891,7 +905,7 @@ function buildDiagnosticPrompt(metrics: ExtendedSystemMetrics): string {
     prompt += `
 
 ### Erreurs récentes (logs)
-${metrics.logs.recentErrors.map(e => `- ${e}`).join("\n")}`;
+${metrics.logs.recentErrors.map(e => `- ${e}`).join('\n')}`;
     if (metrics.logs.errorCount24h) {
       prompt += `
 - **Total erreurs (estimé)**: ${metrics.logs.errorCount24h}`;
@@ -967,41 +981,50 @@ commande2
 /**
  * Parse la réponse XML de Claude en objet structuré
  */
-function parseDiagnosticResponse(response: string): DiagnosticResponse["analysis"] {
+function parseDiagnosticResponse(response: string): DiagnosticResponse['analysis'] {
   // Overall health
-  const healthMatch = response.match(/<OVERALL_HEALTH>(excellent|good|warning|critical)<\/OVERALL_HEALTH>/);
-  const overallHealth = (healthMatch?.[1] as "excellent" | "good" | "warning" | "critical") || "warning";
+  const healthMatch = response.match(
+    /<OVERALL_HEALTH>(excellent|good|warning|critical)<\/OVERALL_HEALTH>/
+  );
+  const overallHealth =
+    (healthMatch?.[1] as 'excellent' | 'good' | 'warning' | 'critical') || 'warning';
 
   // Summary
   const summaryMatch = response.match(/<SUMMARY>([\s\S]*?)<\/SUMMARY>/);
-  const summary = summaryMatch?.[1]?.trim() || "Diagnostic non disponible";
+  const summary = summaryMatch?.[1]?.trim() || 'Diagnostic non disponible';
 
   // Findings
-  const findingsRegex = /<FINDING\s+category="([^"]+)"\s+status="(ok|warning|critical)">\s*<MESSAGE>([\s\S]*?)<\/MESSAGE>\s*(?:<DETAILS>([\s\S]*?)<\/DETAILS>)?\s*<\/FINDING>/g;
-  const findings: NonNullable<DiagnosticResponse["analysis"]>["findings"] = [];
+  const findingsRegex =
+    /<FINDING\s+category="([^"]+)"\s+status="(ok|warning|critical)">\s*<MESSAGE>([\s\S]*?)<\/MESSAGE>\s*(?:<DETAILS>([\s\S]*?)<\/DETAILS>)?\s*<\/FINDING>/g;
+  const findings: NonNullable<DiagnosticResponse['analysis']>['findings'] = [];
 
   let findingMatch;
   while ((findingMatch = findingsRegex.exec(response)) !== null) {
     findings.push({
       category: findingMatch[1],
-      status: findingMatch[2] as "ok" | "warning" | "critical",
+      status: findingMatch[2] as 'ok' | 'warning' | 'critical',
       message: findingMatch[3].trim(),
       details: findingMatch[4]?.trim(),
     });
   }
 
   // Recommendations
-  const recommendationsRegex = /<RECOMMENDATION\s+priority="(high|medium|low)">\s*<TITLE>([\s\S]*?)<\/TITLE>\s*<DESCRIPTION>([\s\S]*?)<\/DESCRIPTION>\s*(?:<COMMANDS>([\s\S]*?)<\/COMMANDS>)?\s*<\/RECOMMENDATION>/g;
-  const recommendations: NonNullable<DiagnosticResponse["analysis"]>["recommendations"] = [];
+  const recommendationsRegex =
+    /<RECOMMENDATION\s+priority="(high|medium|low)">\s*<TITLE>([\s\S]*?)<\/TITLE>\s*<DESCRIPTION>([\s\S]*?)<\/DESCRIPTION>\s*(?:<COMMANDS>([\s\S]*?)<\/COMMANDS>)?\s*<\/RECOMMENDATION>/g;
+  const recommendations: NonNullable<DiagnosticResponse['analysis']>['recommendations'] = [];
 
   let recMatch;
   while ((recMatch = recommendationsRegex.exec(response)) !== null) {
     const commands = recMatch[4]
-      ? recMatch[4].trim().split("\n").map(c => c.trim()).filter(c => c)
+      ? recMatch[4]
+          .trim()
+          .split('\n')
+          .map(c => c.trim())
+          .filter(c => c)
       : undefined;
 
     recommendations.push({
-      priority: recMatch[1] as "high" | "medium" | "low",
+      priority: recMatch[1] as 'high' | 'medium' | 'low',
       title: recMatch[2].trim(),
       description: recMatch[3].trim(),
       commands: commands?.length ? commands : undefined,
@@ -1010,7 +1033,7 @@ function parseDiagnosticResponse(response: string): DiagnosticResponse["analysis
 
   // Maintenance tasks
   const maintenanceRegex = /<TASK\s+frequency="([^"]+)">([\s\S]*?)<\/TASK>/g;
-  const maintenanceTasks: NonNullable<DiagnosticResponse["analysis"]>["maintenanceTasks"] = [];
+  const maintenanceTasks: NonNullable<DiagnosticResponse['analysis']>['maintenanceTasks'] = [];
 
   let maintMatch;
   while ((maintMatch = maintenanceRegex.exec(response)) !== null) {
@@ -1032,23 +1055,37 @@ function parseDiagnosticResponse(response: string): DiagnosticResponse["analysis
   return {
     overallHealth,
     summary,
-    findings: findings.length > 0 ? findings : [{
-      category: "system",
-      status: "ok",
-      message: "Analyse en cours",
-    }],
-    recommendations: recommendations.length > 0 ? recommendations : [{
-      priority: "low",
-      title: "Surveillance continue",
-      description: "Continuer à monitorer les métriques système régulièrement.",
-    }],
-    maintenanceTasks: maintenanceTasks.length > 0 ? maintenanceTasks : [{
-      task: "Vérifier les logs d'erreur",
-      frequency: "daily",
-    }],
-    performanceInsights: performanceInsights.length > 0 ? performanceInsights : [
-      "Aucun insight spécifique détecté",
-    ],
+    findings:
+      findings.length > 0
+        ? findings
+        : [
+            {
+              category: 'system',
+              status: 'ok',
+              message: 'Analyse en cours',
+            },
+          ],
+    recommendations:
+      recommendations.length > 0
+        ? recommendations
+        : [
+            {
+              priority: 'low',
+              title: 'Surveillance continue',
+              description: 'Continuer à monitorer les métriques système régulièrement.',
+            },
+          ],
+    maintenanceTasks:
+      maintenanceTasks.length > 0
+        ? maintenanceTasks
+        : [
+            {
+              task: "Vérifier les logs d'erreur",
+              frequency: 'daily',
+            },
+          ],
+    performanceInsights:
+      performanceInsights.length > 0 ? performanceInsights : ['Aucun insight spécifique détecté'],
   };
 }
 
@@ -1069,11 +1106,11 @@ export async function GET(): Promise<NextResponse> {
       metrics,
     });
   } catch (error) {
-    console.error("[Server Diagnostic] Error collecting metrics:", error);
+    console.error('[Server Diagnostic] Error collecting metrics:', error);
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : "Erreur lors de la collecte des métriques",
+        error: error instanceof Error ? error.message : 'Erreur lors de la collecte des métriques',
       },
       { status: 500 }
     );
@@ -1096,7 +1133,7 @@ export async function POST(): Promise<NextResponse> {
     // Vérifier la clé API Anthropic
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
-      console.error("[Server Diagnostic] ANTHROPIC_API_KEY non configurée");
+      console.error('[Server Diagnostic] ANTHROPIC_API_KEY non configurée');
       return NextResponse.json(
         {
           success: false,
@@ -1114,25 +1151,23 @@ export async function POST(): Promise<NextResponse> {
     const anthropic = new Anthropic({ apiKey });
 
     const message = await anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
+      model: 'claude-sonnet-4-5-20250929',
       max_tokens: 6000,
       temperature: 0.3,
       system: SERVER_DIAGNOSTIC_SYSTEM_PROMPT,
       messages: [
         {
-          role: "user",
+          role: 'user',
           content: analysisPrompt,
         },
       ],
     });
 
     // Extract response
-    const responseContent = message.content[0].type === "text"
-      ? message.content[0].text
-      : "";
+    const responseContent = message.content[0].type === 'text' ? message.content[0].text : '';
 
     if (!responseContent) {
-      throw new Error("Aucune réponse de Claude");
+      throw new Error('Aucune réponse de Claude');
     }
 
     // Parse structured response
@@ -1146,11 +1181,11 @@ export async function POST(): Promise<NextResponse> {
 
     return NextResponse.json(response);
   } catch (error) {
-    console.error("[Server Diagnostic] Error:", error);
+    console.error('[Server Diagnostic] Error:', error);
     return NextResponse.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : "Erreur lors du diagnostic",
+        error: error instanceof Error ? error.message : 'Erreur lors du diagnostic',
       },
       { status: 500 }
     );

--- a/apps/psypnos/app/api/analytics/store-index.ts
+++ b/apps/psypnos/app/api/analytics/store-index.ts
@@ -1,460 +1,123 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Analytics Store Index
- * Phase 4: Scalability & Performance
  *
- * This module provides dynamic selection between JSON and PostgreSQL storage
- * based on the ANALYTICS_STORAGE_MODE environment variable.
+ * Direct re-exports from the PostgreSQL store via Prisma.
  *
- * Usage:
- *   import * as store from '@/app/api/analytics/store-index';
+ * Previously this module dynamically selected between JSON file storage and
+ * PostgreSQL based on the ANALYTICS_STORAGE_MODE env var (defaulting to JSON).
+ * This was the root cause of tracking data never reaching the database:
+ * the env var was never set, so all data went to a JSON file on an ephemeral
+ * filesystem that was wiped on every deployment.
  *
- * Configuration:
- *   - ANALYTICS_STORAGE_MODE="json" (default) - Use JSON file storage
- *   - ANALYTICS_STORAGE_MODE="postgres" - Use PostgreSQL with Prisma
+ * The JSON store is now removed from the data path. PostgreSQL (via Prisma)
+ * is the only supported storage backend.
  */
 
-import { isDatabaseConnected } from "@/lib/db/prisma";
+// Page Visits
+export { trackPageVisit, getPageVisits } from './store-postgres/page-visits';
 
-// Determine storage mode
-function getStorageMode(): "json" | "postgres" {
-  const mode = process.env.ANALYTICS_STORAGE_MODE?.toLowerCase();
+// Section Times
+export { trackSectionTime, getSectionTimes } from './store-postgres/section-times';
 
-  if (mode === "postgres") {
-    return "postgres";
-  }
+// Conversions
+export { trackConversionEvent, getConversionEvents } from './store-postgres/conversions';
 
-  return "json"; // Default
-}
-
-// Cache the storage mode to avoid repeated env checks
-let cachedMode: "json" | "postgres" | null = null;
-let modeChecked = false;
-
-async function resolveStorageMode(): Promise<"json" | "postgres"> {
-  if (modeChecked && cachedMode) {
-    return cachedMode;
-  }
-
-  const requestedMode = getStorageMode();
-
-  if (requestedMode === "postgres") {
-    // Check if database is actually available
-    const dbConnected = await isDatabaseConnected();
-
-    if (!dbConnected) {
-      console.warn(
-        "[Analytics Store] PostgreSQL requested but not available, falling back to JSON"
-      );
-      cachedMode = "json";
-    } else {
-      cachedMode = "postgres";
-    }
-  } else {
-    cachedMode = "json";
-  }
-
-  modeChecked = true;
-  return cachedMode;
-}
-
-// Dynamic import helper
-async function getStore() {
-  const mode = await resolveStorageMode();
-
-  if (mode === "postgres") {
-    return import("./store-postgres");
-  }
-
-  return import("./store");
-}
-
-// ===========================================
-// Exported functions that delegate to the appropriate store
-// ===========================================
-
-// Page Visit Operations
-export async function trackPageVisit(
-  pageVisit: Parameters<(typeof import("./store"))["trackPageVisit"]>[0]
-) {
-  const store = await getStore();
-  return store.trackPageVisit(pageVisit);
-}
-
-export async function getPageVisits(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getPageVisits(startDate, endDate);
-}
-
-// Section Time Operations
-export async function trackSectionTime(
-  sectionTime: Parameters<(typeof import("./store"))["trackSectionTime"]>[0]
-) {
-  const store = await getStore();
-  return store.trackSectionTime(sectionTime);
-}
-
-export async function getSectionTimes(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getSectionTimes(startDate, endDate);
-}
-
-// Conversion Event Operations
-export async function trackConversionEvent(
-  event: Parameters<(typeof import("./store"))["trackConversionEvent"]>[0]
-) {
-  const store = await getStore();
-  return store.trackConversionEvent(event);
-}
-
-export async function getConversionEvents(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getConversionEvents(startDate, endDate);
-}
-
-// Analytics Summary
-export async function getAnalyticsSummary(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getAnalyticsSummary(startDate, endDate);
-}
-
-export async function getAnalyticsSummaryWithComparison(
-  timeRange: "day" | "week" | "month" | "year"
-) {
-  const store = await getStore();
-  return store.getAnalyticsSummaryWithComparison(timeRange);
-}
-
-export async function getVisitsByPeriod(
-  period: "hour" | "day" | "week" | "month" | "year",
-  startDate?: string,
-  endDate?: string
-) {
-  const store = await getStore();
-  return store.getVisitsByPeriod(period, startDate, endDate);
-}
-
-// Heatmap & Traffic
-export async function getSectionHeatmap(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getSectionHeatmap(startDate, endDate);
-}
-
-export async function getTrafficSources(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getTrafficSources(startDate, endDate);
-}
-
-export async function getDeviceBreakdown(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getDeviceBreakdown(startDate, endDate);
-}
+// Analytics
+export {
+  getAnalyticsSummary,
+  getVisitsByPeriod,
+  getAnalyticsSummaryWithComparison,
+  getSectionHeatmap,
+  getTrafficSources,
+  getDeviceBreakdown,
+} from './store-postgres/analytics';
 
 // Custom Events
-export async function trackCustomEvent(
-  event: Parameters<(typeof import("./store"))["trackCustomEvent"]>[0]
-) {
-  const store = await getStore();
-  return store.trackCustomEvent(event);
-}
-
-export async function getCustomEvents(
-  startDate?: string,
-  endDate?: string,
-  category?: string,
-  action?: string
-) {
-  const store = await getStore();
-  return store.getCustomEvents(startDate, endDate, category, action);
-}
-
-export async function getCustomEventsSummary(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getCustomEventsSummary(startDate, endDate);
-}
+export {
+  trackCustomEvent,
+  getCustomEvents,
+  getCustomEventsSummary,
+} from './store-postgres/custom-events';
 
 // Goals
-export async function createGoal(
-  goal: Parameters<(typeof import("./store"))["createGoal"]>[0]
-) {
-  const store = await getStore();
-  return store.createGoal(goal);
-}
-
-export async function getGoals() {
-  const store = await getStore();
-  return store.getGoals();
-}
-
-export async function getGoal(id: string) {
-  const store = await getStore();
-  return store.getGoal(id);
-}
-
-export async function updateGoal(
-  id: string,
-  updates: Parameters<(typeof import("./store"))["updateGoal"]>[1]
-) {
-  const store = await getStore();
-  return store.updateGoal(id, updates);
-}
-
-export async function deleteGoal(id: string) {
-  const store = await getStore();
-  return store.deleteGoal(id);
-}
-
-export async function trackGoalCompletion(
-  completion: Parameters<(typeof import("./store"))["trackGoalCompletion"]>[0]
-) {
-  const store = await getStore();
-  return store.trackGoalCompletion(completion);
-}
-
-export async function getGoalCompletions(
-  goalId?: string,
-  startDate?: string,
-  endDate?: string
-) {
-  const store = await getStore();
-  return store.getGoalCompletions(goalId, startDate, endDate);
-}
-
-export async function getGoalsSummary(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getGoalsSummary(startDate, endDate);
-}
+export {
+  createGoal,
+  getGoals,
+  getGoal,
+  updateGoal,
+  deleteGoal,
+  trackGoalCompletion,
+  getGoalCompletions,
+  getGoalsSummary,
+} from './store-postgres/goals';
 
 // Funnels
-export async function trackFunnelStep(
-  step: Parameters<(typeof import("./store"))["trackFunnelStep"]>[0]
-) {
-  const store = await getStore();
-  return store.trackFunnelStep(step);
-}
-
-export async function getFunnelSteps(
-  funnelName?: string,
-  startDate?: string,
-  endDate?: string
-) {
-  const store = await getStore();
-  return store.getFunnelSteps(funnelName, startDate, endDate);
-}
-
-export async function getFunnelAnalysis(
-  funnelName: string,
-  startDate?: string,
-  endDate?: string
-) {
-  const store = await getStore();
-  return store.getFunnelAnalysis(funnelName, startDate, endDate);
-}
-
-export async function getAvailableFunnels(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getAvailableFunnels(startDate, endDate);
-}
+export {
+  trackFunnelStep,
+  getFunnelSteps,
+  getFunnelAnalysis,
+  getAvailableFunnels,
+} from './store-postgres/funnels';
 
 // Cohorts
-export async function getCohortAnalysis(
-  cohortBy?: "week" | "month" | "utm_source" | "referrer" | "device",
-  startDate?: string,
-  endDate?: string
-) {
-  const store = await getStore();
-  return store.getCohortAnalysis(cohortBy, startDate, endDate);
-}
+export { getCohortAnalysis } from './store-postgres/cohorts';
 
 // Attribution
-export async function getMarketingAttribution(startDate?: string, endDate?: string) {
-  const store = await getStore();
-  return store.getMarketingAttribution(startDate, endDate);
-}
+export { getMarketingAttribution } from './store-postgres/attribution';
 
 // Alerts
-export async function createAlert(
-  alert: Parameters<(typeof import("./store"))["createAlert"]>[0]
-) {
-  const store = await getStore();
-  return store.createAlert(alert);
-}
-
-export async function getAlerts(enabledOnly?: boolean) {
-  const store = await getStore();
-  return store.getAlerts(enabledOnly);
-}
-
-export async function getAlert(id: string) {
-  const store = await getStore();
-  return store.getAlert(id);
-}
-
-export async function updateAlert(
-  id: string,
-  updates: Parameters<(typeof import("./store"))["updateAlert"]>[1]
-) {
-  const store = await getStore();
-  return store.updateAlert(id, updates);
-}
-
-export async function deleteAlert(id: string) {
-  const store = await getStore();
-  return store.deleteAlert(id);
-}
-
-export async function addAlertHistory(
-  history: Parameters<(typeof import("./store"))["addAlertHistory"]>[0]
-) {
-  const store = await getStore();
-  return store.addAlertHistory(history);
-}
-
-export async function getAlertHistory(alertId?: string, limit?: number) {
-  const store = await getStore();
-  return store.getAlertHistory(alertId, limit);
-}
-
-export async function getMetricValue(
-  metric: Parameters<(typeof import("./store"))["getMetricValue"]>[0],
-  timeWindow: Parameters<(typeof import("./store"))["getMetricValue"]>[1]
-) {
-  const store = await getStore();
-  return store.getMetricValue(metric, timeWindow);
-}
-
-export async function evaluateAlertCondition(
-  actualValue: number,
-  threshold: number,
-  condition: Parameters<(typeof import("./store"))["evaluateAlertCondition"]>[2],
-  previousValue?: number
-) {
-  const store = await getStore();
-  return store.evaluateAlertCondition(actualValue, threshold, condition, previousValue);
-}
+export {
+  createAlert,
+  getAlerts,
+  getAlert,
+  updateAlert,
+  deleteAlert,
+  addAlertHistory,
+  getAlertHistory,
+} from './store-postgres/alerts';
 
 // Anomalies
-export async function calculateBaseline(metric: string, days?: number) {
-  const store = await getStore();
-  return store.calculateBaseline(metric, days);
-}
+export {
+  getAnomalies,
+  acknowledgeAnomaly,
+  getMetricValue,
+  evaluateAlertCondition,
+  calculateBaseline,
+  detectAnomaly,
+  runAnomalyDetection,
+} from './store-postgres/anomalies';
 
-export async function detectAnomaly(
-  actualValue: number,
-  baseline: { mean: number; stdDev: number },
-  sensitivity?: "low" | "medium" | "high"
-) {
-  const store = await getStore();
-  return store.detectAnomaly(actualValue, baseline, sensitivity);
-}
+// Reports
+export {
+  createScheduledReport,
+  getScheduledReports,
+  getScheduledReport,
+  updateScheduledReport,
+  deleteScheduledReport,
+} from './store-postgres/reports';
 
-export async function runAnomalyDetection(sensitivity?: "low" | "medium" | "high") {
-  const store = await getStore();
-  return store.runAnomalyDetection(sensitivity);
-}
+// Dashboard
+export {
+  createDashboardConfig,
+  getDashboardConfigs,
+  getDashboardConfig,
+  getDefaultDashboardConfig,
+  updateDashboardConfig,
+  deleteDashboardConfig,
+} from './store-postgres/dashboard';
 
-export async function getAnomalies(
-  startDate?: string,
-  endDate?: string,
-  acknowledgedOnly?: boolean
-) {
-  const store = await getStore();
-  return store.getAnomalies(startDate, endDate, acknowledgedOnly);
-}
+// Re-export getDefaultWidgets from store (pure function, no I/O)
+export { getDefaultWidgets } from './store/dashboard';
 
-export async function acknowledgeAnomaly(id: string, acknowledgedBy?: string) {
-  const store = await getStore();
-  return store.acknowledgeAnomaly(id, acknowledgedBy);
-}
-
-// Scheduled Reports
-export async function createScheduledReport(
-  report: Parameters<(typeof import("./store"))["createScheduledReport"]>[0]
-) {
-  const store = await getStore();
-  return store.createScheduledReport(report);
-}
-
-export async function getScheduledReports(enabledOnly?: boolean) {
-  const store = await getStore();
-  return store.getScheduledReports(enabledOnly);
-}
-
-export async function getScheduledReport(id: string) {
-  const store = await getStore();
-  return store.getScheduledReport(id);
-}
-
-export async function updateScheduledReport(
-  id: string,
-  updates: Parameters<(typeof import("./store"))["updateScheduledReport"]>[1]
-) {
-  const store = await getStore();
-  return store.updateScheduledReport(id, updates);
-}
-
-export async function deleteScheduledReport(id: string) {
-  const store = await getStore();
-  return store.deleteScheduledReport(id);
-}
-
-// Dashboard Config
-export async function createDashboardConfig(
-  config: Parameters<(typeof import("./store"))["createDashboardConfig"]>[0]
-) {
-  const store = await getStore();
-  return store.createDashboardConfig(config);
-}
-
-export async function getDashboardConfigs(userId?: string) {
-  const store = await getStore();
-  return store.getDashboardConfigs(userId);
-}
-
-export async function getDashboardConfig(id: string) {
-  const store = await getStore();
-  return store.getDashboardConfig(id);
-}
-
-export async function getDefaultDashboardConfig(userId: string) {
-  const store = await getStore();
-  return store.getDefaultDashboardConfig(userId);
-}
-
-export async function updateDashboardConfig(
-  id: string,
-  updates: Parameters<(typeof import("./store"))["updateDashboardConfig"]>[1]
-) {
-  const store = await getStore();
-  return store.updateDashboardConfig(id, updates);
-}
-
-export async function deleteDashboardConfig(id: string) {
-  const store = await getStore();
-  return store.deleteDashboardConfig(id);
-}
-
-export async function getDefaultWidgets() {
-  const store = await getStore();
-  return store.getDefaultWidgets();
-}
-
-// ===========================================
-// Storage Mode Info
-// ===========================================
-
-export async function getStorageInfo() {
-  const mode = await resolveStorageMode();
+// Storage info (for diagnostics)
+export function getStorageInfo() {
   return {
-    mode,
-    description:
-      mode === "postgres"
-        ? "PostgreSQL with Prisma ORM (Phase 4)"
-        : "JSON file storage (Legacy)",
+    mode: 'postgres' as const,
+    description: 'PostgreSQL with Prisma ORM',
   };
 }
 
-// Re-export types
+// Re-export types from store-postgres (which re-exports from store/types)
 export type {
   PageVisit,
   SectionTime,
@@ -468,5 +131,4 @@ export type {
   DashboardConfig,
   ScheduledReport,
   Anomaly,
-  Analytics,
-} from "./store";
+} from './store-postgres';

--- a/apps/psypnos/app/api/health/route.ts
+++ b/apps/psypnos/app/api/health/route.ts
@@ -11,27 +11,27 @@
  * - Uptime
  */
 
-import os from "os";
+import os from 'os';
 
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 
-import { checkRedisHealth } from "@/lib/cache/redis";
-import { isDatabaseConnected, prisma } from "@/lib/db/prisma";
+import { checkRedisHealth } from '@/lib/cache/redis';
+import { isDatabaseConnected, prisma } from '@/lib/db/prisma';
 
 interface HealthStatus {
-  status: "healthy" | "degraded" | "unhealthy";
+  status: 'healthy' | 'degraded' | 'unhealthy';
   timestamp: string;
   uptime: number | null;
   uptimeMessage?: string;
   version: string;
   checks: {
     database: {
-      status: "up" | "down";
+      status: 'up' | 'down';
       latencyMs?: number;
       error?: string;
     };
     redis: {
-      status: "up" | "down" | "disabled";
+      status: 'up' | 'down' | 'disabled';
       latencyMs?: number;
       error?: string;
     };
@@ -55,8 +55,8 @@ export async function GET(): Promise<NextResponse<HealthStatus>> {
 
   try {
     const lastSuccessfulDeployment = await prisma.deployment.findFirst({
-      where: { status: "success" },
-      orderBy: { completedAt: "desc" },
+      where: { status: 'success' },
+      orderBy: { completedAt: 'desc' },
       select: { completedAt: true },
     });
 
@@ -64,37 +64,37 @@ export async function GET(): Promise<NextResponse<HealthStatus>> {
       const now = new Date();
       uptime = Math.floor((now.getTime() - lastSuccessfulDeployment.completedAt.getTime()) / 1000);
     } else {
-      uptimeMessage = "Aucun déploiement enregistré";
+      uptimeMessage = 'Aucun déploiement enregistré';
     }
   } catch {
     uptimeMessage = "Impossible de récupérer l'uptime";
   }
 
   // Check database
-  let dbStatus: HealthStatus["checks"]["database"];
+  let dbStatus: HealthStatus['checks']['database'];
   const dbStart = Date.now();
   try {
     const connected = await isDatabaseConnected();
     dbStatus = {
-      status: connected ? "up" : "down",
+      status: connected ? 'up' : 'down',
       latencyMs: Date.now() - dbStart,
     };
   } catch (error) {
     dbStatus = {
-      status: "down",
+      status: 'down',
       latencyMs: Date.now() - dbStart,
-      error: error instanceof Error ? error.message : "Unknown error",
+      error: error instanceof Error ? error.message : 'Unknown error',
     };
   }
 
   // Check Redis
-  let redisStatus: HealthStatus["checks"]["redis"];
+  let redisStatus: HealthStatus['checks']['redis'];
   if (!process.env.REDIS_URL) {
-    redisStatus = { status: "disabled" };
+    redisStatus = { status: 'disabled' };
   } else {
     const redisHealth = await checkRedisHealth();
     redisStatus = {
-      status: redisHealth.available ? "up" : "down",
+      status: redisHealth.available ? 'up' : 'down',
       latencyMs: redisHealth.latencyMs,
       error: redisHealth.error,
     };
@@ -115,18 +115,17 @@ export async function GET(): Promise<NextResponse<HealthStatus>> {
   };
 
   // Determine overall status
-  let overallStatus: HealthStatus["status"] = "healthy";
+  let overallStatus: HealthStatus['status'] = 'healthy';
 
-  // If database mode is postgres and DB is down, it's unhealthy
-  const analyticsMode = process.env.ANALYTICS_STORAGE_MODE || "json";
-  if (analyticsMode === "postgres" && dbStatus.status === "down") {
-    overallStatus = "unhealthy";
+  // Analytics always uses PostgreSQL — if DB is down, it's unhealthy
+  if (dbStatus.status === 'down') {
+    overallStatus = 'unhealthy';
   } else if (
-    (analyticsMode === "postgres" && dbStatus.latencyMs && dbStatus.latencyMs > 1000) ||
-    (redisStatus.status === "down" && process.env.REDIS_URL) ||
+    (dbStatus.latencyMs && dbStatus.latencyMs > 1000) ||
+    (redisStatus.status === 'down' && process.env.REDIS_URL) ||
     memory.percentUsed > 90
   ) {
-    overallStatus = "degraded";
+    overallStatus = 'degraded';
   }
 
   const response: HealthStatus = {
@@ -134,7 +133,7 @@ export async function GET(): Promise<NextResponse<HealthStatus>> {
     timestamp,
     uptime,
     ...(uptimeMessage && { uptimeMessage }),
-    version: process.env.npm_package_version || "1.0.0",
+    version: process.env.npm_package_version || '1.0.0',
     checks: {
       database: dbStatus,
       redis: redisStatus,
@@ -143,7 +142,7 @@ export async function GET(): Promise<NextResponse<HealthStatus>> {
     analyticsMode,
   };
 
-  const httpStatus = overallStatus === "unhealthy" ? 503 : 200;
+  const httpStatus = overallStatus === 'unhealthy' ? 503 : 200;
 
   return NextResponse.json(response, { status: httpStatus });
 }

--- a/apps/psypnos/components/Analytics.tsx
+++ b/apps/psypnos/components/Analytics.tsx
@@ -6,27 +6,28 @@
  *
  * @see /lib/tracking pour l'implémentation complète
  */
-"use client";
+'use client';
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef } from 'react';
 
-import { initTracker, getTracker } from "@/lib/tracking";
+import { initTracker, getTracker } from '@/lib/tracking';
 
 /**
  * Composant Analytics principal
  *
  * Initialise le tracker au montage et gère le nettoyage.
  * Ce composant ne rend rien visuellement.
+ *
+ * Note: initTracker() is idempotent — the Tracker singleton guards against
+ * double-initialization via its own `isInitialized` flag. We intentionally
+ * call it on every mount so that:
+ *   1. If consent is given between unmount/remount cycles, tracking starts.
+ *   2. React StrictMode double-mounts don't break the flow.
  */
 export function Analytics() {
-  const initialized = useRef(false);
-
   useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
-
     initTracker({
-      debug: process.env.NODE_ENV === "development",
+      debug: process.env.NODE_ENV === 'development',
     });
   }, []);
 
@@ -45,10 +46,10 @@ export function SectionTracker() {
   useEffect(() => {
     const timer = setTimeout(() => {
       const tracker = getTracker();
-      const sections = document.querySelectorAll("[data-track-section]");
+      const sections = document.querySelectorAll('[data-track-section]');
       const observed: HTMLElement[] = [];
 
-      sections.forEach((section) => {
+      sections.forEach(section => {
         const element = section as HTMLElement;
         const sectionId = element.dataset.trackSection || element.id;
         if (!sectionId) return;
@@ -65,7 +66,7 @@ export function SectionTracker() {
       clearTimeout(timer);
       // Cleanup: unobserve all tracked sections to prevent memory leaks
       const tracker = getTracker();
-      observedElementsRef.current.forEach((element) => {
+      observedElementsRef.current.forEach(element => {
         tracker.unobserveSection(element);
       });
       observedElementsRef.current = [];


### PR DESCRIPTION
The analytics store-index.ts dynamically selected between JSON file storage
and PostgreSQL based on ANALYTICS_STORAGE_MODE env var, defaulting to JSON.
Since this env var was never configured, all tracking data was silently
written to a JSON file on an ephemeral filesystem (wiped on each deploy),
while admin pages either read from the same JSON file or queried an empty
PostgreSQL database. Result: zero data visible anywhere.

Changes:
- Rewrite store-index.ts as direct re-exports from store-postgres/,
  eliminating the JSON/postgres toggle and async indirection entirely
- Remove useRef guard in Analytics component that prevented tracker
  re-initialization after consent was given between mount cycles
- Update health and diagnostic routes to reflect postgres-only mode
- Fix pre-existing type errors in chatbot conversation routes
- Regenerate Prisma client to resolve missing type exports

https://claude.ai/code/session_015UHc4ioMQq6wFLXhkrPHh9