### PR TITLE
fix(analytics): resolve siteId from database instead of defaulting to "default"

### DIFF
--- a/apps/psypnos/app/api/analytics/dashboard/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/route.ts
@@ -126,7 +126,7 @@ export async function GET(request: NextRequest) {
     const startISO = startDate.toISOString();
     const endISO = endDate.toISOString();
 
-    const siteId = getCurrentSiteId();
+    const siteId = await getCurrentSiteId();
     const cacheTTL = isRealtimeMode ? CACHE_TTL.SHORT : CACHE_TTL.MEDIUM;
     const cacheKey = buildCacheKey(CACHE_KEYS.DASHBOARD, {
       siteId,
@@ -251,7 +251,7 @@ export async function GET(request: NextRequest) {
 
 async function fetchGeoData(startDate: Date, endDate: Date) {
   try {
-    const siteId = getCurrentSiteId();
+    const siteId = await getCurrentSiteId();
 
     const geolocations = await prisma.visitorGeolocation.findMany({
       where: {

--- a/apps/psypnos/app/api/analytics/geolocation/route.ts
+++ b/apps/psypnos/app/api/analytics/geolocation/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
     // Real mode - fetch data from VisitorGeolocation table
     console.log("📊 [Geolocation Analytics] Using REAL data");
 
-    const siteId = getCurrentSiteId();
+    const siteId = await getCurrentSiteId();
 
     // Calculate date filters
     const endDate = endDateParam ? new Date(endDateParam) : new Date();

--- a/apps/psypnos/app/api/analytics/store-postgres/alerts.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/alerts.ts
@@ -180,7 +180,7 @@ export async function createAlert(alert: {
   webhookUrl?: string;
   enabled: boolean;
 }): Promise<Alert> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const result = await prisma.analyticsAlert.create({
     data: {
@@ -207,7 +207,7 @@ export async function createAlert(alert: {
  * Get all alerts
  */
 export async function getAlerts(enabledOnly: boolean = false): Promise<Alert[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const alerts = await prisma.analyticsAlert.findMany({
     where: {

--- a/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
@@ -24,7 +24,7 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
   return getCached(
     cacheKey,
     async () => {
-      const siteId = getCurrentSiteId();
+      const siteId = await getCurrentSiteId();
       const dateFilter = buildDateFilter(startDate, endDate);
 
       // Count total page views (excluding bots) and unique sessions via SQL
@@ -204,7 +204,7 @@ export async function getVisitsByPeriod(
   return getCached(
     cacheKey,
     async () => {
-      const siteId = getCurrentSiteId();
+      const siteId = await getCurrentSiteId();
       const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
@@ -318,7 +318,7 @@ export async function getSectionHeatmap(startDate?: string, endDate?: string) {
   return getCached(
     cacheKey,
     async () => {
-      const siteId = getCurrentSiteId();
+      const siteId = await getCurrentSiteId();
       const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
@@ -384,7 +384,7 @@ export async function getTrafficSources(startDate?: string, endDate?: string) {
   return getCached(
     cacheKey,
     async () => {
-      const siteId = getCurrentSiteId();
+      const siteId = await getCurrentSiteId();
       const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
@@ -433,7 +433,7 @@ export async function getDeviceBreakdown(startDate?: string, endDate?: string) {
   return getCached(
     cacheKey,
     async () => {
-      const siteId = getCurrentSiteId();
+      const siteId = await getCurrentSiteId();
       const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 

--- a/apps/psypnos/app/api/analytics/store-postgres/anomalies.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/anomalies.ts
@@ -59,7 +59,7 @@ export async function getAnomalies(
   endDate?: string,
   acknowledgedOnly?: boolean
 ): Promise<Anomaly[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const where: {
     siteId: string;
@@ -118,7 +118,7 @@ export async function recordAnomaly(anomaly: {
   deviation: number;
   severity: "low" | "medium" | "high";
 }): Promise<Anomaly> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const result = await prisma.analyticsAnomaly.create({
     data: {

--- a/apps/psypnos/app/api/analytics/store-postgres/conversions.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/conversions.ts
@@ -58,7 +58,7 @@ export async function trackConversionEvent(event: {
   completed: boolean;
   metadata?: Record<string, unknown>;
 }): Promise<ConversionEvent> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // Build the data object for JSON storage
   const eventData = buildConversionData({
@@ -92,7 +92,7 @@ export async function getConversionEvents(
   startDate?: string,
   endDate?: string
 ): Promise<ConversionEvent[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
 
   const events = await prisma.analyticsEvent.findMany({
@@ -118,7 +118,7 @@ export async function getConversionStats(
   completed: number;
   byType: Record<string, { total: number; completed: number; rate: number }>;
 }> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
 
   const events = await prisma.analyticsEvent.findMany({

--- a/apps/psypnos/app/api/analytics/store-postgres/custom-events.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/custom-events.ts
@@ -55,7 +55,7 @@ export async function trackCustomEvent(event: {
   value?: number;
   metadata?: Record<string, unknown>;
 }): Promise<CustomEvent> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // Build the data object for JSON storage
   const eventData = buildCustomEventData({
@@ -90,7 +90,7 @@ export async function getCustomEvents(
   category?: string,
   action?: string
 ): Promise<CustomEvent[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
 
   // Build base query

--- a/apps/psypnos/app/api/analytics/store-postgres/dashboard.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/dashboard.ts
@@ -65,7 +65,7 @@ export async function createDashboardConfig(config: {
   isDefault: boolean;
   widgets: Widget[];
 }): Promise<DashboardConfig> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // If setting as default, unset other defaults for this user
   if (config.isDefault) {
@@ -92,7 +92,7 @@ export async function createDashboardConfig(config: {
  * Get dashboard configurations
  */
 export async function getDashboardConfigs(userId?: string): Promise<DashboardConfig[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const where: { siteId: string; userId?: string } = { siteId };
   if (userId) where.userId = userId;
@@ -124,7 +124,7 @@ export async function getDashboardConfig(id: string): Promise<DashboardConfig | 
 export async function getDefaultDashboardConfig(
   userId: string
 ): Promise<DashboardConfig | undefined> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const config = await prisma.analyticsDashboardConfig.findFirst({
     where: { userId, siteId, isDefault: true },
@@ -147,7 +147,7 @@ export async function updateDashboardConfig(
   }>
 ): Promise<DashboardConfig | null> {
   try {
-    const siteId = getCurrentSiteId();
+    const siteId = await getCurrentSiteId();
 
     // If setting as default, unset other defaults for this user
     if (updates.isDefault) {

--- a/apps/psypnos/app/api/analytics/store-postgres/funnels.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/funnels.ts
@@ -53,7 +53,7 @@ export async function trackFunnelStep(step: {
   stepOrder: number;
   metadata?: Record<string, unknown>;
 }): Promise<FunnelStep> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // Build the data object for JSON storage
   const eventData = buildFunnelStepData({
@@ -86,7 +86,7 @@ export async function getFunnelSteps(
   startDate?: string,
   endDate?: string
 ): Promise<FunnelStep[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
 
   const events = await prisma.analyticsEvent.findMany({

--- a/apps/psypnos/app/api/analytics/store-postgres/goals.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/goals.ts
@@ -109,7 +109,7 @@ export async function createGoal(goal: {
   value?: number;
   enabled: boolean;
 }): Promise<Goal> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const result = await prisma.analyticsGoal.create({
     data: {
@@ -135,7 +135,7 @@ export async function createGoal(goal: {
  * Get all goals
  */
 export async function getGoals(): Promise<Goal[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const goals = await prisma.analyticsGoal.findMany({
     where: { siteId },

--- a/apps/psypnos/app/api/analytics/store-postgres/page-visits.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/page-visits.ts
@@ -74,7 +74,7 @@ export async function trackPageVisit(pageVisit: {
   timeOnPage?: number;
   isBot?: boolean;
 }): Promise<PageVisit> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const eventData = buildPageVisitData({
     referrer: pageVisit.referrer,
@@ -123,7 +123,7 @@ export async function getPageVisits(
   endDate?: string,
   limit: number = DEFAULT_PAGE_LIMIT
 ): Promise<PageVisit[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
 
   const visits = await prisma.analyticsEvent.findMany({
@@ -140,7 +140,7 @@ export async function getPageVisits(
 }
 
 export async function getPageVisitsBySession(sessionId: string): Promise<PageVisit[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const visits = await prisma.analyticsEvent.findMany({
     where: {
@@ -162,7 +162,7 @@ export async function getTopPages(
   endDate?: string,
   limit: number = 10
 ): Promise<Array<{ page: string; visits: number; uniqueSessions: number }>> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // Build parameterized SQL query for safe aggregation
   const params: unknown[] = [siteId, 'PAGE_VIEW'];

--- a/apps/psypnos/app/api/analytics/store-postgres/reports.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/reports.ts
@@ -93,7 +93,7 @@ export async function createScheduledReport(report: {
   >;
   enabled: boolean;
 }): Promise<ScheduledReport> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // Store extended data in the metrics JSON field
   const metrics = {
@@ -125,7 +125,7 @@ export async function createScheduledReport(report: {
 export async function getScheduledReports(
   enabledOnly: boolean = false
 ): Promise<ScheduledReport[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   const reports = await prisma.analyticsScheduledReport.findMany({
     where: {

--- a/apps/psypnos/app/api/analytics/store-postgres/section-times.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/section-times.ts
@@ -49,7 +49,7 @@ export async function trackSectionTime(sectionTime: {
   section: string;
   timeSpent: number;
 }): Promise<SectionTime> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // Build the data object for JSON storage
   const eventData = buildSectionTimeData({
@@ -79,7 +79,7 @@ export async function getSectionTimes(
   startDate?: string,
   endDate?: string
 ): Promise<SectionTime[]> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
 
   const times = await prisma.analyticsEvent.findMany({
@@ -107,7 +107,7 @@ export async function getSectionTimeStats(
   viewCount: number;
   uniqueSessions: number;
 }>> {
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
   const dateFilter = buildDateFilter(startDate, endDate);
 
   const events = await prisma.analyticsEvent.findMany({

--- a/apps/psypnos/app/api/analytics/store-postgres/utils.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/utils.ts
@@ -108,13 +108,78 @@ export function fromEventType(type: EventType): string {
 // =============================================================================
 
 /**
- * Gets the current site ID from environment or returns default.
- * In a multi-tenant setup, this would be resolved from the request context.
+ * Cached site ID — resolved once from the database, then reused for all
+ * subsequent calls within the same process lifetime.
  */
-export function getCurrentSiteId(): string {
-  // For now, use environment variable or default
-  // In production, this should come from request context/middleware
-  return process.env.SITE_ID || process.env.NEXT_PUBLIC_SITE_ID || "default";
+let cachedSiteId: string | null = null;
+
+/**
+ * Gets the current site ID.
+ *
+ * Resolution order:
+ * 1. In-memory cache (fastest — set after first DB lookup)
+ * 2. `SITE_ID` or `NEXT_PUBLIC_SITE_ID` environment variable
+ * 3. Database lookup by site slug (defaults to "psypnos")
+ *
+ * The result is cached in memory so subsequent calls are synchronous-speed.
+ * This function MUST be awaited because the first call may hit the database.
+ */
+export async function getCurrentSiteId(): Promise<string> {
+  // Fast path: already resolved
+  if (cachedSiteId) return cachedSiteId;
+
+  // Try environment variables
+  const envId = process.env.SITE_ID || process.env.NEXT_PUBLIC_SITE_ID;
+  if (envId && envId !== "default") {
+    cachedSiteId = envId;
+    return envId;
+  }
+
+  // Look up the site from the database by slug
+  try {
+    const { prisma } = await import("@/lib/db/prisma");
+    const slug = process.env.NEXT_PUBLIC_SITE_SLUG || "psypnos";
+
+    const site = await prisma.site.findFirst({
+      where: { slug, isActive: true },
+      select: { id: true },
+    });
+
+    if (site) {
+      cachedSiteId = site.id;
+      return site.id;
+    }
+
+    // Fallback: grab the first active site (single-tenant deployments)
+    const fallbackSite = await prisma.site.findFirst({
+      where: { isActive: true },
+      select: { id: true },
+    });
+
+    if (fallbackSite) {
+      cachedSiteId = fallbackSite.id;
+      console.warn(
+        `[Analytics] No site found for slug "${slug}", using fallback site ${fallbackSite.id}`
+      );
+      return fallbackSite.id;
+    }
+  } catch (error) {
+    console.error("[Analytics] Failed to resolve site ID from database:", error);
+  }
+
+  // Last resort — will cause FK errors but at least logs help debugging
+  console.error(
+    "[Analytics] CRITICAL: No site found in database. Analytics data will NOT be persisted. " +
+    "Ensure a Site record exists or set the SITE_ID environment variable."
+  );
+  return "default";
+}
+
+/**
+ * Resets the cached site ID (for tests).
+ */
+export function resetCachedSiteId(): void {
+  cachedSiteId = null;
 }
 
 // =============================================================================

--- a/apps/psypnos/app/api/analytics/track/route.ts
+++ b/apps/psypnos/app/api/analytics/track/route.ts
@@ -412,7 +412,7 @@ async function trackGeolocation(
   const { prisma } = await import('@/lib/db/prisma');
   const { getCurrentSiteId } = await import('../store-postgres/utils');
 
-  const siteId = getCurrentSiteId();
+  const siteId = await getCurrentSiteId();
 
   // Use upsert to avoid race conditions between concurrent requests
   // for the same session (findFirst + create is not atomic)


### PR DESCRIPTION
getCurrentSiteId() was returning "default" when env vars were unset, causing
FK constraint failures and analytics data not being persisted. Now it resolves
the actual site ID from the database (with in-memory caching), and all 15
callers have been updated to await the now-async function.

https://claude.ai/code/session_016J2aHkU8RWKE6RRMyq2s4L