### PR TITLE
fix(forms): resolve phone validation mismatch and stale closure bugs in form validation

### DIFF
--- a/apps/psypnos/app/api/appointment-request/route.ts
+++ b/apps/psypnos/app/api/appointment-request/route.ts
@@ -31,8 +31,11 @@ const referralValues = [
   'autre',
 ] as const;
 
-// Regex pour validation téléphone français ou international
+// Regex pour validation téléphone français ou international (chiffres contigus après normalisation)
 const phoneRegex = /^(\+33|0)[1-9](\d{2}){4}$|^\+?\d{10,15}$/;
+
+// Supprime espaces, tirets, points et parenthèses pour normaliser un numéro de téléphone
+const normalizePhone = (value: string) => value.replace(/[\s.\-()]/g, '');
 
 const requestSchema = z.object({
   name: z.string().trim().min(2).max(100),
@@ -40,7 +43,7 @@ const requestSchema = z.object({
   phone: z
     .string()
     .optional()
-    .transform(value => value?.trim() ?? '')
+    .transform(value => normalizePhone(value?.trim() ?? ''))
     .refine(value => !value || phoneRegex.test(value), {
       message: 'Format de téléphone invalide',
     }),

--- a/apps/psypnos/app/api/quick-contact/route.ts
+++ b/apps/psypnos/app/api/quick-contact/route.ts
@@ -21,6 +21,9 @@ const requestTypeValues = ['', 'premiere_consultation', 'question_generale', 'se
 
 const phoneRegex = /^(\+33|0)[1-9](\d{2}){4}$|^\+?\d{10,15}$/;
 
+// Supprime espaces, tirets, points et parenthèses pour normaliser un numéro de téléphone
+const normalizePhone = (value: string) => value.replace(/[\s.\-()]/g, '');
+
 const quickContactSchema = z.object({
   firstName: z.string().trim().min(2, 'Le prénom est requis').max(50),
   lastName: z.string().trim().min(2, 'Le nom est requis').max(50),
@@ -28,7 +31,7 @@ const quickContactSchema = z.object({
   phone: z
     .string()
     .optional()
-    .transform(value => value?.trim().replace(/\s/g, '') ?? '')
+    .transform(value => normalizePhone(value?.trim() ?? ''))
     .refine(value => !value || phoneRegex.test(value), {
       message: 'Format de téléphone invalide',
     }),

--- a/apps/psypnos/components/AppointmentRequestForm.tsx
+++ b/apps/psypnos/components/AppointmentRequestForm.tsx
@@ -39,11 +39,14 @@ const appointmentRequestSchema = z
     phone: z
       .string()
       .optional()
-      .transform(value => value?.trim() ?? '')
-      .refine(value => value.length === 0 || /^[+0-9\s().-]{6,}$/u.test(value), {
-        message:
-          'Format de téléphone invalide. Utilisez le format : 06 12 34 56 78 ou +33 6 12 34 56 78',
-      }),
+      .transform(value => (value?.trim() ?? '').replace(/[\s.\-()]/g, ''))
+      .refine(
+        value => value.length === 0 || /^(\+33|0)[1-9](\d{2}){4}$|^\+?\d{10,15}$/.test(value),
+        {
+          message:
+            'Format de téléphone invalide. Utilisez le format : 06 12 34 56 78 ou +33 6 12 34 56 78',
+        }
+      ),
     contact_preference: z.enum(contactPreferenceValues),
     reason: z
       .string()
@@ -85,7 +88,6 @@ const appointmentRequestSchema = z
     name: data.name.trim(),
     reason: data.reason.trim(),
     availability: data.availability?.trim?.() ?? data.availability,
-    phone: data.phone?.trim?.() ?? data.phone,
   }));
 
 type AppointmentRequestData = z.infer<typeof appointmentRequestSchema>;

--- a/apps/psypnos/components/FloatingContactButton.tsx
+++ b/apps/psypnos/components/FloatingContactButton.tsx
@@ -221,6 +221,10 @@ function ContactModal({ isOpen, onClose }: ContactModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const firstFocusableRef = useRef<HTMLButtonElement>(null);
 
+  // Ref toujours à jour pour éviter les closures périmées dans handleBlur
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
   // Reset form when modal closes
   useEffect(() => {
     if (!isOpen) {
@@ -287,29 +291,37 @@ function ContactModal({ isOpen, onClose }: ContactModalProps) {
 
         setValues(prev => ({ ...prev, [field]: value }));
 
-        // Clear error on change
-        if (errors[field]) {
-          setErrors(prev => {
-            const newErrors = { ...prev };
-            delete newErrors[field];
-            return newErrors;
-          });
-        }
+        // Toujours nettoyer l'erreur du champ modifié via le setter fonctionnel
+        // (évite de dépendre de la closure `errors` qui peut être périmée)
+        setErrors(prev => {
+          if (!prev[field]) return prev;
+          const newErrors = { ...prev };
+          delete newErrors[field];
+          return newErrors;
+        });
       },
-    [errors]
+    []
   );
 
   const handleBlur = useCallback(
     (field: keyof FormValues) => () => {
       setTouched(prev => ({ ...prev, [field]: true }));
 
-      // Validate single field
-      const fieldErrors = validateForm(values);
+      // Utiliser valuesRef pour toujours avoir les valeurs les plus récentes
+      const fieldErrors = validateForm(valuesRef.current);
       if (fieldErrors[field]) {
         setErrors(prev => ({ ...prev, [field]: fieldErrors[field] }));
+      } else {
+        // Nettoyer l'erreur si le champ est désormais valide
+        setErrors(prev => {
+          if (!prev[field]) return prev;
+          const newErrors = { ...prev };
+          delete newErrors[field];
+          return newErrors;
+        });
       }
     },
-    [values]
+    []
   );
 
   const handleSubmit = useCallback(

--- a/packages/ui/src/components/floating-contact-button/FloatingContactButton.tsx
+++ b/packages/ui/src/components/floating-contact-button/FloatingContactButton.tsx
@@ -313,6 +313,10 @@ function ContactModal({
   const modalRef = useRef<HTMLDivElement>(null);
   const firstFocusableRef = useRef<HTMLButtonElement>(null);
 
+  // Ref toujours à jour pour éviter les closures périmées dans handleBlur
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
   // Reset form when modal closes
   useEffect(() => {
     if (!isOpen) {
@@ -375,30 +379,42 @@ function ContactModal({
 
         setValues(prev => ({ ...prev, [field]: value }));
 
-        if (errors[field as keyof FormValidationErrors]) {
-          setErrors(prev => {
-            const newErrors = { ...prev };
-            delete newErrors[field as keyof FormValidationErrors];
-            return newErrors;
-          });
-        }
+        // Toujours nettoyer l'erreur du champ modifié via le setter fonctionnel
+        // (évite de dépendre de la closure `errors` qui peut être périmée)
+        setErrors(prev => {
+          if (!prev[field as keyof FormValidationErrors]) return prev;
+          const newErrors = { ...prev };
+          delete newErrors[field as keyof FormValidationErrors];
+          return newErrors;
+        });
       },
-    [errors]
+    []
   );
 
   const handleBlur = useCallback(
     (field: keyof FormValues) => () => {
       setTouched(prev => ({ ...prev, [field]: true }));
 
-      const fieldErrors = validateForm(values, labels);
-      if (fieldErrors[field as keyof FormValidationErrors]) {
+      // Utiliser valuesRef pour toujours avoir les valeurs les plus récentes
+      // (la closure `values` peut être périmée si onChange et onBlur se suivent dans le même cycle)
+      const fieldErrors = validateForm(valuesRef.current, labels);
+      const fieldKey = field as keyof FormValidationErrors;
+      if (fieldErrors[fieldKey]) {
         setErrors(prev => ({
           ...prev,
-          [field]: fieldErrors[field as keyof FormValidationErrors],
+          [fieldKey]: fieldErrors[fieldKey],
         }));
+      } else {
+        // Nettoyer l'erreur si le champ est désormais valide
+        setErrors(prev => {
+          if (!prev[fieldKey]) return prev;
+          const newErrors = { ...prev };
+          delete newErrors[fieldKey];
+          return newErrors;
+        });
       }
     },
-    [values, labels]
+    [labels]
   );
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
Bug #1 (Appointment Request): Phone numbers with spaces/dashes/dots (e.g. "06 12 34 56 78")
passed frontend validation but were rejected by the backend, causing "Données invalides" errors
and no email being sent. Fix: normalize phone numbers (strip formatting characters) before
validation on both frontend and backend.

Bug #2 (Quick Contact FAB): handleBlur and handleFieldChange used stale closures for `values`
and `errors`, causing phantom validation errors on valid fields. Fix: use a ref for fresh values
in handleBlur, use functional state updaters in handleFieldChange, and clear errors on blur
when the field becomes valid.

https://claude.ai/code/session_01HdGtLrLHvfHScGjufWuG51