### PR TITLE
fix(analytics): resolve empty popular pages and inconsistent KPIs per period

### DIFF
--- a/apps/psypnos/app/api/analytics/dashboard/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/route.ts
@@ -16,6 +16,7 @@ import {
   getSectionHeatmap,
   getVisitsByPeriod,
   getPageVisits,
+  getTopPages,
   getTrafficSources,
   getDeviceBreakdown,
   getGoalsSummary,
@@ -161,6 +162,7 @@ export async function GET(request: NextRequest) {
           comparison,
           heatmap,
           visits,
+          topPages,
           trafficSources,
           deviceBreakdown,
           geoData,
@@ -174,10 +176,12 @@ export async function GET(request: NextRequest) {
             console.error('[Dashboard] getAnalyticsSummary failed:', err);
             return defaultSummary;
           }),
-          getAnalyticsSummaryWithComparison(comparisonTimeRange).catch((err: unknown) => {
-            console.error('[Dashboard] getAnalyticsSummaryWithComparison failed:', err);
-            return { current: defaultSummary, previous: defaultSummary, comparison: {} };
-          }),
+          getAnalyticsSummaryWithComparison(comparisonTimeRange, startISO, endISO).catch(
+            (err: unknown) => {
+              console.error('[Dashboard] getAnalyticsSummaryWithComparison failed:', err);
+              return { current: defaultSummary, previous: defaultSummary, comparison: {} };
+            }
+          ),
           getSectionHeatmap(startISO, endISO).catch((err: unknown) => {
             console.error('[Dashboard] getSectionHeatmap failed:', err);
             return [];
@@ -187,6 +191,10 @@ export async function GET(request: NextRequest) {
             : getVisitsByPeriod(comparisonTimeRange, startISO, endISO)
           ).catch((err: unknown) => {
             console.error('[Dashboard] getVisits failed:', err);
+            return [];
+          }),
+          getTopPages(startISO, endISO, 10).catch((err: unknown) => {
+            console.error('[Dashboard] getTopPages failed:', err);
             return [];
           }),
           getTrafficSources(startISO, endISO).catch((err: unknown) => {
@@ -218,6 +226,7 @@ export async function GET(request: NextRequest) {
           comparison,
           heatmap,
           visits,
+          topPages,
           trafficSources,
           deviceBreakdown,
           geoData,

--- a/apps/psypnos/app/api/analytics/store-index.ts
+++ b/apps/psypnos/app/api/analytics/store-index.ts
@@ -14,7 +14,7 @@
  */
 
 // Page Visits
-export { trackPageVisit, getPageVisits } from './store-postgres/page-visits';
+export { trackPageVisit, getPageVisits, getTopPages } from './store-postgres/page-visits';
 
 // Section Times
 export { trackSectionTime, getSectionTimes } from './store-postgres/section-times';

--- a/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
@@ -101,7 +101,7 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
 
       for (const st of sectionTimeStats) {
         const data = (st.data as Record<string, unknown>) || {};
-        const timeSpent = (typeof data.timeSpent === 'number' ? data.timeSpent : 0);
+        const timeSpent = typeof data.timeSpent === 'number' ? data.timeSpent : 0;
 
         if (st.sessionId) {
           sessionDurations.set(st.sessionId, (sessionDurations.get(st.sessionId) || 0) + timeSpent);
@@ -130,7 +130,8 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
         .slice(0, 5);
 
       // Conversion summary from groupBy
-      const conversionByType: Record<string, { clicks: number; completed: number; rate: number }> = {};
+      const conversionByType: Record<string, { clicks: number; completed: number; rate: number }> =
+        {};
       let totalClicks = 0;
 
       for (const group of conversionStats) {
@@ -205,7 +206,9 @@ export async function getVisitsByPeriod(
     cacheKey,
     async () => {
       const siteId = await getCurrentSiteId();
-      const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const start = startDate
+        ? new Date(startDate)
+        : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
       // Use raw SQL for date_trunc aggregation
@@ -233,47 +236,68 @@ export async function getVisitsByPeriod(
 }
 
 /**
- * Get analytics summary with comparison to previous period
+ * Get analytics summary with comparison to the previous period.
+ *
+ * When explicit startDate / endDate are provided (the normal case from the
+ * dashboard route), the "current" period is exactly [startDate, endDate] and
+ * the "previous" period is the same-length window immediately before it.
+ * This keeps the KPIs aligned with the chart data.
+ *
+ * The legacy `timeRange`-only signature (no dates) is kept as a fallback
+ * but should no longer be used by new code.
+ *
+ * All date arithmetic uses UTC to stay consistent with PostgreSQL date_trunc().
  */
 export async function getAnalyticsSummaryWithComparison(
-  timeRange: 'day' | 'week' | 'month' | 'year'
+  timeRange: 'day' | 'week' | 'month' | 'year',
+  startDateISO?: string,
+  endDateISO?: string
 ) {
-  const now = new Date();
-  let currentStart = new Date();
-  const currentEnd = new Date(now);
-  currentEnd.setHours(23, 59, 59, 999);
+  let currentStart: Date;
+  let currentEnd: Date;
+  let previousStart: Date;
+  let previousEnd: Date;
 
-  let previousStart = new Date();
-  let previousEnd = new Date();
+  if (startDateISO && endDateISO) {
+    // ── Explicit date range from the dashboard query ──────────────
+    // Mirror the exact same duration for the previous period.
+    currentStart = new Date(startDateISO);
+    currentEnd = new Date(endDateISO);
 
-  if (timeRange === 'day') {
-    currentStart = new Date(now);
-    currentStart.setHours(0, 0, 0, 0);
-    previousEnd = new Date(currentStart);
-    previousEnd.setDate(previousEnd.getDate() - 1);
-    previousEnd.setHours(23, 59, 59, 999);
-    previousStart = new Date(previousEnd);
-    previousStart.setHours(0, 0, 0, 0);
-  } else if (timeRange === 'week') {
-    const dayOfWeek = now.getDay();
-    const diff = now.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
-    currentStart = new Date(now.setDate(diff));
-    currentStart.setHours(0, 0, 0, 0);
-    previousStart = new Date(currentStart);
-    previousStart.setDate(previousStart.getDate() - 7);
-    previousEnd = new Date(currentStart);
-    previousEnd.setDate(previousEnd.getDate() - 1);
-    previousEnd.setHours(23, 59, 59, 999);
-  } else if (timeRange === 'month') {
-    currentStart = new Date(now.getFullYear(), now.getMonth(), 1);
-    previousStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-    previousEnd = new Date(now.getFullYear(), now.getMonth(), 0);
-    previousEnd.setHours(23, 59, 59, 999);
-  } else if (timeRange === 'year') {
-    currentStart = new Date(now.getFullYear(), 0, 1);
-    previousStart = new Date(now.getFullYear() - 1, 0, 1);
-    previousEnd = new Date(now.getFullYear() - 1, 11, 31);
-    previousEnd.setHours(23, 59, 59, 999);
+    const durationMs = currentEnd.getTime() - currentStart.getTime();
+    previousEnd = new Date(currentStart.getTime() - 1); // 1 ms before current start
+    previousStart = new Date(previousEnd.getTime() - durationMs);
+  } else {
+    // ── Legacy fallback: derive dates from timeRange ─────────────
+    const now = new Date();
+    currentEnd = new Date(now);
+    currentEnd.setUTCHours(23, 59, 59, 999);
+
+    if (timeRange === 'day') {
+      currentStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+      previousEnd = new Date(currentStart.getTime() - 1);
+      previousStart = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1)
+      );
+    } else if (timeRange === 'week') {
+      const dayOfWeek = now.getUTCDay();
+      const diff = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      currentStart = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + diff)
+      );
+      previousEnd = new Date(currentStart.getTime() - 1);
+      previousStart = new Date(currentStart);
+      previousStart.setUTCDate(previousStart.getUTCDate() - 7);
+    } else if (timeRange === 'month') {
+      currentStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      previousStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+      previousEnd = new Date(currentStart.getTime() - 1);
+    } else {
+      // year
+      currentStart = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+      previousStart = new Date(Date.UTC(now.getUTCFullYear() - 1, 0, 1));
+      previousEnd = new Date(currentStart.getTime() - 1);
+    }
   }
 
   const [currentSummary, previousSummary] = await Promise.all([
@@ -299,8 +323,14 @@ export async function getAnalyticsSummaryWithComparison(
     },
     comparison: {
       totalVisitsChange: calcChange(currentSummary.totalVisits, previousSummary.totalVisits),
-      uniqueSessionsChange: calcChange(currentSummary.uniqueSessions, previousSummary.uniqueSessions),
-      averageTimeOnSiteChange: calcChange(currentSummary.averageTimeOnSite, previousSummary.averageTimeOnSite),
+      uniqueSessionsChange: calcChange(
+        currentSummary.uniqueSessions,
+        previousSummary.uniqueSessions
+      ),
+      averageTimeOnSiteChange: calcChange(
+        currentSummary.averageTimeOnSite,
+        previousSummary.averageTimeOnSite
+      ),
       conversionRateChange: currentSummary.conversionRate - previousSummary.conversionRate,
     },
   };
@@ -319,7 +349,9 @@ export async function getSectionHeatmap(startDate?: string, endDate?: string) {
     cacheKey,
     async () => {
       const siteId = await getCurrentSiteId();
-      const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const start = startDate
+        ? new Date(startDate)
+        : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
       // Get total unique sessions for scroll rate calculation
@@ -335,12 +367,14 @@ export async function getSectionHeatmap(startDate?: string, endDate?: string) {
       const totalSessionCount = totalSessions.length;
 
       // Get section stats using raw SQL for JSON extraction + aggregation
-      const sectionResults = await prisma.$queryRaw<Array<{
-        section: string;
-        visitors: bigint;
-        avg_time_ms: number;
-        view_count: bigint;
-      }>>`
+      const sectionResults = await prisma.$queryRaw<
+        Array<{
+          section: string;
+          visitors: bigint;
+          avg_time_ms: number;
+          view_count: bigint;
+        }>
+      >`
         SELECT
           "name" as section,
           COUNT(DISTINCT "sessionId") as visitors,
@@ -361,9 +395,10 @@ export async function getSectionHeatmap(startDate?: string, endDate?: string) {
         section: row.section,
         visitors: Number(row.visitors),
         avgTimeSeconds: Math.round((row.avg_time_ms || 0) / 1000),
-        scrollRate: totalSessionCount > 0
-          ? parseFloat(((Number(row.visitors) / totalSessionCount) * 100).toFixed(1))
-          : 0,
+        scrollRate:
+          totalSessionCount > 0
+            ? parseFloat(((Number(row.visitors) / totalSessionCount) * 100).toFixed(1))
+            : 0,
         conversionsFromSection: 0,
         conversionsByType: {},
       }));
@@ -385,15 +420,19 @@ export async function getTrafficSources(startDate?: string, endDate?: string) {
     cacheKey,
     async () => {
       const siteId = await getCurrentSiteId();
-      const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const start = startDate
+        ? new Date(startDate)
+        : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
-      const results = await prisma.$queryRaw<Array<{
-        source: string;
-        medium: string;
-        visits: bigint;
-        unique_sessions: bigint;
-      }>>`
+      const results = await prisma.$queryRaw<
+        Array<{
+          source: string;
+          medium: string;
+          visits: bigint;
+          unique_sessions: bigint;
+        }>
+      >`
         SELECT
           COALESCE(data->>'utmSource', data->>'referrerDomain', 'direct') as source,
           COALESCE(data->>'utmMedium', 'none') as medium,
@@ -434,14 +473,18 @@ export async function getDeviceBreakdown(startDate?: string, endDate?: string) {
     cacheKey,
     async () => {
       const siteId = await getCurrentSiteId();
-      const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const start = startDate
+        ? new Date(startDate)
+        : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
-      const results = await prisma.$queryRaw<Array<{
-        device_type: string;
-        visits: bigint;
-        unique_sessions: bigint;
-      }>>`
+      const results = await prisma.$queryRaw<
+        Array<{
+          device_type: string;
+          visits: bigint;
+          unique_sessions: bigint;
+        }>
+      >`
         SELECT
           COALESCE(data->>'deviceType', 'unknown') as device_type,
           COUNT(*) as visits,

--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -519,17 +519,14 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
         }
       });
 
-      // Build top pages from section data
-      const topSections = dashboardData.summary?.topSections || [];
-      const totalSectionVisits = topSections.reduce(
-        (sum: number, s: any) => sum + (s.visits || 0),
-        0
-      );
-      const topPages: TopPage[] = topSections.map((section: any) => ({
-        path: section.section || 'Unknown',
-        views: section.visits || 0,
-        uniqueVisitors: section.uniqueSessions ?? section.visitors ?? section.visits ?? 0,
-        percentage: totalSectionVisits > 0 ? ((section.visits || 0) / totalSectionVisits) * 100 : 0,
+      // Build top pages from actual PAGE_VIEW aggregation (getTopPages)
+      const rawTopPages = dashboardData.topPages || [];
+      const totalPageVisits = rawTopPages.reduce((sum: number, p: any) => sum + (p.visits || 0), 0);
+      const topPages: TopPage[] = rawTopPages.map((page: any) => ({
+        path: page.page || 'Unknown',
+        views: page.visits || 0,
+        uniqueVisitors: page.uniqueSessions ?? page.visits ?? 0,
+        percentage: totalPageVisits > 0 ? ((page.visits || 0) / totalPageVisits) * 100 : 0,
       }));
 
       // Build section engagement data
@@ -757,22 +754,16 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
       const analyticsData: AnalyticsData = {
         healthScore,
         kpis: {
-          visitors:
-            dashboardData.comparison?.current?.totalVisits ||
-            dashboardData.summary?.totalVisits ||
-            0,
+          // Use summary (covers the actual selected period) as the primary
+          // source for current values. comparison.comparison provides the
+          // percentage change vs the mirror previous period.
+          visitors: dashboardData.summary?.totalVisits || 0,
           visitorsChange: dashboardData.comparison?.comparison?.totalVisitsChange || 0,
-          conversionRate:
-            dashboardData.comparison?.current?.conversionRate ||
-            dashboardData.summary?.conversionRate ||
-            0,
+          conversionRate: dashboardData.summary?.conversionRate || 0,
           conversionChange: dashboardData.comparison?.comparison?.conversionRateChange || 0,
-          avgDuration:
-            (dashboardData.comparison?.current?.averageTimeOnSite ||
-              dashboardData.summary?.averageTimeOnSite ||
-              0) / 1000,
+          avgDuration: (dashboardData.summary?.averageTimeOnSite || 0) / 1000,
           durationChange:
-            ((dashboardData.comparison?.comparison?.averageTimeOnSiteChange || 0) / 100) * 60, // convert % to seconds estimate
+            ((dashboardData.comparison?.comparison?.averageTimeOnSiteChange || 0) / 100) * 60,
         },
         trafficChart: chartData,
         topPages,


### PR DESCRIPTION
Bug 1 – Popular pages always empty:
topPages was derived from SECTION_TIME events (page sections like "hero",
"services") instead of PAGE_VIEW events. Added getTopPages() call to the
dashboard route and wired the frontend to use actual page path aggregation.

Bug 2 – KPIs inconsistent with chart data per selected period:
getAnalyticsSummaryWithComparison() computed its own date ranges from the
timeRange granularity (day/week/month/year), ignoring the actual period.
For "last30days" it compared today vs yesterday instead of 30d vs prev 30d.
Refactored to accept explicit start/end dates and mirror the exact period
duration for comparison.

Bug 3 – Local timezone in comparison calculations:
Replaced all setHours() calls with setUTCHours()/Date.UTC() to stay
consistent with PostgreSQL's date_trunc() which operates in UTC.

https://claude.ai/code/session_01XyRtbgDoeCTPrCLUSvmgnH