### PR TITLE
fix(analytics): resolve all-zeros graph for non-realtime periods (last7days, last30days, etc.)

### DIFF
--- a/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
@@ -12,6 +12,9 @@ import { prisma } from '@/lib/db/prisma';
 
 import { buildDateFilter, getCurrentSiteId } from './utils';
 
+/** Whitelist of valid PostgreSQL date_trunc precision values */
+const VALID_DATE_TRUNC_PERIODS = new Set(['microseconds', 'milliseconds', 'second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year', 'decade', 'century', 'millennium']);
+
 /**
  * Get analytics summary for a date range using SQL aggregations
  */
@@ -189,13 +192,40 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
 }
 
 /**
- * Get visits aggregated by time period using SQL date_trunc
+ * Get visits aggregated by time period using SQL date_trunc.
+ *
+ * IMPORTANT: The `period` parameter is injected as a raw SQL literal (via
+ * Prisma.raw) rather than as a parameterised value.  This is necessary
+ * because Prisma's tagged-template $queryRaw creates a SEPARATE positional
+ * parameter ($N) for every interpolation, even when the same JS variable is
+ * referenced twice.  Using ${period} in both the SELECT and GROUP BY clauses
+ * produced `date_trunc($1, …)` vs `date_trunc($5, …)` — two distinct
+ * parameter references that PostgreSQL could not prove equivalent at parse
+ * time, causing:
+ *   ERROR: column "…" must appear in the GROUP BY clause or be used in an
+ *          aggregate function
+ * The error was silently swallowed by the dashboard route's .catch() handler,
+ * resulting in an empty visits array and an all-zeros chart.
+ *
+ * Safety: the value is validated against a strict whitelist before injection.
+ *
+ * Additionally, GROUP BY 1 is used (positional reference to the first SELECT
+ * expression) to guarantee structural equivalence in all PostgreSQL versions.
+ *
+ * The returned `period` field is normalised to an ISO-8601 string so that
+ * downstream consumers (Redis cache, JSON serialisation, frontend Date
+ * parsing) all receive a consistent, unambiguous format.
  */
 export async function getVisitsByPeriod(
   period: 'hour' | 'day' | 'week' | 'month' | 'year',
   startDate?: string,
   endDate?: string
 ) {
+  // Validate period against whitelist to prevent SQL injection
+  if (!VALID_DATE_TRUNC_PERIODS.has(period)) {
+    throw new Error(`Invalid date_trunc period: "${period}"`);
+  }
+
   const cacheKey = buildCacheKey(CACHE_KEYS.VISITS_BY_PERIOD, {
     period,
     start: startDate,
@@ -211,10 +241,13 @@ export async function getVisitsByPeriod(
         : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
-      // Use raw SQL for date_trunc aggregation
-      const results = await prisma.$queryRaw<Array<{ period: string; visits: bigint }>>`
+      // Inject the period as a raw SQL literal — safe because we validated
+      // it against VALID_DATE_TRUNC_PERIODS above.
+      const periodLiteral = Prisma.raw(`'${period}'`);
+
+      const results = await prisma.$queryRaw<Array<{ period: Date; visits: bigint }>>`
         SELECT
-          date_trunc(${period}, "createdAt") as period,
+          date_trunc(${periodLiteral}, "createdAt") as period,
           COUNT(*) as visits
         FROM "AnalyticsEvent"
         WHERE "siteId" = ${siteId}
@@ -222,12 +255,16 @@ export async function getVisitsByPeriod(
           AND "createdAt" >= ${start}
           AND "createdAt" <= ${end}
           AND (data->>'isBot' IS NULL OR data->>'isBot' != 'true')
-        GROUP BY date_trunc(${period}, "createdAt")
-        ORDER BY period ASC
+        GROUP BY 1
+        ORDER BY 1 ASC
       `;
 
+      // Normalise period to ISO-8601 string for consistent serialisation.
+      // Prisma returns timestamp columns as Date objects; after Redis
+      // round-tripping they become strings — normalising here removes the
+      // ambiguity.
       return results.map(r => ({
-        period: r.period,
+        period: (r.period instanceof Date ? r.period : new Date(r.period)).toISOString(),
         visits: Number(r.visits),
       }));
     },

--- a/apps/psypnos/components/analytics/v2/utils/chartDateUtils.ts
+++ b/apps/psypnos/components/analytics/v2/utils/chartDateUtils.ts
@@ -631,6 +631,10 @@ export interface Visit {
  *
  * Uses UTC normalization to match PostgreSQL's date_trunc() and the
  * UTC-based bucket timestamps.
+ *
+ * If exact timestamp matching fails (due to serialisation quirks, timezone
+ * drift, or millisecond rounding), a nearest-bucket fallback is used to
+ * guarantee that visits are never silently dropped.
  */
 export const aggregateVisitsIntoBuckets = (
   buckets: ChartBucket[],
@@ -646,11 +650,16 @@ export const aggregateVisitsIntoBuckets = (
   // Clone buckets to avoid mutation
   const result = buckets.map(b => ({ ...b }));
 
+  if (result.length === 0) return result;
+
   // Create a timestamp-to-index map for O(1) lookups
   const timestampToIndex = new Map<number, number>();
   result.forEach((bucket, index) => {
     timestampToIndex.set(bucket.timestamp, index);
   });
+
+  // Pre-sort bucket timestamps for nearest-bucket binary search fallback
+  const sortedBucketTimestamps = Array.from(timestampToIndex.keys()).sort((a, b) => a - b);
 
   // Aggregate visits
   visits.forEach(visit => {
@@ -667,7 +676,43 @@ export const aggregateVisitsIntoBuckets = (
       customStartDate,
       customEndDate
     );
-    const bucketIndex = timestampToIndex.get(normalizedDate.getTime());
+    let bucketIndex = timestampToIndex.get(normalizedDate.getTime());
+
+    // Fallback: find nearest bucket if exact match fails.
+    // This handles edge cases such as minor timestamp discrepancies from
+    // serialisation (Date ↔ string round-trips) or timezone offsets.
+    if (bucketIndex === undefined && sortedBucketTimestamps.length > 0) {
+      const ts = normalizedDate.getTime();
+      let lo = 0;
+      let hi = sortedBucketTimestamps.length - 1;
+
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (sortedBucketTimestamps[mid]! <= ts) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+
+      // lo is the index of the first bucket timestamp > ts.
+      // The best candidate is either lo-1 (bucket ≤ ts) or lo.
+      const candidates = [lo - 1, lo].filter(
+        i => i >= 0 && i < sortedBucketTimestamps.length
+      );
+      let bestTs = sortedBucketTimestamps[candidates[0]!]!;
+      let bestDist = Math.abs(ts - bestTs);
+      for (const c of candidates) {
+        const candidateTs = sortedBucketTimestamps[c]!;
+        const dist = Math.abs(ts - candidateTs);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestTs = candidateTs;
+        }
+      }
+
+      bucketIndex = timestampToIndex.get(bestTs);
+    }
 
     if (bucketIndex !== undefined && result[bucketIndex]) {
       result[bucketIndex].value += visit.visits || 1;

--- a/apps/psypnos/lib/pwaDataMode.ts
+++ b/apps/psypnos/lib/pwaDataMode.ts
@@ -120,7 +120,18 @@ export function generateMockRawVisits(
 }
 
 /**
- * Génère des données de visites mockées pour une période donnée
+ * Génère des données de visites mockées pour une période donnée.
+ *
+ * IMPORTANT: Le champ `period` DOIT être un timestamp ISO-8601 complet
+ * (ex: "2026-02-19T00:00:00.000Z") pour être compatible avec le frontend
+ * (chartDateUtils.ts) qui le parse via `new Date(visit.period)`.
+ *
+ * Les anciens formats ("2026-W08", "2026-02", "2026") ne sont PAS parsables
+ * par `new Date()` et provoquaient des graphiques à zéro en mode simulation.
+ *
+ * Le format doit correspondre exactement à ce que retourne PostgreSQL via
+ * `date_trunc()` : un timestamp tronqué au début de la période (jour, lundi
+ * de la semaine, 1er du mois, 1er janvier).
  */
 export function generateMockVisits(
   timeRange: 'day' | 'week' | 'month' | 'year',
@@ -131,48 +142,50 @@ export function generateMockVisits(
   const data: Array<{ period: string; visits: number; sessions: number }> = [];
 
   if (timeRange === 'day') {
+    // Daily buckets: midnight UTC for each of the last 7 days
     for (let i = 6; i >= 0; i--) {
-      const date = new Date(now);
-      date.setDate(date.getDate() - i);
-      const dateStr = date.toISOString().split('T')[0];
+      const date = new Date(Date.UTC(
+        now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - i
+      ));
       data.push({
-        period: dateStr,
+        period: date.toISOString(),
         visits: randomInRange(80, 150),
         sessions: randomInRange(60, 120)
       });
     }
   } else if (timeRange === 'week') {
+    // Weekly buckets: Monday at midnight UTC (ISO week start, matches date_trunc('week'))
     for (let i = 11; i >= 0; i--) {
-      const date = new Date(now);
-      date.setDate(date.getDate() - (i * 7));
-      const tempDate = new Date(date);
-      tempDate.setDate(tempDate.getDate() + 4 - (tempDate.getDay() || 7));
-      const yearStart = new Date(tempDate.getFullYear(), 0, 1);
-      const weekNum = Math.ceil((((tempDate.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
-      const year = date.getFullYear();
-      const weekKey = `${year}-W${weekNum.toString().padStart(2, '0')}`;
+      const date = new Date(Date.UTC(
+        now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - (i * 7)
+      ));
+      // Align to Monday (ISO week start)
+      const dayOfWeek = date.getUTCDay();
+      const diff = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      date.setUTCDate(date.getUTCDate() + diff);
+      date.setUTCHours(0, 0, 0, 0);
       data.push({
-        period: weekKey,
+        period: date.toISOString(),
         visits: randomInRange(400, 800),
         sessions: randomInRange(300, 650)
       });
     }
   } else if (timeRange === 'month') {
+    // Monthly buckets: 1st of each month at midnight UTC (matches date_trunc('month'))
     for (let i = 11; i >= 0; i--) {
-      const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
-      const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+      const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));
       data.push({
-        period: monthKey,
+        period: date.toISOString(),
         visits: randomInRange(1500, 3000),
         sessions: randomInRange(1200, 2500)
       });
     }
   } else {
+    // Yearly buckets: January 1st at midnight UTC (matches date_trunc('year'))
     for (let i = 9; i >= 0; i--) {
-      const date = new Date(now.getFullYear() - i, 0, 1);
-      const yearKey = `${date.getFullYear()}`;
+      const date = new Date(Date.UTC(now.getUTCFullYear() - i, 0, 1));
       data.push({
-        period: yearKey,
+        period: date.toISOString(),
         visits: randomInRange(15000, 30000),
         sessions: randomInRange(12000, 25000)
       });


### PR DESCRIPTION
Root cause: Prisma's $queryRaw tagged-template creates separate positional
parameters ($1, $5) for each ${period} interpolation. Using the same JS
variable twice (SELECT and GROUP BY) produced two distinct SQL parameters
that PostgreSQL could not prove equivalent at parse time, causing a GROUP BY
error silently caught by .catch() — returning [] and rendering all-zeros.

Fix: inject the period as a raw SQL literal via Prisma.raw() with strict
whitelist validation, and use GROUP BY 1 (positional reference). Normalize
returned period timestamps to ISO-8601 strings for consistent serialization
across Redis cache round-trips and frontend Date parsing.

Also fix:
- generateMockVisits: produce ISO-8601 timestamps instead of unparseable
  formats ("2026-W08", "2026-02") that caused NaN in mock/PWA mode
- aggregateVisitsIntoBuckets: add nearest-bucket binary search fallback
  when exact timestamp matching fails due to serialization drift

https://claude.ai/code/session_01KmeJGMJmxw6BFrWZ6x5qQ8