### PR TITLE
fix(analytics): store page_exit/scroll_depth as proper EventTypes for engagement tracking

### DIFF
--- a/apps/psypnos/__tests__/unit/analytics-store-utils.test.ts
+++ b/apps/psypnos/__tests__/unit/analytics-store-utils.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for analytics store utility functions.
+ *
+ * Verifies that the data builder functions produce the correct structure
+ * for PAGE_EXIT and SCROLL_DEPTH events, and that the event type mapping
+ * covers the newly corrected event types.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildPageExitData,
+  buildCustomEventData,
+  buildSectionTimeData,
+  toEventType,
+  fromEventType,
+} from '../../app/api/analytics/store-postgres/utils';
+
+describe('analytics store-postgres/utils', () => {
+  describe('buildPageExitData', () => {
+    it('should include timeOnPage and scrollDepthPercent', () => {
+      const result = buildPageExitData({
+        timeOnPage: 45000,
+        scrollDepthPercent: 82,
+      });
+
+      expect(result).toEqual({
+        timeOnPage: 45000,
+        scrollDepthPercent: 82,
+      });
+    });
+
+    it('should include engagementScore when provided', () => {
+      const result = buildPageExitData({
+        timeOnPage: 60000,
+        scrollDepthPercent: 95,
+        engagementScore: 78,
+      });
+
+      expect(result).toEqual({
+        timeOnPage: 60000,
+        scrollDepthPercent: 95,
+        engagementScore: 78,
+      });
+    });
+
+    it('should omit engagementScore when undefined', () => {
+      const result = buildPageExitData({
+        timeOnPage: 5000,
+        scrollDepthPercent: 20,
+      });
+
+      expect(result).not.toHaveProperty('engagementScore');
+    });
+  });
+
+  describe('toEventType', () => {
+    it('should map page_exit to PAGE_EXIT', () => {
+      expect(toEventType('page_exit')).toBe('PAGE_EXIT');
+    });
+
+    it('should map scroll_depth to SCROLL_DEPTH', () => {
+      expect(toEventType('scroll_depth')).toBe('SCROLL_DEPTH');
+    });
+
+    it('should map page_view to PAGE_VIEW', () => {
+      expect(toEventType('page_view')).toBe('PAGE_VIEW');
+    });
+
+    it('should map section_time to SECTION_TIME', () => {
+      expect(toEventType('section_time')).toBe('SECTION_TIME');
+    });
+
+    it('should map conversion to CONVERSION', () => {
+      expect(toEventType('conversion')).toBe('CONVERSION');
+    });
+
+    it('should map custom_event to CUSTOM', () => {
+      expect(toEventType('custom_event')).toBe('CUSTOM');
+    });
+
+    it('should fallback to CUSTOM for unknown types', () => {
+      expect(toEventType('unknown_type')).toBe('CUSTOM');
+    });
+  });
+
+  describe('fromEventType', () => {
+    it('should map PAGE_EXIT back to page_exit', () => {
+      expect(fromEventType('PAGE_EXIT' as never)).toBe('page_exit');
+    });
+
+    it('should map SCROLL_DEPTH back to scroll_depth', () => {
+      expect(fromEventType('SCROLL_DEPTH' as never)).toBe('scroll_depth');
+    });
+
+    it('should map SECTION_TIME back to section_time', () => {
+      expect(fromEventType('SECTION_TIME' as never)).toBe('section_time');
+    });
+  });
+
+  describe('buildCustomEventData', () => {
+    it('should build event with category and action', () => {
+      const result = buildCustomEventData({
+        category: 'Session',
+        action: 'end',
+      });
+
+      expect(result).toEqual({
+        category: 'Session',
+        action: 'end',
+      });
+    });
+
+    it('should include optional fields when provided', () => {
+      const result = buildCustomEventData({
+        category: 'CTA',
+        action: 'click',
+        label: 'book-appointment',
+        value: 1,
+        metadata: { location: 'hero' },
+      });
+
+      expect(result).toEqual({
+        category: 'CTA',
+        action: 'click',
+        label: 'book-appointment',
+        value: 1,
+        metadata: { location: 'hero' },
+      });
+    });
+  });
+
+  describe('buildSectionTimeData', () => {
+    it('should build section time data with name and timeSpent', () => {
+      const result = buildSectionTimeData({
+        sectionName: 'Approche',
+        timeSpent: 12500,
+      });
+
+      expect(result).toEqual({
+        sectionId: undefined,
+        sectionName: 'Approche',
+        timeSpent: 12500,
+      });
+    });
+  });
+});

--- a/apps/psypnos/app/(pages)/sections/approach.tsx
+++ b/apps/psypnos/app/(pages)/sections/approach.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { ApproachInfographic } from "../../../components/ApproachInfographic";
-import { CTAButton } from "../../../components/CTAButton";
-import { SectionTitle } from "../../../components/SectionTitle";
+import { ApproachInfographic } from '../../../components/ApproachInfographic';
+import { CTAButton } from '../../../components/CTAButton';
+import { SectionTitle } from '../../../components/SectionTitle';
 
 type ApproachItem = {
   title: string;
@@ -13,46 +13,46 @@ type ApproachItem = {
 
 const approachItems: ApproachItem[] = [
   {
-    title: "Anxiété",
+    title: 'Anxiété',
     description:
       "Je vous aide à comprendre ce qui déclenche votre anxiété et à apaiser les mécanismes qui l'entretiennent. Grâce à l'hypnose et à des outils de respiration et de recentrage, vous apprenez à calmer votre corps et votre esprit, jusqu'à retrouver progressivement un sentiment de confiance et de sécurité intérieure.",
-    icon: "/images/icons/anxiete.svg",
-    iconAlt: "Picto représentant des ondes apaisées",
+    icon: '/images/icons/anxiete.svg',
+    iconAlt: 'Picto représentant des ondes apaisées',
   },
   {
-    title: "Dépression",
+    title: 'Dépression',
     description:
       "Je vous accompagne pour rallumer la flamme intérieure qui semble s'être affaiblie. En explorant vos émotions, vos croyances et votre rapport à vous-même, vous redécouvrez votre énergie de vie et la capacité de vous sentir à nouveau pleinement vivant, au-delà du simple fait d'aller mieux.",
-    icon: "/images/icons/depression.svg",
-    iconAlt: "Picto représentant un soleil se levant",
+    icon: '/images/icons/depression.svg',
+    iconAlt: 'Picto représentant un soleil se levant',
   },
   {
-    title: "Stress",
+    title: 'Stress',
     description:
       "Je vous offre un espace pour comprendre ce qui vous pèse et transformer votre manière de réagir face aux pressions du quotidien. Par l'hypnose, la respiration et la pleine présence, vous libérez les tensions accumulées et retrouvez votre calme naturel, en renouant avec votre capacité d'adaptation sans épuisement.",
-    icon: "/images/icons/stress.svg",
-    iconAlt: "Picto représentant des vagues harmonieuses",
+    icon: '/images/icons/stress.svg',
+    iconAlt: 'Picto représentant des vagues harmonieuses',
   },
   {
-    title: "Burn-out",
+    title: 'Burn-out',
     description:
-      "Je vous aide à restaurer le repos et la sécurité intérieure nécessaires à votre reconstruction. Ensemble, nous explorons ce qui a conduit à cet épuisement — votre rythme, vos exigences, votre rapport au travail ou aux autres — afin de reconstruire une énergie plus juste et un mode de vie plus équilibré.",
-    icon: "/images/icons/burnout.svg",
-    iconAlt: "Picto représentant une flamme protectrice",
+      'Je vous aide à restaurer le repos et la sécurité intérieure nécessaires à votre reconstruction. Ensemble, nous explorons ce qui a conduit à cet épuisement — votre rythme, vos exigences, votre rapport au travail ou aux autres — afin de reconstruire une énergie plus juste et un mode de vie plus équilibré.',
+    icon: '/images/icons/burnout.svg',
+    iconAlt: 'Picto représentant une flamme protectrice',
   },
   {
-    title: "Crise de vie",
+    title: 'Crise de vie',
     description:
       "Je vous accompagne dans ces périodes de bouleversement pour vous aider à y voir plus clair et à en saisir le sens. Grâce à l'hypnose et à la psychothérapie transpersonnelle, vous apprenez à accueillir vos émotions, à transformer vos questionnements en leviers d'évolution et à retrouver une direction intérieure plus alignée.",
-    icon: "/images/icons/crise-de-vie.svg",
-    iconAlt: "Picto représentant une boussole lumineuse",
+    icon: '/images/icons/crise-de-vie.svg',
+    iconAlt: 'Picto représentant une boussole lumineuse',
   },
   {
-    title: "Deuil",
+    title: 'Deuil',
     description:
       "Je vous aide à traverser la douleur du deuil tout en apprivoisant l'absence. Par un travail d'accueil des émotions et de reconnexion à la continuité du lien, vous apprenez à vivre autrement cette relation, non pas en oubliant, mais en retrouvant la paix et un nouvel équilibre intérieur.",
-    icon: "/images/icons/deuil.svg",
-    iconAlt: "Picto représentant un cœur bienveillant",
+    icon: '/images/icons/deuil.svg',
+    iconAlt: 'Picto représentant un cœur bienveillant',
   },
 ];
 
@@ -61,6 +61,8 @@ export function ApproachSection() {
     <section
       id="approche"
       className="px-6 py-20 sm:px-10 lg:px-16"
+      data-track-section="approche"
+      data-track-section-name="Approche"
     >
       <div className="mx-auto max-w-6xl space-y-12">
         <SectionTitle
@@ -76,7 +78,7 @@ export function ApproachSection() {
             animationProps={{
               initial: { opacity: 0, y: 24 },
               animate: { opacity: 1, y: 0 },
-              transition: { duration: 0.8, delay: 0.3, ease: "easeOut" },
+              transition: { duration: 0.8, delay: 0.3, ease: 'easeOut' },
             }}
           >
             Demander un rendez-vous

--- a/apps/psypnos/app/(pages)/sections/blog.tsx
+++ b/apps/psypnos/app/(pages)/sections/blog.tsx
@@ -128,7 +128,12 @@ export function BlogSection({ initialData }: BlogSectionProps) {
   }
 
   return (
-    <section id="blog" className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+    <section
+      id="blog"
+      className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16"
+      data-track-section="blog"
+      data-track-section-name="Blog"
+    >
       <div className="mx-auto max-w-6xl space-y-12">
         <SectionTitle
           eyebrow="Ressources & Articles"
@@ -167,7 +172,7 @@ export function BlogSection({ initialData }: BlogSectionProps) {
                 >
                   {/* Vignette */}
                   {hasMounted && imageExists[post.slug] && (
-                    <div className="relative h-48 overflow-hidden bg-night/80">
+                    <div className="bg-night/80 relative h-48 overflow-hidden">
                       <Image
                         src={post.image || `/images/blog/${post.slug}.webp`}
                         alt={post.title}
@@ -180,75 +185,75 @@ export function BlogSection({ initialData }: BlogSectionProps) {
                   )}
 
                   <div className="flex flex-1 flex-col p-6 pl-8">
-                  {/* Badge catégorie */}
-                  <div className="mb-3">
-                    <span
-                      className={`inline-flex items-center gap-1.5 rounded-full ${colors.bg} px-3 py-1 text-xs font-medium ${colors.text}`}
-                    >
-                      <svg
-                        className="h-3 w-3"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
+                    {/* Badge catégorie */}
+                    <div className="mb-3">
+                      <span
+                        className={`inline-flex items-center gap-1.5 rounded-full ${colors.bg} px-3 py-1 text-xs font-medium ${colors.text}`}
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                        />
-                      </svg>
-                      {post.category}
-                    </span>
-                  </div>
-
-                  {/* Titre */}
-                  <h3 className="text-ivory group-hover:text-gold mb-3 text-xl font-semibold transition-colors">
-                    {post.title}
-                  </h3>
-
-                  {/* Description */}
-                  <p className="text-ivory/70 mb-4 line-clamp-3 flex-1 text-sm">
-                    {post.description}
-                  </p>
-
-                  {/* Métadonnées */}
-                  <div className="text-ivory/60 flex flex-wrap items-center gap-3 text-xs">
-                    <div className="flex items-center gap-1">
-                      <svg
-                        className="h-3.5 w-3.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                        />
-                      </svg>
-                      <time dateTime={post.date}>{formattedDate}</time>
+                        <svg
+                          className="h-3 w-3"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                          />
+                        </svg>
+                        {post.category}
+                      </span>
                     </div>
-                  </div>
 
-                  {/* Indicateur "Lire" */}
-                  <div className="text-gold mt-4 flex items-center gap-2 text-sm font-medium opacity-0 transition-opacity group-hover:opacity-100">
-                    <span>Lire l'article</span>
-                    <svg
-                      className="h-4 w-4 transition-transform group-hover:translate-x-1"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M14 5l7 7m0 0l-7 7m7-7H3"
-                      />
-                    </svg>
-                  </div>
+                    {/* Titre */}
+                    <h3 className="text-ivory group-hover:text-gold mb-3 text-xl font-semibold transition-colors">
+                      {post.title}
+                    </h3>
+
+                    {/* Description */}
+                    <p className="text-ivory/70 mb-4 line-clamp-3 flex-1 text-sm">
+                      {post.description}
+                    </p>
+
+                    {/* Métadonnées */}
+                    <div className="text-ivory/60 flex flex-wrap items-center gap-3 text-xs">
+                      <div className="flex items-center gap-1">
+                        <svg
+                          className="h-3.5 w-3.5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                          />
+                        </svg>
+                        <time dateTime={post.date}>{formattedDate}</time>
+                      </div>
+                    </div>
+
+                    {/* Indicateur "Lire" */}
+                    <div className="text-gold mt-4 flex items-center gap-2 text-sm font-medium opacity-0 transition-opacity group-hover:opacity-100">
+                      <span>Lire l'article</span>
+                      <svg
+                        className="h-4 w-4 transition-transform group-hover:translate-x-1"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M14 5l7 7m0 0l-7 7m7-7H3"
+                        />
+                      </svg>
+                    </div>
                   </div>
 
                   {/* Barre de progression au hover */}

--- a/apps/psypnos/app/(pages)/sections/contact.tsx
+++ b/apps/psypnos/app/(pages)/sections/contact.tsx
@@ -1,16 +1,18 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
+import { motion } from 'framer-motion';
 
-import { ContactForm } from "../../../components/ContactForm";
-import { SectionTitle } from "../../../components/SectionTitle";
-import { SocialLinks } from "../../../components/SocialLinks";
+import { ContactForm } from '../../../components/ContactForm';
+import { SectionTitle } from '../../../components/SectionTitle';
+import { SocialLinks } from '../../../components/SocialLinks';
 
 export function ContactSection() {
   return (
     <section
       id="contact"
       className="px-6 py-20 sm:px-10 lg:px-16"
+      data-track-section="contact"
+      data-track-section-name="Contact"
     >
       <div className="mx-auto max-w-4xl space-y-12">
         <SectionTitle
@@ -22,8 +24,8 @@ export function ContactSection() {
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, amount: 0.3 }}
-          transition={{ duration: 0.6, ease: "easeOut" }}
-          className="rounded-3xl border border-ivory/10 bg-night/40 p-10 shadow-xl shadow-night/60 md:col-span-1"
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+          className="border-ivory/10 bg-night/40 shadow-night/60 rounded-3xl border p-10 shadow-xl md:col-span-1"
         >
           <ContactForm />
         </motion.div>
@@ -33,10 +35,10 @@ export function ContactSection() {
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, amount: 0.3 }}
-          transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
+          transition={{ duration: 0.6, delay: 0.2, ease: 'easeOut' }}
           className="mt-10 text-center"
         >
-          <p className="mb-4 text-sm text-ivory/60">
+          <p className="text-ivory/60 mb-4 text-sm">
             Suivez-moi sur les réseaux sociaux pour des réflexions et ressources régulières
           </p>
           <SocialLinks variant="stacked" showLabels />

--- a/apps/psypnos/app/(pages)/sections/formats.tsx
+++ b/apps/psypnos/app/(pages)/sections/formats.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { CTAButton } from "../../../components/CTAButton";
-import { SectionTitle } from "../../../components/SectionTitle";
-import { SessionFormatsInfographic } from "../../../components/SessionFormatsInfographic";
+import { CTAButton } from '../../../components/CTAButton';
+import { SectionTitle } from '../../../components/SectionTitle';
+import { SessionFormatsInfographic } from '../../../components/SessionFormatsInfographic';
 
 type SessionFormat = {
   title: string;
@@ -13,28 +13,36 @@ type SessionFormat = {
 
 const sessionFormats: SessionFormat[] = [
   {
-    title: "En présentiel",
-    description: "Rencontres dans un cadre bienveillant et sécurisant, face à face pour une connexion authentique.",
-    icon: "/images/icons/seance-presentiel.svg",
-    iconAlt: "Icône représentant une séance en présentiel",
+    title: 'En présentiel',
+    description:
+      'Rencontres dans un cadre bienveillant et sécurisant, face à face pour une connexion authentique.',
+    icon: '/images/icons/seance-presentiel.svg',
+    iconAlt: 'Icône représentant une séance en présentiel',
   },
   {
-    title: "Par visioconférence",
-    description: "Séances depuis le confort de votre domicile, avec la même qualité et présence thérapeutique.",
-    icon: "/images/icons/seance-visioconference.svg",
-    iconAlt: "Icône représentant une séance par visioconférence",
+    title: 'Par visioconférence',
+    description:
+      'Séances depuis le confort de votre domicile, avec la même qualité et présence thérapeutique.',
+    icon: '/images/icons/seance-visioconference.svg',
+    iconAlt: 'Icône représentant une séance par visioconférence',
   },
   {
-    title: "Par téléphone",
-    description: "Un accompagnement vocal pour ceux qui préfèrent cette approche, pratique et tout aussi efficace.",
-    icon: "/images/icons/seance-telephone.svg",
-    iconAlt: "Icône représentant une séance par téléphone",
+    title: 'Par téléphone',
+    description:
+      'Un accompagnement vocal pour ceux qui préfèrent cette approche, pratique et tout aussi efficace.',
+    icon: '/images/icons/seance-telephone.svg',
+    iconAlt: 'Icône représentant une séance par téléphone',
   },
 ];
 
 export function SessionFormatsSection() {
   return (
-    <section id="formats-seance" className="px-6 py-20 sm:px-10 lg:px-16">
+    <section
+      id="formats-seance"
+      className="px-6 py-20 sm:px-10 lg:px-16"
+      data-track-section="formats"
+      data-track-section-name="Formats de séance"
+    >
       <div className="mx-auto max-w-6xl space-y-12">
         <SectionTitle
           eyebrow="Formats flexibles"
@@ -49,7 +57,7 @@ export function SessionFormatsSection() {
             animationProps={{
               initial: { opacity: 0, y: 24 },
               animate: { opacity: 1, y: 0 },
-              transition: { duration: 0.8, delay: 1.1, ease: "easeOut" },
+              transition: { duration: 0.8, delay: 1.1, ease: 'easeOut' },
             }}
           >
             Demander un rendez-vous

--- a/apps/psypnos/app/(pages)/sections/hero.tsx
+++ b/apps/psypnos/app/(pages)/sections/hero.tsx
@@ -56,6 +56,8 @@ export function HeroSection() {
       ref={heroRef}
       className="bg-night relative overflow-hidden px-6 pb-24 pt-24 sm:px-8 lg:px-16"
       aria-label="Introduction"
+      data-track-section="hero"
+      data-track-section-name="Accueil"
     >
       {/* Gradient glow effects */}
       <motion.div

--- a/apps/psypnos/app/(pages)/sections/journey.tsx
+++ b/apps/psypnos/app/(pages)/sections/journey.tsx
@@ -1,12 +1,16 @@
-"use client";
+'use client';
 
-import { CTAButton } from "../../../components/CTAButton";
-import { JourneyInfographic } from "../../../components/JourneyInfographic";
-import { SectionTitle } from "../../../components/SectionTitle";
+import { CTAButton } from '../../../components/CTAButton';
+import { JourneyInfographic } from '../../../components/JourneyInfographic';
+import { SectionTitle } from '../../../components/SectionTitle';
 
 export function JourneySection() {
   return (
-    <section className="px-6 py-20 sm:px-10 lg:px-16">
+    <section
+      className="px-6 py-20 sm:px-10 lg:px-16"
+      data-track-section="parcours"
+      data-track-section-name="Parcours"
+    >
       <div className="mx-auto max-w-6xl space-y-12">
         <SectionTitle
           eyebrow="Votre voyage"
@@ -20,7 +24,7 @@ export function JourneySection() {
             animationProps={{
               initial: { opacity: 0, y: 24 },
               animate: { opacity: 1, y: 0 },
-              transition: { duration: 0.8, delay: 0.5, ease: "easeOut" },
+              transition: { duration: 0.8, delay: 0.5, ease: 'easeOut' },
             }}
           >
             Demander un rendez-vous

--- a/apps/psypnos/app/(pages)/sections/pricing.tsx
+++ b/apps/psypnos/app/(pages)/sections/pricing.tsx
@@ -39,6 +39,8 @@ export function PricingSection() {
       ref={sectionRef}
       id="tarifs"
       className="relative overflow-hidden px-6 py-16 sm:px-10 sm:py-20 lg:px-16 lg:py-24"
+      data-track-section="tarifs"
+      data-track-section-name="Tarifs"
     >
       {/* Parallax background elements */}
       <div

--- a/apps/psypnos/app/(pages)/sections/respiration.tsx
+++ b/apps/psypnos/app/(pages)/sections/respiration.tsx
@@ -1,14 +1,19 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
+import { motion } from 'framer-motion';
 
-import { CTAButton } from "../../../components/CTAButton";
-import GoldGlowImage from "../../../components/GoldGlowImage";
-import { SectionTitle } from "../../../components/SectionTitle";
+import { CTAButton } from '../../../components/CTAButton';
+import GoldGlowImage from '../../../components/GoldGlowImage';
+import { SectionTitle } from '../../../components/SectionTitle';
 
 export function RespirationSection() {
   return (
-    <section id="respiration-holotropique" className="bg-gradient-to-br from-night via-night/95 to-night px-6 py-20 sm:px-10 lg:px-16">
+    <section
+      id="respiration-holotropique"
+      className="from-night via-night/95 to-night bg-gradient-to-br px-6 py-20 sm:px-10 lg:px-16"
+      data-track-section="respiration"
+      data-track-section-name="Respiration holotropique"
+    >
       <div className="mx-auto max-w-5xl space-y-12">
         <SectionTitle
           eyebrow="Respiration holotropique"
@@ -18,26 +23,34 @@ Avec sécurité et bienveillance, nous vous offrons l'opportunité de vous accom
 "
         />
         <div className="grid gap-8 sm:grid-cols-2">
-          <div className="space-y-6 text-left" style={{ display: "flex", alignItems: "normal", justifyContent: "center", height: "100%", flexDirection: "column" }} >
+          <div
+            className="space-y-6 text-left"
+            style={{
+              display: 'flex',
+              alignItems: 'normal',
+              justifyContent: 'center',
+              height: '100%',
+              flexDirection: 'column',
+            }}
+          >
             {[
-              "Un lieu magique dans un magnifique moulin bourguignon",
-              "Un accompagnement bienveillant et respectueux",
-              "Une préparation personnalisée pour définir vos intentions",
-              "Une musique immersive et un support corporel sécurisant",
-              "Une exploration intérieure et une libération des blocages",
+              'Un lieu magique dans un magnifique moulin bourguignon',
+              'Un accompagnement bienveillant et respectueux',
+              'Une préparation personnalisée pour définir vos intentions',
+              'Une musique immersive et un support corporel sécurisant',
+              'Une exploration intérieure et une libération des blocages',
               "Un temps d'intégration avec dessin, écriture et partage",
-              "Une expérience immersive et transformante",
-            ].map((item) => (
+              'Une expérience immersive et transformante',
+            ].map(item => (
               <motion.div
                 key={item}
                 initial={{ opacity: 0, y: 16 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
-                transition={{ duration: 0.5, ease: "easeOut" }}
+                transition={{ duration: 0.5, ease: 'easeOut' }}
                 className="flex items-start gap-4"
               >
-
-                <span className="mt-1 inline-flex h-4 w-4 flex-none items-center justify-center rounded-full bg-gold/20 text-gold">
+                <span className="bg-gold/20 text-gold mt-1 inline-flex h-4 w-4 flex-none items-center justify-center rounded-full">
                   <span className="text-lg font-bold">+</span>
                 </span>
                 <p className="text-ivory/80">{item}</p>
@@ -47,7 +60,7 @@ Avec sécurité et bienveillance, nous vous offrons l'opportunité de vous accom
               initial={{ opacity: 0, y: 16 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.5, ease: "easeOut", delay: 0.3 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.3 }}
               className="flex flex-col gap-3 pt-4 sm:flex-row"
             >
               <CTAButton variant="primary" href="/inscription-seminaire">
@@ -62,7 +75,7 @@ Avec sécurité et bienveillance, nous vous offrons l'opportunité de vous accom
             initial={{ opacity: 0, x: 40 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true, amount: 0.3 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
             className="relative overflow-hidden"
           >
             <GoldGlowImage
@@ -74,7 +87,10 @@ Avec sécurité et bienveillance, nous vous offrons l'opportunité de vous accom
               shadowOpacity={0.92}
               className="rounded-full"
             />
-            <div className="absolute inset-0 bg-gradient-to-tr from-night/80 via-night/30 to-transparent" aria-hidden />
+            <div
+              className="from-night/80 via-night/30 absolute inset-0 bg-gradient-to-tr to-transparent"
+              aria-hidden
+            />
           </motion.div>
         </div>
       </div>

--- a/apps/psypnos/app/(pages)/sections/seminars.tsx
+++ b/apps/psypnos/app/(pages)/sections/seminars.tsx
@@ -93,7 +93,12 @@ export function SeminarsSection({ initialData }: SeminarsSectionProps) {
   }
 
   return (
-    <section id="seminaires" className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+    <section
+      id="seminaires"
+      className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16"
+      data-track-section="seminaires"
+      data-track-section-name="Séminaires"
+    >
       <div className="mx-auto max-w-6xl space-y-12">
         <SectionTitle
           eyebrow="Séminaires à venir"

--- a/apps/psypnos/app/(pages)/sections/testimonials.tsx
+++ b/apps/psypnos/app/(pages)/sections/testimonials.tsx
@@ -194,7 +194,11 @@ export function TestimonialsSection({ initialData }: TestimonialsSectionProps) {
   }
 
   return (
-    <section className="bg-night/60 overflow-hidden py-20">
+    <section
+      className="bg-night/60 overflow-hidden py-20"
+      data-track-section="temoignages"
+      data-track-section-name="Témoignages"
+    >
       {/* Title with constrained width */}
       <div className="mx-auto max-w-6xl px-6 sm:px-10 lg:px-16">
         <motion.div

--- a/apps/psypnos/app/(pages)/sections/therapy.tsx
+++ b/apps/psypnos/app/(pages)/sections/therapy.tsx
@@ -1,12 +1,17 @@
-"use client";
+'use client';
 
-import { CTAButton } from "../../../components/CTAButton";
-import { SectionTitle } from "../../../components/SectionTitle";
+import { CTAButton } from '../../../components/CTAButton';
+import { SectionTitle } from '../../../components/SectionTitle';
 
 export function TherapySections() {
   return (
     <>
-      <section id="psychotherapie" className="px-6 py-20 sm:px-10 lg:px-16">
+      <section
+        id="psychotherapie"
+        className="px-6 py-20 sm:px-10 lg:px-16"
+        data-track-section="psychotherapie"
+        data-track-section-name="Psychothérapie"
+      >
         <div className="mx-auto max-w-6xl space-y-12 text-center">
           <SectionTitle
             eyebrow="Psychothérapie"
@@ -21,7 +26,7 @@ export function TherapySections() {
               animationProps={{
                 initial: { opacity: 0, y: 24 },
                 animate: { opacity: 1, y: 0 },
-                transition: { duration: 0.8, delay: 0.7, ease: "easeOut" },
+                transition: { duration: 0.8, delay: 0.7, ease: 'easeOut' },
               }}
             >
               Demander un rendez-vous
@@ -33,7 +38,7 @@ export function TherapySections() {
               animationProps={{
                 initial: { opacity: 0, y: 24 },
                 animate: { opacity: 1, y: 0 },
-                transition: { duration: 0.8, delay: 0.8, ease: "easeOut" },
+                transition: { duration: 0.8, delay: 0.8, ease: 'easeOut' },
               }}
             >
               En savoir plus
@@ -41,7 +46,12 @@ export function TherapySections() {
           </div>
         </div>
       </section>
-      <section id="hypnose" className="px-6 py-20 sm:px-10 lg:px-16">
+      <section
+        id="hypnose"
+        className="px-6 py-20 sm:px-10 lg:px-16"
+        data-track-section="hypnose"
+        data-track-section-name="Hypnose"
+      >
         <div className="mx-auto max-w-6xl space-y-12 text-center">
           <SectionTitle
             eyebrow="Hypnose"
@@ -56,7 +66,7 @@ export function TherapySections() {
               animationProps={{
                 initial: { opacity: 0, y: 24 },
                 animate: { opacity: 1, y: 0 },
-                transition: { duration: 0.8, delay: 0.9, ease: "easeOut" },
+                transition: { duration: 0.8, delay: 0.9, ease: 'easeOut' },
               }}
             >
               Demander un rendez-vous
@@ -68,7 +78,7 @@ export function TherapySections() {
               animationProps={{
                 initial: { opacity: 0, y: 24 },
                 animate: { opacity: 1, y: 0 },
-                transition: { duration: 0.8, delay: 1.0, ease: "easeOut" },
+                transition: { duration: 0.8, delay: 1.0, ease: 'easeOut' },
               }}
             >
               En savoir plus

--- a/apps/psypnos/app/api/analytics/store-index.ts
+++ b/apps/psypnos/app/api/analytics/store-index.ts
@@ -16,6 +16,9 @@
 // Page Visits
 export { trackPageVisit, getPageVisits, getTopPages } from './store-postgres/page-visits';
 
+// Page Exits & Scroll Depth
+export { trackPageExit, trackScrollDepth } from './store-postgres/page-exits';
+
 // Section Times
 export { trackSectionTime, getSectionTimes } from './store-postgres/section-times';
 

--- a/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
@@ -13,7 +13,21 @@ import { prisma } from '@/lib/db/prisma';
 import { buildDateFilter, getCurrentSiteId } from './utils';
 
 /** Whitelist of valid PostgreSQL date_trunc precision values */
-const VALID_DATE_TRUNC_PERIODS = new Set(['microseconds', 'milliseconds', 'second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year', 'decade', 'century', 'millennium']);
+const VALID_DATE_TRUNC_PERIODS = new Set([
+  'microseconds',
+  'milliseconds',
+  'second',
+  'minute',
+  'hour',
+  'day',
+  'week',
+  'month',
+  'quarter',
+  'year',
+  'decade',
+  'century',
+  'millennium',
+]);
 
 /**
  * Get analytics summary for a date range using SQL aggregations
@@ -31,64 +45,78 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
       const dateFilter = buildDateFilter(startDate, endDate);
 
       // Count total page views (excluding bots) and unique sessions via SQL
-      const [pageViewStats, bounceStats, sectionTimeStats, conversionStats] = await Promise.all([
-        // 1. Page view counts + unique sessions (SQL aggregation)
-        prisma.analyticsEvent.groupBy({
-          by: ['sessionId'],
-          where: {
-            siteId,
-            type: EventType.PAGE_VIEW,
-            ...dateFilter,
-            NOT: {
-              data: {
-                path: ['isBot'],
-                equals: true,
+      const [pageViewStats, bounceStats, pageExitStats, sectionTimeStats, conversionStats] =
+        await Promise.all([
+          // 1. Page view counts + unique sessions (SQL aggregation)
+          prisma.analyticsEvent.groupBy({
+            by: ['sessionId'],
+            where: {
+              siteId,
+              type: EventType.PAGE_VIEW,
+              ...dateFilter,
+              NOT: {
+                data: {
+                  path: ['isBot'],
+                  equals: true,
+                },
               },
             },
-          },
-          _count: { id: true },
-        }),
+            _count: { id: true },
+          }),
 
-        // 2. Total page views count (for total)
-        prisma.analyticsEvent.count({
-          where: {
-            siteId,
-            type: EventType.PAGE_VIEW,
-            ...dateFilter,
-            NOT: {
-              data: {
-                path: ['isBot'],
-                equals: true,
+          // 2. Total page views count (for total)
+          prisma.analyticsEvent.count({
+            where: {
+              siteId,
+              type: EventType.PAGE_VIEW,
+              ...dateFilter,
+              NOT: {
+                data: {
+                  path: ['isBot'],
+                  equals: true,
+                },
               },
             },
-          },
-        }),
+          }),
 
-        // 3. Section times grouped by session (for avg time on site)
-        prisma.analyticsEvent.findMany({
-          where: {
-            siteId,
-            type: EventType.SECTION_TIME,
-            ...dateFilter,
-          },
-          select: {
-            sessionId: true,
-            name: true,
-            data: true,
-          },
-        }),
+          // 3. Page exit events (primary source for session duration & scroll depth)
+          prisma.analyticsEvent.findMany({
+            where: {
+              siteId,
+              type: EventType.PAGE_EXIT,
+              ...dateFilter,
+            },
+            select: {
+              sessionId: true,
+              data: true,
+            },
+          }),
 
-        // 4. Conversion counts grouped by name
-        prisma.analyticsEvent.groupBy({
-          by: ['name'],
-          where: {
-            siteId,
-            type: EventType.CONVERSION,
-            ...dateFilter,
-          },
-          _count: { id: true },
-        }),
-      ]);
+          // 4. Section times grouped by session (for topSections & fallback duration)
+          prisma.analyticsEvent.findMany({
+            where: {
+              siteId,
+              type: EventType.SECTION_TIME,
+              ...dateFilter,
+            },
+            select: {
+              sessionId: true,
+              name: true,
+              data: true,
+            },
+          }),
+
+          // 5. Conversion counts grouped by name
+          prisma.analyticsEvent.groupBy({
+            by: ['name'],
+            where: {
+              siteId,
+              type: EventType.CONVERSION,
+              ...dateFilter,
+            },
+            _count: { id: true },
+          }),
+        ]);
 
       // Compute summary from grouped results
       const totalVisits = bounceStats;
@@ -98,8 +126,31 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
       const bouncedSessions = pageViewStats.filter(s => s._count.id === 1).length;
       const bounceRate = uniqueSessions > 0 ? (bouncedSessions / uniqueSessions) * 100 : 0;
 
-      // Average time on site from section times
-      const sessionDurations = new Map<string, number>();
+      // ── Session duration from PAGE_EXIT events (primary) ──────────
+      const pageExitSessionTimes = new Map<string, number>();
+      let totalScrollDepth = 0;
+      let scrollDepthCount = 0;
+
+      for (const pe of pageExitStats) {
+        const data = (pe.data as Record<string, unknown>) || {};
+        const timeOnPage = typeof data.timeOnPage === 'number' ? data.timeOnPage : 0;
+        const scrollPct = typeof data.scrollDepthPercent === 'number' ? data.scrollDepthPercent : 0;
+
+        if (pe.sessionId && timeOnPage > 0) {
+          pageExitSessionTimes.set(
+            pe.sessionId,
+            (pageExitSessionTimes.get(pe.sessionId) || 0) + timeOnPage
+          );
+        }
+
+        if (scrollPct > 0) {
+          totalScrollDepth += scrollPct;
+          scrollDepthCount++;
+        }
+      }
+
+      // ── Session duration from SECTION_TIME events (fallback) ──────
+      const sectionSessionDurations = new Map<string, number>();
       const sectionStats = new Map<string, { totalTime: number; count: number }>();
 
       for (const st of sectionTimeStats) {
@@ -107,7 +158,10 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
         const timeSpent = typeof data.timeSpent === 'number' ? data.timeSpent : 0;
 
         if (st.sessionId) {
-          sessionDurations.set(st.sessionId, (sessionDurations.get(st.sessionId) || 0) + timeSpent);
+          sectionSessionDurations.set(
+            st.sessionId,
+            (sectionSessionDurations.get(st.sessionId) || 0) + timeSpent
+          );
         }
 
         const section = st.name || 'unknown';
@@ -117,10 +171,15 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
         sectionStats.set(section, current);
       }
 
+      // Use PAGE_EXIT as primary source; fall back to SECTION_TIME
+      const durationSource =
+        pageExitSessionTimes.size > 0 ? pageExitSessionTimes : sectionSessionDurations;
       const averageTimeOnSite =
-        sessionDurations.size > 0
-          ? Array.from(sessionDurations.values()).reduce((a, b) => a + b, 0) / sessionDurations.size
+        durationSource.size > 0
+          ? Array.from(durationSource.values()).reduce((a, b) => a + b, 0) / durationSource.size
           : 0;
+
+      const averageScrollDepth = scrollDepthCount > 0 ? totalScrollDepth / scrollDepthCount : 0;
 
       const topSections = Array.from(sectionStats.entries())
         .filter(([section]) => section.toLowerCase() !== 'unknown')
@@ -181,6 +240,7 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
         totalVisits,
         uniqueSessions,
         averageTimeOnSite,
+        averageScrollDepth,
         conversionRate,
         bounceRate,
         topSections,
@@ -498,7 +558,10 @@ export async function getTrafficSources(startDate?: string, endDate?: string) {
 }
 
 /**
- * Get device breakdown using SQL aggregation
+ * Get device breakdown using SQL aggregation.
+ *
+ * Computes avgTimeOnSite per device type by joining PAGE_VIEW (which stores
+ * deviceType) with PAGE_EXIT (which stores timeOnPage) on sessionId.
  */
 export async function getDeviceBreakdown(startDate?: string, endDate?: string) {
   const cacheKey = buildCacheKey(CACHE_KEYS.DEVICE_BREAKDOWN, {
@@ -515,32 +578,66 @@ export async function getDeviceBreakdown(startDate?: string, endDate?: string) {
         : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const end = endDate ? new Date(endDate) : new Date();
 
-      const results = await prisma.$queryRaw<
-        Array<{
-          device_type: string;
-          visits: bigint;
-          unique_sessions: bigint;
-        }>
-      >`
-        SELECT
-          COALESCE(data->>'deviceType', 'unknown') as device_type,
-          COUNT(*) as visits,
-          COUNT(DISTINCT "sessionId") as unique_sessions
-        FROM "AnalyticsEvent"
-        WHERE "siteId" = ${siteId}
-          AND "type" = 'PAGE_VIEW'
-          AND "createdAt" >= ${start}
-          AND "createdAt" <= ${end}
-          AND (data->>'isBot' IS NULL OR data->>'isBot' != 'true')
-        GROUP BY device_type
-        ORDER BY visits DESC
-      `;
+      const [deviceStats, avgTimeByDevice] = await Promise.all([
+        // Visit counts per device type from PAGE_VIEW
+        prisma.$queryRaw<
+          Array<{
+            device_type: string;
+            visits: bigint;
+            unique_sessions: bigint;
+          }>
+        >`
+          SELECT
+            COALESCE(data->>'deviceType', 'unknown') as device_type,
+            COUNT(*) as visits,
+            COUNT(DISTINCT "sessionId") as unique_sessions
+          FROM "AnalyticsEvent"
+          WHERE "siteId" = ${siteId}
+            AND "type" = 'PAGE_VIEW'
+            AND "createdAt" >= ${start}
+            AND "createdAt" <= ${end}
+            AND (data->>'isBot' IS NULL OR data->>'isBot' != 'true')
+          GROUP BY device_type
+          ORDER BY visits DESC
+        `,
 
-      return results.map(row => ({
+        // Avg time on site per device type via PAGE_EXIT + PAGE_VIEW join
+        prisma.$queryRaw<
+          Array<{
+            device_type: string;
+            avg_time: number;
+          }>
+        >`
+          SELECT
+            COALESCE(sv.device_type, 'unknown') as device_type,
+            AVG(CAST(pe.data->>'timeOnPage' AS DOUBLE PRECISION)) as avg_time
+          FROM "AnalyticsEvent" pe
+          INNER JOIN (
+            SELECT DISTINCT ON ("sessionId")
+              "sessionId",
+              COALESCE(data->>'deviceType', 'unknown') as device_type
+            FROM "AnalyticsEvent"
+            WHERE "siteId" = ${siteId}
+              AND "type" = 'PAGE_VIEW'
+              AND "createdAt" >= ${start}
+              AND "createdAt" <= ${end}
+            ORDER BY "sessionId", "createdAt" ASC
+          ) sv ON pe."sessionId" = sv."sessionId"
+          WHERE pe."siteId" = ${siteId}
+            AND pe."type" = 'PAGE_EXIT'
+            AND pe."createdAt" >= ${start}
+            AND pe."createdAt" <= ${end}
+          GROUP BY sv.device_type
+        `,
+      ]);
+
+      const avgTimeMap = new Map(avgTimeByDevice.map(r => [r.device_type, r.avg_time || 0]));
+
+      return deviceStats.map(row => ({
         deviceType: row.device_type,
         visits: Number(row.visits),
         uniqueSessions: Number(row.unique_sessions),
-        avgTimeOnSite: 0,
+        avgTimeOnSite: avgTimeMap.get(row.device_type) || 0,
       }));
     },
     CACHE_TTL.MEDIUM

--- a/apps/psypnos/app/api/analytics/store-postgres/index.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/index.ts
@@ -20,16 +20,19 @@ export type {
   DashboardConfig,
   ScheduledReport,
   Anomaly,
-} from "../store/types";
+} from '../store/types';
 
 // Page Visits
-export { trackPageVisit, getPageVisits } from "./page-visits";
+export { trackPageVisit, getPageVisits } from './page-visits';
+
+// Page Exits & Scroll Depth
+export { trackPageExit, trackScrollDepth } from './page-exits';
 
 // Section Times
-export { trackSectionTime, getSectionTimes } from "./section-times";
+export { trackSectionTime, getSectionTimes } from './section-times';
 
 // Conversions
-export { trackConversionEvent, getConversionEvents } from "./conversions";
+export { trackConversionEvent, getConversionEvents } from './conversions';
 
 // Analytics
 export {
@@ -39,14 +42,10 @@ export {
   getSectionHeatmap,
   getTrafficSources,
   getDeviceBreakdown,
-} from "./analytics";
+} from './analytics';
 
 // Custom Events
-export {
-  trackCustomEvent,
-  getCustomEvents,
-  getCustomEventsSummary,
-} from "./custom-events";
+export { trackCustomEvent, getCustomEvents, getCustomEventsSummary } from './custom-events';
 
 // Goals
 export {
@@ -58,21 +57,16 @@ export {
   trackGoalCompletion,
   getGoalCompletions,
   getGoalsSummary,
-} from "./goals";
+} from './goals';
 
 // Funnels
-export {
-  trackFunnelStep,
-  getFunnelSteps,
-  getFunnelAnalysis,
-  getAvailableFunnels,
-} from "./funnels";
+export { trackFunnelStep, getFunnelSteps, getFunnelAnalysis, getAvailableFunnels } from './funnels';
 
 // Cohorts
-export { getCohortAnalysis } from "./cohorts";
+export { getCohortAnalysis } from './cohorts';
 
 // Attribution
-export { getMarketingAttribution } from "./attribution";
+export { getMarketingAttribution } from './attribution';
 
 // Alerts
 export {
@@ -83,7 +77,7 @@ export {
   deleteAlert,
   addAlertHistory,
   getAlertHistory,
-} from "./alerts";
+} from './alerts';
 
 // Anomalies
 export {
@@ -94,7 +88,7 @@ export {
   calculateBaseline,
   detectAnomaly,
   runAnomalyDetection,
-} from "./anomalies";
+} from './anomalies';
 
 // Reports
 export {
@@ -103,7 +97,7 @@ export {
   getScheduledReport,
   updateScheduledReport,
   deleteScheduledReport,
-} from "./reports";
+} from './reports';
 
 // Dashboard
 export {
@@ -113,7 +107,7 @@ export {
   getDefaultDashboardConfig,
   updateDashboardConfig,
   deleteDashboardConfig,
-} from "./dashboard";
+} from './dashboard';
 
 // Re-export getDefaultWidgets from main store (it's a pure function)
-export { getDefaultWidgets } from "../store/dashboard";
+export { getDefaultWidgets } from '../store/dashboard';

--- a/apps/psypnos/app/api/analytics/store-postgres/page-exits.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/page-exits.ts
@@ -1,0 +1,81 @@
+/**
+ * PostgreSQL Page Exit Operations
+ *
+ * Uses the unified AnalyticsEvent model with EventType.PAGE_EXIT.
+ * Page exit data (timeOnPage, scrollDepthPercent, engagementScore) is
+ * stored in the `data` JSON field.
+ *
+ * Previously, page_exit events were stored as EventType.CUSTOM via
+ * trackCustomEvent(), making them invisible to engagement aggregation
+ * queries. This module stores them under their proper EventType so that
+ * getAnalyticsSummary() and getDeviceBreakdown() can compute session
+ * duration and scroll depth correctly.
+ */
+
+import { EventType } from '@prisma/client';
+
+import { prisma } from '@/lib/db/prisma';
+
+import {
+  toPrismaJson,
+  buildPageExitData,
+  buildDateFilter,
+  extractFromData,
+  getCurrentSiteId,
+} from './utils';
+
+/**
+ * Persists a page_exit event as EventType.PAGE_EXIT.
+ */
+export async function trackPageExit(params: {
+  timestamp: string;
+  sessionId: string;
+  page: string;
+  timeOnPage: number;
+  scrollDepthPercent: number;
+  engagementScore?: number;
+}): Promise<void> {
+  const siteId = await getCurrentSiteId();
+
+  const eventData = buildPageExitData({
+    timeOnPage: params.timeOnPage,
+    scrollDepthPercent: params.scrollDepthPercent,
+    engagementScore: params.engagementScore,
+  });
+
+  await prisma.analyticsEvent.create({
+    data: {
+      type: EventType.PAGE_EXIT,
+      path: params.page,
+      name: 'page_exit',
+      sessionId: params.sessionId,
+      data: toPrismaJson(eventData),
+      createdAt: new Date(params.timestamp),
+      siteId,
+    },
+  });
+}
+
+/**
+ * Persists a scroll_depth event as EventType.SCROLL_DEPTH.
+ */
+export async function trackScrollDepth(params: {
+  timestamp: string;
+  sessionId: string;
+  page: string;
+  depth: number;
+}): Promise<void> {
+  const siteId = await getCurrentSiteId();
+
+  await prisma.analyticsEvent.create({
+    data: {
+      type: EventType.SCROLL_DEPTH,
+      path: params.page,
+      name: `scroll_${params.depth}`,
+      sessionId: params.sessionId,
+      data: toPrismaJson({ depth: params.depth }),
+      createdAt: new Date(params.timestamp),
+      siteId,
+    },
+  });
+}

--- a/apps/psypnos/app/api/analytics/track/route.ts
+++ b/apps/psypnos/app/api/analytics/track/route.ts
@@ -282,28 +282,22 @@ async function processEvents(
           break;
 
         case 'page_exit':
-          await store.trackCustomEvent({
+          await store.trackPageExit({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
-            category: 'Engagement',
-            action: 'page_exit',
-            label: event.url,
-            value: event.timeOnPage,
-            metadata: {
-              scrollDepthPercent: event.scrollDepthPercent,
-              engagementScore: event.engagementScore,
-            },
+            page: event.url,
+            timeOnPage: event.timeOnPage || 0,
+            scrollDepthPercent: event.scrollDepthPercent || 0,
+            engagementScore: event.engagementScore,
           });
           break;
 
         case 'scroll_depth':
-          await store.trackCustomEvent({
+          await store.trackScrollDepth({
             timestamp: event.timestamp,
             sessionId: event.sessionId,
-            category: 'Engagement',
-            action: 'scroll_depth',
-            label: event.url,
-            value: event.depth,
+            page: event.url,
+            depth: event.depth || 0,
           });
           break;
 

--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -782,7 +782,7 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
           heatmapData.length > 0
             ? heatmapData.reduce((sum: number, h: any) => sum + (h.scrollRate || 0), 0) /
               heatmapData.length
-            : 0,
+            : (dashboardData.summary?.averageScrollDepth ?? 0),
         sectionEngagement,
         deviceBreakdown,
         totalConversions: conversionTypes.reduce((sum, c) => sum + c.completed, 0),


### PR DESCRIPTION
page_exit and scroll_depth events were stored as EventType.CUSTOM via
trackCustomEvent(), making them invisible to getAnalyticsSummary() and
getDeviceBreakdown() aggregation queries. This caused averageTimeOnSite,
scrollDepth, and per-device avgTimeOnSite to always read 0.

- Add store-postgres/page-exits.ts with trackPageExit() (PAGE_EXIT) and
  trackScrollDepth() (SCROLL_DEPTH) using their dedicated EventTypes
- Update track/route.ts to call the new functions instead of trackCustomEvent
- Fix getAnalyticsSummary() to compute averageTimeOnSite from PAGE_EXIT
  events (primary) with SECTION_TIME fallback, and add averageScrollDepth
- Fix getDeviceBreakdown() to compute avgTimeOnSite per device via a
  PAGE_EXIT + PAGE_VIEW sessionId join
- Update useAnalytics hook to fall back to summary.averageScrollDepth
  when heatmap data is empty
- Add data-track-section attributes to 11 homepage sections so the
  SectionTracker can observe them for engagement metrics
- Add unit tests for analytics store utility functions (16 tests)

https://claude.ai/code/session_017t87e5qZYpRdK87s3RxjYC