### PR TITLE
fix(analytics): align SocialPost schema with app code to enable Posts tab tracking

### DIFF
--- a/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
 /**
  * API pour les analytics des réseaux sociaux formatées pour le PostsPanel
  *
@@ -27,10 +25,7 @@ import {
 import { getTotalFollowersByPlatform } from '@/lib/social/snapshots';
 
 // Platform display config
-const PLATFORM_CONFIG: Record<
-  string,
-  { name: string; icon: string; color: string }
-> = {
+const PLATFORM_CONFIG: Record<string, { name: string; icon: string; color: string }> = {
   FACEBOOK: { name: 'Facebook', icon: 'facebook', color: '#1877F2' },
   INSTAGRAM: { name: 'Instagram', icon: 'instagram', color: '#E4405F' },
   LINKEDIN: { name: 'LinkedIn', icon: 'linkedin', color: '#0A66C2' },
@@ -89,7 +84,12 @@ export async function GET(request: NextRequest) {
       getTrendData(30, startDate, endDate),
       startDate && endDate
         ? getComparisonStats(startDate, endDate)
-        : Promise.resolve({ postsChange: 0, reachChange: 0, engagementChange: 0, engagementRateChange: 0 }),
+        : Promise.resolve({
+            postsChange: 0,
+            reachChange: 0,
+            engagementChange: 0,
+            engagementRateChange: 0,
+          }),
       getBestPostingTimes(startDate, endDate),
       getPostTypeStats(startDate, endDate),
       getTotalFollowersByPlatform(),
@@ -97,7 +97,7 @@ export async function GET(request: NextRequest) {
     ]);
 
     // Format platform stats for PostsPanel
-    const platforms = platformStats.map((p) => {
+    const platforms = platformStats.map(p => {
       const config = PLATFORM_CONFIG[p.platform] || {
         name: p.platform,
         icon: p.platform.toLowerCase(),
@@ -118,7 +118,7 @@ export async function GET(request: NextRequest) {
     });
 
     // Format top posts for PostsPanel
-    const formattedTopPosts = topPosts.map((p) => ({
+    const formattedTopPosts = topPosts.map(p => ({
       id: p.id,
       platform: p.platform.toLowerCase(),
       type: p.mediaType,
@@ -134,7 +134,7 @@ export async function GET(request: NextRequest) {
     }));
 
     // Format trend data — use real reach when available, fallback to impressions
-    const engagementTrends = trendData.map((t) => ({
+    const engagementTrends = trendData.map(t => ({
       label: t.date,
       reach: t.reach > 0 ? t.reach : t.impressions,
       engagement: t.engagements,
@@ -154,19 +154,19 @@ export async function GET(request: NextRequest) {
       followersChange: platforms.reduce((sum, p) => sum + p.followersChange, 0),
       platforms,
       topPosts: formattedTopPosts,
-      postTypes: postTypes.map((pt) => ({
+      postTypes: postTypes.map(pt => ({
         type: pt.type,
         count: pt.count,
         avgEngagement: pt.avgEngagement,
         percentage: pt.percentage,
       })),
       engagementTrends,
-      bestPostingTimes: bestTimes.map((bt) => ({
+      bestPostingTimes: bestTimes.map(bt => ({
         day: bt.day,
         hour: bt.hour,
         engagement: bt.engagement,
       })),
-      hashtagPerformance: hashtagPerformance.map((h) => ({
+      hashtagPerformance: hashtagPerformance.map(h => ({
         hashtag: h.hashtag,
         usageCount: h.usageCount,
         avgEngagementRate: h.avgEngagementRate,

--- a/apps/psypnos/lib/social/analytics.ts
+++ b/apps/psypnos/lib/social/analytics.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - SocialPost model not available in Kairn schema
+// @ts-nocheck — pre-existing type issues in refreshPostAnalytics (social client interface)
 /**
  * Service d'analytics pour les réseaux sociaux
  *
@@ -146,13 +145,16 @@ export async function getDashboardStats(
   startDate?: Date,
   endDate?: Date
 ): Promise<SocialDashboardStats> {
-  const dateFilter = buildDateFilter(startDate, endDate);
+  // Post counts use createdAt (includes drafts/scheduled without publishedAt)
+  const createdFilter = buildDateFilter(startDate, endDate, 'createdAt');
+  // Analytics aggregate uses publishedAt (only published posts have analytics)
+  const publishedFilter = buildDateFilter(startDate, endDate);
 
   // Compter les posts par statut
   const postCounts = await prisma.socialPost.groupBy({
     by: ['status'],
     _count: { _all: true },
-    where: dateFilter,
+    where: createdFilter,
   });
 
   const countByStatus = Object.fromEntries(
@@ -170,7 +172,7 @@ export async function getDashboardStats(
       shares: true,
     },
     where: {
-      post: dateFilter,
+      post: publishedFilter,
     },
   });
 
@@ -196,8 +198,7 @@ export async function getDashboardStats(
     totalLikes: analyticsAgg._sum.likes || 0,
     totalComments: analyticsAgg._sum.comments || 0,
     totalShares: analyticsAgg._sum.shares || 0,
-    averageEngagementRate:
-      totalImpressions > 0 ? (totalEngagements / totalImpressions) * 100 : 0,
+    averageEngagementRate: totalImpressions > 0 ? (totalEngagements / totalImpressions) * 100 : 0,
   };
 }
 
@@ -311,7 +312,7 @@ export async function getTopPerformingPosts(
     take: limit,
   });
 
-  return posts.map((post: typeof posts[number]) => {
+  return posts.map((post: (typeof posts)[number]) => {
     const impressions = post.analytics?.impressions || 0;
     const engagements = post.analytics?.engagements || 0;
     const mediaUrls = Array.isArray(post.mediaUrls) ? post.mediaUrls.map(String) : [];
@@ -438,7 +439,7 @@ export async function getRecentPosts(limit = 20): Promise<RecentPost[]> {
     take: limit,
   });
 
-  return posts.map((post: typeof posts[number]) => ({
+  return posts.map((post: (typeof posts)[number]) => ({
     id: post.id,
     platform: post.platform as SocialPlatform,
     content: post.content,
@@ -459,9 +460,7 @@ export async function getRecentPosts(limit = 20): Promise<RecentPost[]> {
 /**
  * Rafraîchit les analytics d'un post depuis l'API de la plateforme
  */
-export async function refreshPostAnalytics(
-  postId: string
-): Promise<SocialPostAnalytics | null> {
+export async function refreshPostAnalytics(postId: string): Promise<SocialPostAnalytics | null> {
   const post = await prisma.socialPost.findUnique({
     where: { id: postId },
     include: { account: true },
@@ -547,7 +546,7 @@ export async function refreshRecentAnalytics(
     }
 
     // Petit délai pour éviter le rate limiting
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise(resolve => setTimeout(resolve, 500));
   }
 
   return { refreshed, failed };
@@ -569,10 +568,7 @@ export interface ComparisonStats {
  * de même durée. Ex: si startDate-endDate = 30 jours, on compare avec les 30 jours
  * précédents.
  */
-export async function getComparisonStats(
-  startDate: Date,
-  endDate: Date
-): Promise<ComparisonStats> {
+export async function getComparisonStats(startDate: Date, endDate: Date): Promise<ComparisonStats> {
   const durationMs = endDate.getTime() - startDate.getTime();
   const prevStart = new Date(startDate.getTime() - durationMs);
   const prevEnd = new Date(startDate.getTime());
@@ -591,8 +587,7 @@ export async function getComparisonStats(
     postsChange: pctChange(currentStats.publishedPosts, previousStats.publishedPosts),
     reachChange: pctChange(currentStats.totalReach, previousStats.totalReach),
     engagementChange: pctChange(currentStats.totalEngagements, previousStats.totalEngagements),
-    engagementRateChange:
-      currentStats.averageEngagementRate - previousStats.averageEngagementRate,
+    engagementRateChange: currentStats.averageEngagementRate - previousStats.averageEngagementRate,
   };
 }
 
@@ -764,7 +759,7 @@ export interface HashtagPerformance {
 function extractHashtags(content: string): string[] {
   const matches = content.match(/#[\w\u00C0-\u024F]+/g);
   if (!matches) return [];
-  return [...new Set(matches.map((h) => h.toLowerCase()))];
+  return [...new Set(matches.map(h => h.toLowerCase()))];
 }
 
 /**
@@ -853,7 +848,18 @@ export async function getHashtagPerformance(
 // Helpers
 // ===========================================
 
-function buildDateFilter(startDate?: Date, endDate?: Date) {
+/**
+ * Construit un filtre Prisma de plage de dates.
+ *
+ * @param startDate - Début de la plage (inclus)
+ * @param endDate - Fin de la plage (inclus)
+ * @param field - Champ de date à filtrer (défaut: 'publishedAt')
+ */
+function buildDateFilter(
+  startDate?: Date,
+  endDate?: Date,
+  field: 'publishedAt' | 'createdAt' = 'publishedAt'
+) {
   if (!startDate && !endDate) {
     return {};
   }
@@ -861,12 +867,12 @@ function buildDateFilter(startDate?: Date, endDate?: Date) {
   const filter: Record<string, unknown> = {};
 
   if (startDate || endDate) {
-    filter.createdAt = {};
+    filter[field] = {};
     if (startDate) {
-      (filter.createdAt as Record<string, Date>).gte = startDate;
+      (filter[field] as Record<string, Date>).gte = startDate;
     }
     if (endDate) {
-      (filter.createdAt as Record<string, Date>).lte = endDate;
+      (filter[field] as Record<string, Date>).lte = endDate;
     }
   }
 

--- a/apps/psypnos/lib/social/snapshots.ts
+++ b/apps/psypnos/lib/social/snapshots.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
+// @ts-nocheck — pre-existing type issues (Prisma JSON typing, social client interface)
 /**
  * Service de snapshots pour le suivi historique des métriques de comptes sociaux
  *
@@ -116,7 +116,7 @@ export async function captureAllSnapshots(): Promise<{
   errors: Array<{ accountId: string; error: string }>;
 }> {
   const accounts = await getAllSocialAccounts();
-  const activeAccounts = accounts.filter((a) => a.isActive);
+  const activeAccounts = accounts.filter(a => a.isActive);
 
   let captured = 0;
   let failed = 0;
@@ -151,7 +151,7 @@ export async function captureAllSnapshots(): Promise<{
     }
 
     // Petit délai pour éviter le rate limiting
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await new Promise(resolve => setTimeout(resolve, 300));
   }
 
   return { captured, failed, errors };
@@ -180,7 +180,7 @@ export async function getAccountSnapshots(
     orderBy: { snapshotDate: 'asc' },
   });
 
-  return snapshots.map((s) => ({
+  return snapshots.map(s => ({
     accountId: s.accountId,
     platform: s.platform as SocialPlatform,
     followers: s.followers,
@@ -227,10 +227,7 @@ export async function getLatestSnapshots(): Promise<AccountSnapshot[]> {
  * Calcule la croissance des followers pour chaque plateforme
  * sur une période donnée.
  */
-export async function getFollowerGrowth(
-  startDate: Date,
-  endDate: Date
-): Promise<FollowerGrowth[]> {
+export async function getFollowerGrowth(startDate: Date, endDate: Date): Promise<FollowerGrowth[]> {
   const accounts = await prisma.socialAccount.findMany({
     where: { isActive: true },
     select: { id: true, platform: true },
@@ -314,9 +311,10 @@ export async function getTotalFollowersByPlatform(): Promise<
     });
 
     const previousFollowers = weekAgoSnapshots.reduce((sum, s) => sum + s.followers, 0);
-    const change = previousFollowers > 0
-      ? ((currentFollowers - previousFollowers) / previousFollowers) * 100
-      : 0;
+    const change =
+      previousFollowers > 0
+        ? ((currentFollowers - previousFollowers) / previousFollowers) * 100
+        : 0;
 
     result.set(platform, { followers: currentFollowers, change });
   }

--- a/apps/psypnos/lib/social/store.ts
+++ b/apps/psypnos/lib/social/store.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - SocialPost model not available in Kairn schema
+// @ts-nocheck — pre-existing type issues (SocialTemplate/SocialGenerationLog models, SocialAccount fields)
 /**
  * Store pour les opérations CRUD sur les données des réseaux sociaux
  *

--- a/apps/psypnos/lib/social/types.ts
+++ b/apps/psypnos/lib/social/types.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
 /**
  * Types TypeScript pour le système d'automatisation des réseaux sociaux
  *
@@ -18,12 +15,7 @@
 /**
  * Plateformes sociales supportées
  */
-export type SocialPlatform =
-  | 'FACEBOOK'
-  | 'LINKEDIN'
-  | 'INSTAGRAM'
-  | 'TWITTER'
-  | 'THREADS';
+export type SocialPlatform = 'FACEBOOK' | 'LINKEDIN' | 'INSTAGRAM' | 'TWITTER' | 'THREADS';
 
 /**
  * Plateformes actuellement implémentées
@@ -55,12 +47,7 @@ export type GenerationSource = 'ai' | 'manual';
 /**
  * Tons de génération pour le contenu
  */
-export type ContentTone =
-  | 'informatif'
-  | 'inspirant'
-  | 'promotionnel'
-  | 'educatif'
-  | 'personnel';
+export type ContentTone = 'informatif' | 'inspirant' | 'promotionnel' | 'educatif' | 'personnel';
 
 /**
  * Angles de contenu pour la génération
@@ -152,44 +139,44 @@ export type LinkedInExpertiseLevel = 1 | 2 | 3 | 4 | 5;
  * Formats de posts Instagram pour la promotion de séminaires
  */
 export type SeminarInstagramFormat =
-  | 'compte_rebours'      // Urgence avec décompte des jours/places
-  | 'apercu_experience'   // Prévisualisation de l'expérience
-  | 'temoignage_passe'    // Retour sur un séminaire précédent
-  | 'question_reflexive'  // Question qui fait réfléchir sur le besoin
-  | 'liste_benefices'     // Liste des bénéfices de participation
-  | 'coulisses';          // Behind-the-scenes de la préparation
+  | 'compte_rebours' // Urgence avec décompte des jours/places
+  | 'apercu_experience' // Prévisualisation de l'expérience
+  | 'temoignage_passe' // Retour sur un séminaire précédent
+  | 'question_reflexive' // Question qui fait réfléchir sur le besoin
+  | 'liste_benefices' // Liste des bénéfices de participation
+  | 'coulisses'; // Behind-the-scenes de la préparation
 
 /**
  * Formats de posts LinkedIn pour la promotion de séminaires
  */
 export type SeminarLinkedInFormat =
-  | 'annonce_expert'      // Annonce avec positionnement d'expertise
-  | 'probleme_solution'   // Problème courant + séminaire comme solution
+  | 'annonce_expert' // Annonce avec positionnement d'expertise
+  | 'probleme_solution' // Problème courant + séminaire comme solution
   | 'observation_terrain' // Observation qui justifie le séminaire
-  | 'invitation_reflexion'// Question pro + invitation au séminaire
-  | 'programme_detaille'  // Présentation structurée du programme
-  | 'derniere_chance';    // Urgence professionnelle
+  | 'invitation_reflexion' // Question pro + invitation au séminaire
+  | 'programme_detaille' // Présentation structurée du programme
+  | 'derniere_chance'; // Urgence professionnelle
 
 /**
  * Formats de posts Facebook pour la promotion de séminaires
  */
 export type SeminarFacebookFormat =
-  | 'invitation_chaleureuse'  // Ton conversationnel et accueillant
+  | 'invitation_chaleureuse' // Ton conversationnel et accueillant
   | 'histoire_transformation' // Récit d'un participant passé
-  | 'question_engagement'     // Question + invitation
-  | 'details_pratiques'       // Infos concrètes avec CTA
-  | 'derniers_jours'          // Urgence bienveillante
-  | 'partage_vision';         // Pourquoi ce séminaire existe
+  | 'question_engagement' // Question + invitation
+  | 'details_pratiques' // Infos concrètes avec CTA
+  | 'derniers_jours' // Urgence bienveillante
+  | 'partage_vision'; // Pourquoi ce séminaire existe
 
 /**
  * Formats de posts Threads pour la promotion de séminaires
  */
 export type SeminarThreadsFormat =
-  | 'pensee_spontanee'    // Réflexion naturelle sur le séminaire
-  | 'micro_confession'    // Partage personnel du praticien
-  | 'question_ouverte'    // Question sans réponse directe
+  | 'pensee_spontanee' // Réflexion naturelle sur le séminaire
+  | 'micro_confession' // Partage personnel du praticien
+  | 'question_ouverte' // Question sans réponse directe
   | 'fragment_anticipation' // Évocation poétique de l'expérience
-  | 'rappel_humain';      // Rappel simple et authentique
+  | 'rappel_humain'; // Rappel simple et authentique
 
 /**
  * Niveau d'urgence pour les posts de séminaires
@@ -337,7 +324,7 @@ export interface SocialPostMetadata {
   instagramFormat?: InstagramPostFormat;
   authenticityLevel?: AuthenticityLevel;
 
-// Options spécifiques Threads
+  // Options spécifiques Threads
   threadsFormat?: ThreadsPostFormat;
   threadsAuthenticityLevel?: ThreadsAuthenticityLevel;
 
@@ -539,7 +526,7 @@ export interface GenerationOptions {
   // Options spécifiques Instagram
   instagramFormat?: InstagramPostFormat;
   authenticityLevel?: AuthenticityLevel;
-// Options spécifiques Threads
+  // Options spécifiques Threads
   threadsFormat?: ThreadsPostFormat;
   threadsAuthenticityLevel?: ThreadsAuthenticityLevel;
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1050,6 +1050,10 @@ model SocialPost {
   blogSlug       String?
   /// Media URLs as JSON array
   mediaUrls      Json?
+  /// Hashtags as JSON array
+  hashtags       Json?
+  /// Link URL included in the post
+  linkUrl        String?
   /// Post status
   status         SocialPostStatus @default(DRAFT)
   /// Scheduled publication time
@@ -1058,12 +1062,20 @@ model SocialPost {
   publishedAt    DateTime?
   /// Platform-specific post ID after publishing
   externalPostId String?
-  /// External post URL
-  externalUrl    String?
+  /// Direct link to view published post on the platform
+  platformUrl    String?
   /// Error message if failed
   errorMessage   String?
   /// Retry count for failed posts
   retryCount     Int              @default(0)
+  /// Content generation source ('ai' or 'manual')
+  generatedBy    String?
+  /// AI prompt used for generation
+  aiPrompt       String?          @db.Text
+  /// AI model used for generation
+  aiModel        String?
+  /// Platform-specific metadata as JSON
+  metadata       Json?
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
 


### PR DESCRIPTION
The Posts tab in /admin/analytics displayed no data because the SocialPost
Prisma model was missing 7 fields that store.ts/types.ts expected: hashtags,
linkUrl, platformUrl (was externalUrl), generatedBy, aiPrompt, aiModel, and
metadata. This caused Prisma runtime errors on post creation, leaving the
table empty.

Also fixes buildDateFilter() to filter published posts by publishedAt instead
of createdAt, and removes @ts-nocheck from types.ts and route.ts.

https://claude.ai/code/session_01RrnpvqSgT7rRfbfkEUUReR