### PR TITLE
fix(analytics): fix traffic distribution dropping all visits without UTM medium

### DIFF
--- a/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
+++ b/apps/psypnos/app/api/analytics/store-postgres/analytics.ts
@@ -532,7 +532,18 @@ export async function getTrafficSources(startDate?: string, endDate?: string) {
       >`
         SELECT
           COALESCE(data->>'utmSource', data->>'referrerDomain', 'direct') as source,
-          COALESCE(data->>'utmMedium', 'none') as medium,
+          COALESCE(
+            NULLIF(data->>'utmMedium', ''),
+            CASE
+              WHEN data->>'referrerDomain' IS NOT NULL THEN
+                CASE
+                  WHEN data->>'referrerDomain' ~* '(google|bing|yahoo|duckduckgo|baidu|yandex|ecosia|qwant)\.' THEN 'organic'
+                  WHEN data->>'referrerDomain' ~* '(facebook|instagram|twitter|x\.com|linkedin|tiktok|pinterest|reddit|threads|mastodon|youtube)\.' THEN 'social'
+                  ELSE 'referral'
+                END
+              ELSE 'direct'
+            END
+          ) as medium,
           COUNT(*) as visits,
           COUNT(DISTINCT "sessionId") as unique_sessions
         FROM "AnalyticsEvent"

--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -508,14 +508,22 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
 
       trafficSources.forEach((source: any) => {
         const medium = source.medium?.toLowerCase() || '';
-        if (medium === 'direct' || medium === '(none)') {
+        const sourceName = source.source?.toLowerCase() || '';
+        if (medium === 'direct' || medium === '(none)' || medium === 'none' || (medium === '' && sourceName === 'direct')) {
           directTraffic += source.visits || 0;
         } else if (medium === 'organic') {
           organicTraffic += source.visits || 0;
-        } else if (medium === 'referral') {
+        } else if (medium === 'referral' || medium === 'email' || medium === 'cpc' || medium === 'cpm') {
           referralTraffic += source.visits || 0;
         } else if (medium === 'social') {
           socialTraffic += source.visits || 0;
+        } else {
+          // Any other unrecognized medium: classify based on source name
+          if (sourceName === 'direct' || sourceName === '') {
+            directTraffic += source.visits || 0;
+          } else {
+            referralTraffic += source.visits || 0;
+          }
         }
       });
 


### PR DESCRIPTION
The SQL query defaulted to medium='none' when utmMedium was absent, but
the frontend only matched 'direct' and '(none)' (GA-style), causing all
non-UTM traffic to silently disappear from the pie chart.

Backend: infer medium from referrer domain when utmMedium is not set —
detect search engines as 'organic', social platforms as 'social', other
referrers as 'referral', and no referrer as 'direct'.

Frontend: handle 'none' medium defensively, add fallback for unrecognized
mediums (email, cpc, etc.), and ensure no traffic is silently dropped.

https://claude.ai/code/session_01CvR3D2umPQJ2ABfG72sbBU