### PR TITLE
fix(chatbot): fix admin page loading error and add multi-tenant isolation

### DIFF
--- a/apps/psypnos/app/admin/chatbot/page.tsx
+++ b/apps/psypnos/app/admin/chatbot/page.tsx
@@ -1,26 +1,24 @@
-"use client";
+'use client';
 
-export const dynamic = "force-dynamic";
+import { useCallback, useEffect, useState } from 'react';
 
-import { useCallback, useEffect, useState } from "react";
+import { useToast } from '@/lib/toast-context';
 
-import { useToast } from "@/lib/toast-context";
+import { DeleteConfirmation } from '../_components/DeleteConfirmation';
 
-import { DeleteConfirmation } from "../_components/DeleteConfirmation";
-
-import { ChatbotStatsCards } from "./_components/ChatbotStats";
-import { ChatbotToggle } from "./_components/ChatbotToggle";
-import { ChatbotSkeleton } from "./_components/ChatbotSkeleton";
-import { ConversationFilters } from "./_components/ConversationFilters";
-import { ConversationsTable } from "./_components/ConversationsTable";
-import { ConversationDrawer } from "./_components/ConversationDrawer";
-import { Pagination } from "./_components/Pagination";
+import { ChatbotSkeleton } from './_components/ChatbotSkeleton';
+import { ChatbotStatsCards } from './_components/ChatbotStats';
+import { ChatbotToggle } from './_components/ChatbotToggle';
+import { ConversationDrawer } from './_components/ConversationDrawer';
+import { ConversationFilters } from './_components/ConversationFilters';
+import { ConversationsTable } from './_components/ConversationsTable';
+import { Pagination } from './_components/Pagination';
 import type {
   ConversationPreview,
   ConversationsResponse,
   ChatbotStats,
   PaginationInfo,
-} from "./types";
+} from './types';
 
 const DEFAULT_STATS: ChatbotStats = {
   totalConversations: 0,
@@ -59,13 +57,13 @@ export default function ChatbotAdminPage() {
   const [isDeleting, setIsDeleting] = useState(false);
 
   // Filters
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
-  const [satisfactionFilter, setSatisfactionFilter] = useState("");
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [satisfactionFilter, setSatisfactionFilter] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
 
   // Debounced search
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState('');
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(search), 400);
@@ -82,14 +80,14 @@ export default function ChatbotAdminPage() {
     setIsRefreshing(true);
     try {
       const params = new URLSearchParams();
-      params.set("page", String(currentPage));
-      params.set("limit", "20");
-      if (debouncedSearch) params.set("search", debouncedSearch);
-      if (statusFilter) params.set("status", statusFilter);
-      if (satisfactionFilter) params.set("satisfaction", satisfactionFilter);
+      params.set('page', String(currentPage));
+      params.set('limit', '20');
+      if (debouncedSearch) params.set('search', debouncedSearch);
+      if (statusFilter) params.set('status', statusFilter);
+      if (satisfactionFilter) params.set('satisfaction', satisfactionFilter);
 
       const response = await fetch(`/api/admin/chatbot/conversations?${params}`);
-      if (!response.ok) throw new Error("Erreur lors du chargement");
+      if (!response.ok) throw new Error('Erreur lors du chargement');
 
       const data: ConversationsResponse = await response.json();
       setConversations(data.conversations);
@@ -97,10 +95,10 @@ export default function ChatbotAdminPage() {
       setPagination(data.pagination);
     } catch (error) {
       addToast({
-        title: "Erreur de chargement",
+        title: 'Erreur de chargement',
         description:
-          error instanceof Error ? error.message : "Impossible de charger les conversations",
-        variant: "error",
+          error instanceof Error ? error.message : 'Impossible de charger les conversations',
+        variant: 'error',
       });
     } finally {
       setIsInitialLoading(false);
@@ -114,7 +112,7 @@ export default function ChatbotAdminPage() {
 
   // Selection handlers
   function toggleSelect(id: string) {
-    setSelectedIds((prev) => {
+    setSelectedIds(prev => {
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);
@@ -126,10 +124,10 @@ export default function ChatbotAdminPage() {
   }
 
   function toggleSelectAll() {
-    if (conversations.every((c) => selectedIds.has(c.id))) {
+    if (conversations.every(c => selectedIds.has(c.id))) {
       setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(conversations.map((c) => c.id)));
+      setSelectedIds(new Set(conversations.map(c => c.id)));
     }
   }
 
@@ -138,30 +136,30 @@ export default function ChatbotAdminPage() {
     setIsDeleting(true);
     try {
       const response = await fetch(`/api/admin/chatbot/conversations/${id}`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
-      if (!response.ok) throw new Error("Erreur lors de la suppression");
+      if (!response.ok) throw new Error('Erreur lors de la suppression');
 
-      setConversations((prev) => prev.filter((c) => c.id !== id));
+      setConversations(prev => prev.filter(c => c.id !== id));
       selectedIds.delete(id);
       setSelectedIds(new Set(selectedIds));
       setDeleteTarget(null);
       setDrawerConversation(null);
 
       addToast({
-        title: "Conversation supprimée",
-        description: "La conversation a été supprimée avec succès",
-        variant: "success",
+        title: 'Conversation supprimée',
+        description: 'La conversation a été supprimée avec succès',
+        variant: 'success',
       });
 
       // Refresh stats
       void fetchConversations();
     } catch (error) {
       addToast({
-        title: "Erreur de suppression",
+        title: 'Erreur de suppression',
         description:
-          error instanceof Error ? error.message : "Impossible de supprimer la conversation",
-        variant: "error",
+          error instanceof Error ? error.message : 'Impossible de supprimer la conversation',
+        variant: 'error',
       });
     } finally {
       setIsDeleting(false);
@@ -174,30 +172,30 @@ export default function ChatbotAdminPage() {
 
     setIsDeleting(true);
     try {
-      const response = await fetch("/api/admin/chatbot/conversations/bulk", {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+      const response = await fetch('/api/admin/chatbot/conversations/bulk', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids: Array.from(selectedIds) }),
       });
-      if (!response.ok) throw new Error("Erreur lors de la suppression");
+      if (!response.ok) throw new Error('Erreur lors de la suppression');
 
       const data = await response.json();
       setSelectedIds(new Set());
       setBulkDeleteConfirm(false);
 
       addToast({
-        title: "Conversations supprimées",
+        title: 'Conversations supprimées',
         description: `${data.deleted} conversation(s) supprimée(s)`,
-        variant: "success",
+        variant: 'success',
       });
 
       void fetchConversations();
     } catch (error) {
       addToast({
-        title: "Erreur de suppression",
+        title: 'Erreur de suppression',
         description:
-          error instanceof Error ? error.message : "Impossible de supprimer les conversations",
-        variant: "error",
+          error instanceof Error ? error.message : 'Impossible de supprimer les conversations',
+        variant: 'error',
       });
     } finally {
       setIsDeleting(false);
@@ -213,8 +211,8 @@ export default function ChatbotAdminPage() {
       {/* Page header */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-2xl font-semibold text-ivory">ChatBot IA</h2>
-          <p className="text-sm text-ivory/60">
+          <h2 className="text-ivory text-2xl font-semibold">ChatBot IA</h2>
+          <p className="text-ivory/60 text-sm">
             Historique des conversations et gestion du chatbot.
           </p>
         </div>
@@ -222,21 +220,21 @@ export default function ChatbotAdminPage() {
           type="button"
           onClick={() => void fetchConversations()}
           disabled={isRefreshing}
-          className="inline-flex items-center justify-center rounded-md border border-gold/40 px-4 py-2 text-sm font-medium text-gold transition hover:bg-gold/10 disabled:opacity-50"
+          className="border-gold/40 text-gold hover:bg-gold/10 inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium transition disabled:opacity-50"
         >
-          {isRefreshing ? "Actualisation..." : "Actualiser"}
+          {isRefreshing ? 'Actualisation...' : 'Actualiser'}
         </button>
       </div>
 
       {/* Chatbot toggle */}
       <ChatbotToggle
-        onStatusChange={(enabled) => {
+        onStatusChange={enabled => {
           addToast({
-            title: enabled ? "ChatBot IA activé" : "ChatBot IA désactivé",
+            title: enabled ? 'ChatBot IA activé' : 'ChatBot IA désactivé',
             description: enabled
-              ? "Le chatbot est maintenant visible sur le site"
-              : "Le chatbot est masqué pour les visiteurs",
-            variant: "success",
+              ? 'Le chatbot est maintenant visible sur le site'
+              : 'Le chatbot est masqué pour les visiteurs',
+            variant: 'success',
           });
         }}
       />
@@ -256,20 +254,20 @@ export default function ChatbotAdminPage() {
 
       {/* Bulk actions */}
       {selectedIds.size > 0 && (
-        <div className="flex items-center gap-3 rounded-lg border border-gold/20 bg-gold/5 px-4 py-2">
-          <span className="text-sm text-gold">
-            {selectedIds.size} conversation{selectedIds.size > 1 ? "s" : ""} sélectionnée
-            {selectedIds.size > 1 ? "s" : ""}
+        <div className="border-gold/20 bg-gold/5 flex items-center gap-3 rounded-lg border px-4 py-2">
+          <span className="text-gold text-sm">
+            {selectedIds.size} conversation{selectedIds.size > 1 ? 's' : ''} sélectionnée
+            {selectedIds.size > 1 ? 's' : ''}
           </span>
           <button
             onClick={() => setBulkDeleteConfirm(true)}
-            className="rounded-md bg-rose-500/80 px-3 py-1 text-xs font-semibold text-ivory transition hover:bg-rose-500"
+            className="text-ivory rounded-md bg-rose-500/80 px-3 py-1 text-xs font-semibold transition hover:bg-rose-500"
           >
             Supprimer la sélection
           </button>
           <button
             onClick={() => setSelectedIds(new Set())}
-            className="text-xs text-ivory/50 transition hover:text-ivory"
+            className="text-ivory/50 hover:text-ivory text-xs transition"
           >
             Tout désélectionner
           </button>
@@ -294,7 +292,7 @@ export default function ChatbotAdminPage() {
         conversation={drawerConversation}
         open={Boolean(drawerConversation)}
         onClose={() => setDrawerConversation(null)}
-        onDelete={(conv) => {
+        onDelete={conv => {
           setDrawerConversation(null);
           setDeleteTarget(conv);
         }}
@@ -307,7 +305,7 @@ export default function ChatbotAdminPage() {
         description={
           deleteTarget
             ? `Êtes-vous sûr de vouloir supprimer cette conversation (${deleteTarget.messageCount} messages) ? Cette action est irréversible.`
-            : ""
+            : ''
         }
         loading={isDeleting}
         onCancel={() => setDeleteTarget(null)}
@@ -322,7 +320,7 @@ export default function ChatbotAdminPage() {
       <DeleteConfirmation
         open={bulkDeleteConfirm}
         title="Supprimer les conversations sélectionnées"
-        description={`Êtes-vous sûr de vouloir supprimer ${selectedIds.size} conversation${selectedIds.size > 1 ? "s" : ""} ? Cette action est irréversible.`}
+        description={`Êtes-vous sûr de vouloir supprimer ${selectedIds.size} conversation${selectedIds.size > 1 ? 's' : ''} ? Cette action est irréversible.`}
         loading={isDeleting}
         onCancel={() => setBulkDeleteConfirm(false)}
         onConfirm={() => void handleBulkDelete()}

--- a/apps/psypnos/app/api/admin/chatbot/conversations/[id]/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 import { withAdminAuth } from '../../../../auth/middleware';
 
@@ -15,8 +16,9 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   const { id } = await params;
 
   try {
-    const conversation = await prisma.chatConversation.findUnique({
-      where: { id },
+    const siteId = await getSiteId();
+    const conversation = await prisma.chatConversation.findFirst({
+      where: { id, siteId },
       include: {
         messages: {
           orderBy: { createdAt: 'asc' },
@@ -74,8 +76,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
   const { id } = await params;
 
   try {
-    const conversation = await prisma.chatConversation.findUnique({
-      where: { id },
+    const siteId = await getSiteId();
+    const conversation = await prisma.chatConversation.findFirst({
+      where: { id, siteId },
     });
 
     if (!conversation) {

--- a/apps/psypnos/app/api/admin/chatbot/conversations/bulk/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/bulk/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
-import { withAdminAuth } from '../../../../auth/middleware';
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
+
+import { withAdminAuth } from '../../../../auth/middleware';
 
 const bulkDeleteSchema = z.object({
   ids: z.array(z.string()).min(1).max(100),
@@ -25,9 +27,10 @@ export async function DELETE(request: Request) {
     }
 
     const { ids } = parsed.data;
+    const siteId = await getSiteId();
 
     const result = await prisma.chatConversation.deleteMany({
-      where: { id: { in: ids } },
+      where: { id: { in: ids }, siteId },
     });
 
     return NextResponse.json({

--- a/apps/psypnos/app/api/admin/chatbot/conversations/route.ts
+++ b/apps/psypnos/app/api/admin/chatbot/conversations/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 import { withAdminAuth } from '../../../auth/middleware';
 
@@ -22,8 +23,10 @@ export async function GET(request: Request) {
   const sortOrder = searchParams.get('sortOrder') === 'asc' ? 'asc' : 'desc';
 
   try {
-    // Build where clause
-    const where: Record<string, unknown> = {};
+    const siteId = await getSiteId();
+
+    // Build where clause — always scoped to current site
+    const where: Record<string, unknown> = { siteId };
 
     if (status && ['active', 'ended', 'transferred'].includes(status)) {
       where.status = status;
@@ -73,7 +76,8 @@ export async function GET(request: Request) {
       prisma.chatConversation.count({ where }),
     ]);
 
-    // Get overall stats
+    // Get overall stats — scoped to current site
+    const siteFilter = { siteId };
     const [
       totalConversations,
       activeConversations,
@@ -84,14 +88,20 @@ export async function GET(request: Request) {
       todayConversations,
       weekConversations,
     ] = await Promise.all([
-      prisma.chatConversation.count(),
-      prisma.chatConversation.count({ where: { status: 'active' } }),
-      prisma.chatConversation.count({ where: { satisfied: true } }),
-      prisma.chatConversation.count({ where: { satisfied: false } }),
-      prisma.chatMessage.count(),
-      prisma.chatConversation.aggregate({ _avg: { messageCount: true } }),
+      prisma.chatConversation.count({ where: siteFilter }),
+      prisma.chatConversation.count({ where: { ...siteFilter, status: 'active' } }),
+      prisma.chatConversation.count({ where: { ...siteFilter, satisfied: true } }),
+      prisma.chatConversation.count({ where: { ...siteFilter, satisfied: false } }),
+      prisma.chatMessage.count({
+        where: { conversation: { siteId } },
+      }),
+      prisma.chatConversation.aggregate({
+        where: siteFilter,
+        _avg: { messageCount: true },
+      }),
       prisma.chatConversation.count({
         where: {
+          ...siteFilter,
           createdAt: {
             gte: new Date(new Date().setHours(0, 0, 0, 0)),
           },
@@ -99,6 +109,7 @@ export async function GET(request: Request) {
       }),
       prisma.chatConversation.count({
         where: {
+          ...siteFilter,
           createdAt: {
             gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
           },

--- a/apps/psypnos/app/api/chat/feedback/route.ts
+++ b/apps/psypnos/app/api/chat/feedback/route.ts
@@ -1,10 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Type incompatibilities to fix
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 const feedbackSchema = z.object({
   conversationId: z.string(),
@@ -25,6 +23,17 @@ export async function POST(request: Request) {
     }
 
     const { conversationId, satisfied } = parsed.data;
+    const siteId = await getSiteId();
+
+    // Verify the conversation belongs to this site before updating
+    const conversation = await prisma.chatConversation.findFirst({
+      where: { id: conversationId, siteId },
+      select: { id: true },
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: 'Conversation introuvable' }, { status: 404 });
+    }
 
     // Update conversation with feedback
     await prisma.chatConversation.update({
@@ -41,7 +50,7 @@ export async function POST(request: Request) {
       message: 'Merci pour votre retour !',
     });
   } catch (error) {
-    console.error('Feedback error:', error);
+    console.error('[Chat] Feedback error:', error);
     return NextResponse.json(
       { error: "Erreur lors de l'enregistrement du feedback" },
       { status: 500 }
@@ -51,10 +60,13 @@ export async function POST(request: Request) {
 
 /**
  * GET /api/chat/feedback
- * Get chat statistics (admin only)
+ * Get chat statistics (scoped to current site)
  */
 export async function GET() {
   try {
+    const siteId = await getSiteId();
+    const siteFilter = { siteId };
+
     const [
       totalConversations,
       satisfiedConversations,
@@ -62,18 +74,19 @@ export async function GET() {
       totalMessages,
       averageMessagesPerConversation,
     ] = await Promise.all([
-      prisma.chatConversation.count(),
-      prisma.chatConversation.count({ where: { satisfied: true } }),
-      prisma.chatConversation.count({ where: { satisfied: false } }),
-      prisma.chatMessage.count(),
+      prisma.chatConversation.count({ where: siteFilter }),
+      prisma.chatConversation.count({ where: { ...siteFilter, satisfied: true } }),
+      prisma.chatConversation.count({ where: { ...siteFilter, satisfied: false } }),
+      prisma.chatMessage.count({ where: { conversation: { siteId } } }),
       prisma.chatConversation.aggregate({
+        where: siteFilter,
         _avg: { messageCount: true },
       }),
     ]);
 
     // Recent conversations with feedback
     const recentFeedback = await prisma.chatConversation.findMany({
-      where: { satisfied: { not: null } },
+      where: { ...siteFilter, satisfied: { not: null } },
       take: 10,
       orderBy: { endedAt: 'desc' },
       select: {
@@ -101,7 +114,7 @@ export async function GET() {
       recentFeedback,
     });
   } catch (error) {
-    console.error('Stats error:', error);
+    console.error('[Chat] Stats error:', error);
     return NextResponse.json(
       { error: 'Erreur lors de la récupération des statistiques' },
       { status: 500 }

--- a/apps/psypnos/app/api/chat/route.ts
+++ b/apps/psypnos/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 import { recordAttemptAsync, getClientIP } from '../common/rate-limiter';
 
@@ -85,6 +86,17 @@ IMPORTANT : À la fin de ta réponse, si une action est pertinente, ajoute sur u
 
 const FALLBACK_ERROR_MESSAGE =
   'Désolé, je rencontre des difficultés techniques. Vous pouvez nous contacter directement via le formulaire de contact.';
+
+/**
+ * Parse the User-Agent header to determine device type (mobile, tablet, desktop).
+ */
+function parseDeviceType(userAgent: string | null): string {
+  if (!userAgent) return 'unknown';
+  const ua = userAgent.toLowerCase();
+  if (/tablet|ipad|playbook|silk/.test(ua)) return 'tablet';
+  if (/mobile|iphone|ipod|android.*phone|windows phone|blackberry/.test(ua)) return 'mobile';
+  return 'desktop';
+}
 
 /**
  * Sanitize message history for Anthropic API:
@@ -179,6 +191,22 @@ export async function POST(request: Request) {
 
   const { message, conversationId: existingConversationId, sessionId, context } = parsed.data;
 
+  // Resolve site ID for multi-tenancy
+  let siteId: string;
+  try {
+    siteId = await getSiteId();
+  } catch (siteError) {
+    console.error('[Chat] Failed to resolve siteId:', siteError);
+    return NextResponse.json(
+      {
+        error: 'database_error',
+        message: FALLBACK_ERROR_MESSAGE,
+        suggestedActions: [{ type: 'contact', label: 'Nous contacter', url: '/contact' }],
+      },
+      { status: 500 }
+    );
+  }
+
   // Get or create conversation
   let conversation;
   let conversationId = existingConversationId;
@@ -198,11 +226,14 @@ export async function POST(request: Request) {
 
     if (!conversation) {
       const ipHash = crypto.createHash('sha256').update(clientIP).digest('hex').slice(0, 16);
+      const deviceType = parseDeviceType(request.headers.get('user-agent'));
       conversation = await prisma.chatConversation.create({
         data: {
           sessionId: sessionId || `chat-${Date.now()}`,
           ipHash,
           referrer: context?.currentPage,
+          deviceType,
+          siteId,
         },
         include: { messages: true },
       });

--- a/apps/psypnos/components/ChatWidgetWrapper.tsx
+++ b/apps/psypnos/components/ChatWidgetWrapper.tsx
@@ -1,10 +1,25 @@
 'use client';
 
 import { ChatWidget } from '@kairn/ui';
-import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 import { trackConversionEvent } from '../hooks/useAnalytics';
+
+/**
+ * Get or create a persistent session ID for chatbot conversation tracking.
+ * Stored in sessionStorage so it persists across page navigations within
+ * the same browser session.
+ */
+function getChatSessionId(): string {
+  if (typeof window === 'undefined') return '';
+  let id = sessionStorage.getItem('psypnos_chat_session');
+  if (!id) {
+    id = `chat_${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+    sessionStorage.setItem('psypnos_chat_session', id);
+  }
+  return id;
+}
 
 /**
  * Psypnos-specific wrapper for the AI ChatWidget.
@@ -64,6 +79,7 @@ export function PsypnosChatWidget() {
       secondaryColor="#1a1a2e"
       position="bottom-left"
       contactUrl="/contact"
+      sessionId={getChatSessionId()}
       onBookAppointment={handleBookAppointment}
       onConversationEnd={handleConversationEnd}
     />

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -51,6 +51,9 @@ model Site {
   analyticsDashboardConfigs AnalyticsDashboardConfig[]
   analyticsScheduledReports AnalyticsScheduledReport[]
 
+  // Relations - Chat
+  chatConversations ChatConversation[]
+
   @@index([slug])
   @@index([domain])
 }
@@ -1302,9 +1305,14 @@ model ChatConversation {
   updatedAt  DateTime      @updatedAt
   endedAt    DateTime?
 
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
   // Relations
   messages   ChatMessage[]
 
+  @@index([siteId])
   @@index([sessionId])
   @@index([createdAt])
   @@index([status])


### PR DESCRIPTION
The /admin/chatbot page was failing with "Erreur de chargement" because
ChatConversation/ChatMessage tables were missing from the database (no
prisma db push after schema addition) and the chat API was not storing
siteId for multi-tenant isolation.

Changes:
- Add siteId field to ChatConversation model + Site relation
- Add deviceType tracking via User-Agent parsing in POST /api/chat
- Scope all admin chatbot queries by siteId (list, detail, delete, bulk)
- Scope feedback and stats routes by siteId
- Add persistent sessionId in ChatWidgetWrapper via sessionStorage
- Remove dead `export const dynamic` from client component page.tsx

IMPORTANT: Run `prisma db push` from an environment with DB access to
create/update the ChatConversation and ChatMessage tables.

https://claude.ai/code/session_01MDZEEVsCMGR6w1EjzjT1KX