### PR TITLE
Refactor hero section logo from SVG to text element

### DIFF
--- a/apps/psypnos/app/(pages)/sections/hero.tsx
+++ b/apps/psypnos/app/(pages)/sections/hero.tsx
@@ -80,7 +80,7 @@ export function HeroSection() {
           initial={fadeInInitial}
           animate={fadeIn}
           transition={hasMounted ? { duration: 2, ease: 'easeOut' } : { duration: 0 }}
-          className="bg-night/40 flex h-24 w-24 flex-col items-center justify-center "
+          className="bg-night/40 flex flex-col items-center justify-center"
         >
           <motion.svg
             initial={hasMounted ? { scale: 0.5, rotate: -360 } : { scale: 1, rotate: 0 }}
@@ -106,28 +106,14 @@ export function HeroSection() {
               strokeLinecap="round"
             />
           </motion.svg>
-          <motion.svg
+          <motion.span
             initial={fadeInInitial}
             animate={fadeIn}
             transition={hasMounted ? { duration: 2, delay: 1, ease: 'easeOut' } : { duration: 0 }}
-            width="100"
-            height="50"
-            viewBox="0 0 1000 500"
-            aria-label="Psypnos"
-            className="bg-night/40 flex h-24 w-24 items-center justify-center "
+            className="font-display text-gold text-2xl font-semibold"
           >
-            <text
-              x="50%"
-              y="50%"
-              fill="#E5C78E"
-              textAnchor="middle"
-              fontFamily="'Playfair Display',serif"
-              fontSize="180"
-              fontWeight="bold"
-            >
-              Psypnos
-            </text>
-          </motion.svg>
+            Psypnos
+          </motion.span>
         </motion.div>
 
         <motion.div


### PR DESCRIPTION
## Description

Refactored the Psypnos logo in the hero section from an SVG text element to a styled text span. This simplifies the markup and improves maintainability by using Tailwind CSS classes instead of inline SVG attributes.

**Changes:**
- Removed fixed dimensions (`h-24 w-24`) from the container and adjusted layout classes
- Replaced `motion.svg` with `motion.span` for the logo text
- Removed SVG-specific attributes (`width`, `height`, `viewBox`, `aria-label`)
- Replaced inline SVG `<text>` element with plain text "Psypnos"
- Applied Tailwind classes for styling: `font-display text-gold text-2xl font-semibold`

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

## Test Plan

Visual verification of the hero section logo rendering with the same animation behavior and styling as before.

https://claude.ai/code/session_016n6svtSQZv4MNLoLL9AUep