### PR TITLE
fix(chat): accepter conversationId null dans la validation Zod

### DIFF
--- a/apps/psypnos/__tests__/unit/chat-route.test.ts
+++ b/apps/psypnos/__tests__/unit/chat-route.test.ts
@@ -251,6 +251,21 @@ describe('POST /api/chat', () => {
     expect(data.message).not.toContain('[ACTION:');
   });
 
+  it('devrait accepter conversationId: null et créer une nouvelle conversation', async () => {
+    const request = createChatRequest({ message: 'Bonjour', conversationId: null });
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    // null est traité comme absent — une nouvelle conversation est créée
+    expect(prisma.chatConversation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          siteId: 'site-123',
+        }),
+      })
+    );
+  });
+
   it('devrait créer une nouvelle conversation si aucun conversationId fourni', async () => {
     const request = createChatRequest({ message: 'Bonjour' });
     await POST(request);

--- a/apps/psypnos/app/api/chat/route.ts
+++ b/apps/psypnos/app/api/chat/route.ts
@@ -37,7 +37,7 @@ function getAnthropicClient(): Anthropic {
 
 const chatRequestSchema = z.object({
   message: z.string().min(1).max(1000),
-  conversationId: z.string().optional(),
+  conversationId: z.string().nullish(),
   sessionId: z.string().optional(),
   context: z
     .object({

--- a/packages/ui/src/components/chat/ChatWidget.tsx
+++ b/packages/ui/src/components/chat/ChatWidget.tsx
@@ -149,7 +149,7 @@ export function ChatWidget({
           },
           body: JSON.stringify({
             message: content.trim(),
-            conversationId,
+            conversationId: conversationId ?? undefined,
             sessionId,
             context: {
               siteName,


### PR DESCRIPTION
## Résumé

- Corrige le bug empêchant le ChatBot AI de fonctionner (validation Zod rejetant `conversationId: null`)
- Côté serveur : `z.string().optional()` → `z.string().nullish()` pour accepter `null` et `undefined`
- Côté client : `conversationId` → `conversationId ?? undefined` pour envoyer un payload JSON propre
- Ajout d'un test unitaire couvrant le cas `conversationId: null`

Fixes #166

## Plan de test

- [x] Test unitaire : `conversationId: null` retourne HTTP 200 et crée une nouvelle conversation
- [x] Tests existants (11/11) passent sans régression
- [x] Lint : 0 erreurs
- [x] Type-check : 0 erreurs
- [x] Build complet : succès

https://claude.ai/code/session_01ED9Sbm8d5WkCkGFvGrfR3T