### PR TITLE
fix(analytics): corriger la perte des données d'engagement par section

### DIFF
--- a/apps/psypnos/app/api/analytics/track/route.ts
+++ b/apps/psypnos/app/api/analytics/track/route.ts
@@ -56,12 +56,14 @@ const VALID_EVENT_TYPES = [
   'session_end',
 ] as const;
 
-const BaseEventSchema = z.object({
-  type: z.enum(VALID_EVENT_TYPES),
-  timestamp: z.string().refine(s => !isNaN(Date.parse(s)), { message: 'Invalid timestamp' }),
-  sessionId: z.string().min(1),
-  url: z.string().min(1),
-});
+const BaseEventSchema = z
+  .object({
+    type: z.enum(VALID_EVENT_TYPES),
+    timestamp: z.string().refine(s => !isNaN(Date.parse(s)), { message: 'Invalid timestamp' }),
+    sessionId: z.string().min(1),
+    url: z.string().min(1),
+  })
+  .passthrough();
 
 const TrackingPayloadSchema = z.object({
   events: z.array(BaseEventSchema).min(1).max(100),

--- a/apps/psypnos/components/Analytics.tsx
+++ b/apps/psypnos/components/Analytics.tsx
@@ -44,7 +44,11 @@ export function SectionTracker() {
   const observedElementsRef = useRef<HTMLElement[]>([]);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
+    /**
+     * Finds all [data-track-section] elements in the DOM and registers
+     * them with the analytics tracker for visibility / time tracking.
+     */
+    const observeAllSections = () => {
       const tracker = getTracker();
       const sections = document.querySelectorAll('[data-track-section]');
       const observed: HTMLElement[] = [];
@@ -60,10 +64,20 @@ export function SectionTracker() {
       });
 
       observedElementsRef.current = observed;
-    }, 100);
+    };
+
+    // Initial attempt — works for returning visitors who already have consent.
+    const timer = setTimeout(observeAllSections, 100);
+
+    // Listen for deferred consent: on first visit the tracker isn't
+    // initialized until the user interacts with the cookie banner.
+    // CookieConsentBanner dispatches this event after calling initTracker().
+    const onTrackerReady = () => observeAllSections();
+    window.addEventListener('kairn:tracker-ready', onTrackerReady);
 
     return () => {
       clearTimeout(timer);
+      window.removeEventListener('kairn:tracker-ready', onTrackerReady);
       // Cleanup: unobserve all tracked sections to prevent memory leaks
       const tracker = getTracker();
       observedElementsRef.current.forEach(element => {

--- a/apps/psypnos/components/CookieConsentBanner.tsx
+++ b/apps/psypnos/components/CookieConsentBanner.tsx
@@ -1,13 +1,8 @@
-"use client";
+'use client';
 
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 
-import {
-  getConsentLevel,
-  setConsentLevel,
-  initTracker,
-  type ConsentLevel,
-} from "@/lib/tracking";
+import { getConsentLevel, setConsentLevel, initTracker, type ConsentLevel } from '@/lib/tracking';
 
 /**
  * Bannière de consentement cookies RGPD.
@@ -35,6 +30,10 @@ export function CookieConsentBanner() {
     // didn't exist yet; the singleton's isInitialized is still false
     // so this second call will proceed normally.
     initTracker();
+
+    // Signal SectionTracker to (re-)observe sections now that the
+    // tracker is initialized with proper consent.
+    window.dispatchEvent(new Event('kairn:tracker-ready'));
   };
 
   if (!visible) return null;
@@ -43,36 +42,35 @@ export function CookieConsentBanner() {
     <div
       role="dialog"
       aria-label="Gestion des cookies et du suivi"
-      className="fixed bottom-0 left-0 right-0 z-[9999] border-t border-gold/20 bg-night/95 backdrop-blur-xl px-4 py-4 shadow-[0_-4px_24px_rgba(0,0,0,0.4)] sm:px-6"
+      className="border-gold/20 bg-night/95 fixed bottom-0 left-0 right-0 z-[9999] border-t px-4 py-4 shadow-[0_-4px_24px_rgba(0,0,0,0.4)] backdrop-blur-xl sm:px-6"
     >
       <div className="mx-auto max-w-4xl">
-        <p className="mb-3 text-sm leading-relaxed text-ivory/80">
-          Ce site utilise des cookies pour mesurer l&apos;audience et améliorer
-          votre expérience. Vous pouvez choisir le niveau de suivi que vous
-          acceptez.{" "}
+        <p className="text-ivory/80 mb-3 text-sm leading-relaxed">
+          Ce site utilise des cookies pour mesurer l&apos;audience et améliorer votre expérience.
+          Vous pouvez choisir le niveau de suivi que vous acceptez.{' '}
           <a
             href="/politique-de-confidentialite"
-            className="text-gold underline hover:text-gold/80 transition-colors"
+            className="text-gold hover:text-gold/80 underline transition-colors"
           >
             Politique de confidentialité
           </a>
         </p>
         <div className="flex flex-wrap gap-2">
           <button
-            onClick={() => handleConsent("essential")}
-            className="rounded-lg border border-ivory/20 bg-transparent px-4 py-2 text-sm text-ivory hover:bg-ivory/10 transition-colors"
+            onClick={() => handleConsent('essential')}
+            className="border-ivory/20 text-ivory hover:bg-ivory/10 rounded-lg border bg-transparent px-4 py-2 text-sm transition-colors"
           >
             Essentiel uniquement
           </button>
           <button
-            onClick={() => handleConsent("analytics")}
-            className="rounded-lg border border-gold bg-gold px-4 py-2 text-sm font-medium text-night hover:bg-gold/90 transition-colors"
+            onClick={() => handleConsent('analytics')}
+            className="border-gold bg-gold text-night hover:bg-gold/90 rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
           >
             Accepter les statistiques
           </button>
           <button
-            onClick={() => handleConsent("marketing")}
-            className="rounded-lg border border-ivory/20 bg-transparent px-4 py-2 text-sm text-ivory hover:bg-ivory/10 transition-colors"
+            onClick={() => handleConsent('marketing')}
+            className="border-ivory/20 text-ivory hover:bg-ivory/10 rounded-lg border bg-transparent px-4 py-2 text-sm transition-colors"
           >
             Tout accepter
           </button>


### PR DESCRIPTION
## Résumé

- **Fix principal** : Ajout de `.passthrough()` sur le schéma Zod `BaseEventSchema` dans l'API `/api/analytics/track` — Zod supprimait silencieusement tous les champs spécifiques aux événements (`timeSpent`, `sectionName`, `timeOnPage`, `scrollDepthPercent`, etc.)
- **Fix secondaire** : Ajout d'un événement DOM `kairn:tracker-ready` entre `CookieConsentBanner` et `SectionTracker` pour observer les sections dès l'obtention du consentement (première visite)

## Cause racine

`z.object()` supprime par défaut les clés non déclarées dans le schéma. Le `BaseEventSchema` ne déclarait que `type`, `timestamp`, `sessionId` et `url`, donc tous les champs spécifiques (`sectionName`, `timeSpent`, `timeOnPage`, etc.) étaient perdus à la validation.

Conséquence : aucun événement `SECTION_TIME` enregistré en base (les composants "Temps par section" et "Engagement par section" étaient vides), et les `PAGE_EXIT` étaient stockés avec `timeOnPage: 0`.

## Test plan

- [x] Lint : 0 erreurs
- [x] Type-check : passé
- [x] Tests unitaires : 398 passés, couverture ≥ 60%
- [x] Tests UI : 97 passés
- [x] Build complet : passé
- [ ] Vérifier en preview que les événements `SECTION_TIME` sont bien enregistrés après navigation sur le site
- [ ] Vérifier que les composants Engagement affichent des données après quelques visites

Fixes #157

https://claude.ai/code/session_01JNCbNsvvAS21wZ4myTYyqE