### PR TITLE
fix(admin): affichage responsive des pages admin sur smartphone

### DIFF
--- a/apps/psypnos/app/admin/seminars/_components/SeminarsTable.tsx
+++ b/apps/psypnos/app/admin/seminars/_components/SeminarsTable.tsx
@@ -21,23 +21,23 @@ export function SeminarsTable({ seminars, onEdit, onDelete, onShare }: SeminarsT
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-night/40 bg-night/60 shadow-aurora/40">
+    <div className="overflow-x-auto rounded-xl border border-night/40 bg-night/60 shadow-aurora/40">
       <table className="min-w-full divide-y divide-night/40 text-sm">
         <thead className="bg-night/80 text-xs uppercase tracking-wide text-ivory/60">
           <tr>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="px-3 py-3 text-left font-medium sm:px-4">
               Titre
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="hidden px-3 py-3 text-left font-medium sm:table-cell sm:px-4">
               Intervenants
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="hidden px-3 py-3 text-left font-medium md:table-cell md:px-4">
               Période
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="hidden px-3 py-3 text-left font-medium lg:table-cell lg:px-4">
               Capacité
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="px-3 py-3 text-right font-medium sm:px-4">
               Actions
             </th>
           </tr>
@@ -45,21 +45,31 @@ export function SeminarsTable({ seminars, onEdit, onDelete, onShare }: SeminarsT
         <tbody className="divide-y divide-night/40">
           {seminars.map((seminar) => (
             <tr key={seminar.id} className="bg-night/40 text-ivory/90">
-              <td className="px-4 py-3">
+              <td className="px-3 py-3 sm:px-4">
                 <div className="flex flex-col gap-1">
                   <span className="font-medium text-ivory">{seminar.title}</span>
                   <span className="text-xs text-ivory/60">{renderTags(seminar.tags)}</span>
+                  <span className="text-xs text-ivory/50 sm:hidden">
+                    {renderSpeakers(seminar)}
+                  </span>
+                  <span className="text-xs text-ivory/50 sm:hidden md:hidden">
+                    {formatDateRange(seminar.startAt, seminar.endAt)}
+                  </span>
                 </div>
               </td>
-              <td className="px-4 py-3 text-ivory/80">{renderSpeakers(seminar)}</td>
-              <td className="px-4 py-3 text-ivory/80">{formatDateRange(seminar.startAt, seminar.endAt)}</td>
-              <td className="px-4 py-3">
+              <td className="hidden px-3 py-3 text-ivory/80 sm:table-cell sm:px-4">
+                {renderSpeakers(seminar)}
+              </td>
+              <td className="hidden px-3 py-3 text-ivory/80 md:table-cell md:px-4">
+                {formatDateRange(seminar.startAt, seminar.endAt)}
+              </td>
+              <td className="hidden px-3 py-3 lg:table-cell lg:px-4">
                 <span className="rounded-full bg-night/60 px-3 py-1 text-xs font-semibold text-gold">
                   {seminar.capacity}
                 </span>
               </td>
-              <td className="px-4 py-3">
-                <div className="flex items-center gap-2">
+              <td className="px-3 py-3 sm:px-4">
+                <div className="flex flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-2">
                   <button
                     type="button"
                     onClick={() => onShare(seminar)}

--- a/apps/psypnos/app/admin/settings/page.tsx
+++ b/apps/psypnos/app/admin/settings/page.tsx
@@ -120,7 +120,7 @@ export default function SettingsPage() {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1 }}
-        className="grid grid-cols-2 gap-4 rounded-2xl bg-gradient-to-r from-night/80 to-night/60 p-6 border border-ivory/10 lg:grid-cols-4"
+        className="grid grid-cols-2 gap-3 rounded-2xl bg-gradient-to-r from-night/80 to-night/60 p-4 border border-ivory/10 sm:gap-4 sm:p-6 sm:grid-cols-4"
       >
         <QuickStat
           icon={Bell}
@@ -279,13 +279,13 @@ function QuickStat({
   color: string;
 }) {
   return (
-    <div className="flex items-center gap-3">
-      <div className={`flex h-10 w-10 items-center justify-center rounded-xl bg-night/60 ${color}`}>
-        <Icon className="h-5 w-5" />
+    <div className="flex items-center gap-2 sm:gap-3">
+      <div className={`flex h-8 w-8 items-center justify-center rounded-lg bg-night/60 sm:h-10 sm:w-10 sm:rounded-xl ${color}`}>
+        <Icon className="h-4 w-4 sm:h-5 sm:w-5" />
       </div>
-      <div>
-        <p className="text-xl font-bold text-ivory">{value}</p>
-        <p className="text-xs text-ivory/50">{label}</p>
+      <div className="min-w-0">
+        <p className="text-lg font-bold text-ivory sm:text-xl">{value}</p>
+        <p className="truncate text-[11px] text-ivory/50 sm:text-xs">{label}</p>
       </div>
     </div>
   );

--- a/apps/psypnos/app/admin/testimonials/_components/TestimonialsTable.tsx
+++ b/apps/psypnos/app/admin/testimonials/_components/TestimonialsTable.tsx
@@ -18,23 +18,23 @@ export function TestimonialsTable({ testimonials, onEdit, onDelete }: Testimonia
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-night/40 bg-night/60 shadow-aurora/40">
+    <div className="overflow-x-auto rounded-xl border border-night/40 bg-night/60 shadow-aurora/40">
       <table className="min-w-full divide-y divide-night/40 text-sm">
         <thead className="bg-night/80 text-xs uppercase tracking-wide text-ivory/60">
           <tr>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="px-3 py-3 text-left font-medium sm:px-4">
               Témoignage
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="hidden px-3 py-3 text-left font-medium sm:table-cell sm:px-4">
               Auteur·rice
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="hidden px-3 py-3 text-left font-medium md:table-cell md:px-4">
               Fonction
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="hidden px-3 py-3 text-left font-medium lg:table-cell lg:px-4">
               Mise à jour
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-medium">
+            <th scope="col" className="px-3 py-3 text-right font-medium sm:px-4">
               Actions
             </th>
           </tr>
@@ -42,14 +42,23 @@ export function TestimonialsTable({ testimonials, onEdit, onDelete }: Testimonia
         <tbody className="divide-y divide-night/40">
           {testimonials.map((testimonial) => (
             <tr key={testimonial.id} className="bg-night/40 text-ivory/90">
-              <td className="px-4 py-3">
-                <p className="text-sm text-ivory/70">{truncate(testimonial.quote)}</p>
+              <td className="px-3 py-3 sm:px-4">
+                <p className="text-sm text-ivory/70">{truncate(testimonial.quote, 80)}</p>
+                <p className="mt-1 text-xs font-medium text-ivory sm:hidden">
+                  {testimonial.author}
+                </p>
               </td>
-              <td className="px-4 py-3 font-medium text-ivory">{testimonial.author}</td>
-              <td className="px-4 py-3 text-ivory/70">{testimonial.role ?? "—"}</td>
-              <td className="px-4 py-3 text-ivory/70">{formatDate(testimonial.updatedAt)}</td>
-              <td className="px-4 py-3">
-                <div className="flex items-center gap-2">
+              <td className="hidden px-3 py-3 font-medium text-ivory sm:table-cell sm:px-4">
+                {testimonial.author}
+              </td>
+              <td className="hidden px-3 py-3 text-ivory/70 md:table-cell md:px-4">
+                {testimonial.role ?? "—"}
+              </td>
+              <td className="hidden px-3 py-3 text-ivory/70 lg:table-cell lg:px-4">
+                {formatDate(testimonial.updatedAt)}
+              </td>
+              <td className="px-3 py-3 sm:px-4">
+                <div className="flex flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-2">
                   <button
                     type="button"
                     onClick={() => onEdit(testimonial)}

--- a/apps/psypnos/app/admin/users/_components/UsersTable.tsx
+++ b/apps/psypnos/app/admin/users/_components/UsersTable.tsx
@@ -17,20 +17,20 @@ export function UsersTable({ users, onEdit, onDelete, onResetPassword }: UsersTa
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-night/40 bg-night/60">
+    <div className="overflow-x-auto rounded-xl border border-night/40 bg-night/60">
       <table className="min-w-full divide-y divide-night/40">
         <thead className="bg-night/70 text-left text-xs uppercase tracking-[0.2em] text-gold">
           <tr>
-            <th scope="col" className="px-6 py-3">
+            <th scope="col" className="px-3 py-3 sm:px-4">
               Email
             </th>
-            <th scope="col" className="px-6 py-3">
+            <th scope="col" className="hidden px-3 py-3 sm:table-cell sm:px-4">
               Créé le
             </th>
-            <th scope="col" className="px-6 py-3">
+            <th scope="col" className="hidden px-3 py-3 md:table-cell md:px-4">
               Mis à jour
             </th>
-            <th scope="col" className="px-6 py-3 text-right">
+            <th scope="col" className="px-3 py-3 text-right sm:px-4">
               Actions
             </th>
           </tr>
@@ -41,29 +41,34 @@ export function UsersTable({ users, onEdit, onDelete, onResetPassword }: UsersTa
             const updatedAt = new Date(user.updatedAt).toLocaleDateString("fr-FR");
             return (
               <tr key={user.id} className="hover:bg-night/50">
-                <td className="px-6 py-4 font-medium text-ivory">{user.email}</td>
-                <td className="px-6 py-4">{createdAt}</td>
-                <td className="px-6 py-4">{updatedAt}</td>
-                <td className="px-6 py-4">
-                  <div className="flex items-center justify-end gap-3">
+                <td className="px-3 py-3 sm:px-4 sm:py-4">
+                  <span className="font-medium text-ivory">{user.email}</span>
+                  <span className="mt-0.5 block text-xs text-ivory/50 sm:hidden">
+                    {createdAt}
+                  </span>
+                </td>
+                <td className="hidden px-3 py-3 sm:table-cell sm:px-4 sm:py-4">{createdAt}</td>
+                <td className="hidden px-3 py-3 md:table-cell md:px-4 md:py-4">{updatedAt}</td>
+                <td className="px-3 py-3 sm:px-4 sm:py-4">
+                  <div className="flex flex-col items-end gap-1 sm:flex-row sm:justify-end sm:gap-2">
                     <button
                       type="button"
                       onClick={() => onResetPassword(user)}
-                      className="rounded-md border border-gold/40 px-3 py-1 text-xs font-semibold text-gold transition hover:border-gold/80 hover:text-gold"
+                      className="rounded-md border border-gold/40 px-2 py-1 text-xs font-semibold text-gold transition hover:border-gold/80 hover:text-gold sm:px-3"
                     >
                       Réinitialiser
                     </button>
                     <button
                       type="button"
                       onClick={() => onEdit(user)}
-                      className="rounded-md border border-night/40 px-3 py-1 text-xs font-semibold text-ivory/80 transition hover:border-night/60 hover:text-ivory"
+                      className="rounded-md border border-night/40 px-2 py-1 text-xs font-semibold text-ivory/80 transition hover:border-night/60 hover:text-ivory sm:px-3"
                     >
                       Modifier
                     </button>
                     <button
                       type="button"
                       onClick={() => onDelete(user)}
-                      className="rounded-md border border-rose-500/50 px-3 py-1 text-xs font-semibold text-rose-300 transition hover:border-rose-400 hover:text-rose-200"
+                      className="rounded-md border border-rose-500/50 px-2 py-1 text-xs font-semibold text-rose-300 transition hover:border-rose-400 hover:text-rose-200 sm:px-3"
                     >
                       Supprimer
                     </button>


### PR DESCRIPTION
## Résumé

- Corrige l'affichage des tables admin (témoignages, utilisateurs, séminaires) sur smartphone : masquage progressif des colonnes secondaires, scroll horizontal, boutons empilés verticalement
- Améliore la grille de stats de la page Settings pour un meilleur rendu sur petit écran

Fixes #171

## Modifications

| Fichier | Changement |
|---|---|
| `TestimonialsTable.tsx` | `overflow-x-auto`, colonnes masquées (`sm:`, `md:`, `lg:`), auteur inline sous témoignage sur mobile, boutons empilés |
| `UsersTable.tsx` | `overflow-x-auto`, colonnes dates masquées, padding réduit (`px-6`→`px-3`), boutons empilés, date sous email |
| `SeminarsTable.tsx` | `overflow-x-auto`, colonnes secondaires masquées, infos reportées sous titre sur mobile, boutons empilés |
| `settings/page.tsx` | Grid `grid-cols-2 sm:grid-cols-4` (au lieu de `lg:`), padding/gap réduits, icônes compactes |

## Plan de test

- [ ] Vérifier l'affichage des pages `/admin/testimonials`, `/admin/users`, `/admin/seminars` et `/admin/settings` sur un écran de smartphone (~375px)
- [ ] Vérifier que le layout desktop (≥1024px) n'est pas impacté
- [ ] Vérifier que les boutons d'action restent accessibles sur toutes les tailles d'écran

https://claude.ai/code/session_01G635PiQTshVFGnq7u6pNNx