### PR TITLE
fix(social): corriger la publication des posts planifiés sur les réseaux sociaux

### DIFF
--- a/apps/psypnos/__tests__/unit/social-publish-cron.test.ts
+++ b/apps/psypnos/__tests__/unit/social-publish-cron.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests unitaires pour le cron de publication sociale.
+ *
+ * Vérifie que :
+ * - Les routes CRON exportent bien GET et POST (QStash envoie POST)
+ * - markPostAsFailed ne double-incrémente pas retryCount
+ * - Le script setup-qstash-schedules passe method: 'GET'
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { describe, it, expect } from 'vitest';
+
+const CRON_DIR = join(__dirname, '../../app/api/cron');
+
+/**
+ * Vérifie qu'un fichier route.ts exporte GET et POST.
+ * Détecte les deux patterns : `export { GET as POST }` et `export async function POST`
+ */
+function routeExportsPostHandler(routePath: string): boolean {
+  const content = readFileSync(routePath, 'utf-8');
+  return (
+    content.includes('export { GET as POST }') ||
+    content.includes('export async function POST') ||
+    content.includes('export function POST')
+  );
+}
+
+/**
+ * Vérifie qu'un fichier route.ts exporte GET.
+ */
+function routeExportsGetHandler(routePath: string): boolean {
+  const content = readFileSync(routePath, 'utf-8');
+  return content.includes('export async function GET') || content.includes('export function GET');
+}
+
+// ─── Test 1 : Routes CRON — compatibilité QStash POST ─────────────
+
+describe('routes CRON - compatibilité QStash POST', () => {
+  const cronRoutes = [
+    'social-publish',
+    'refresh-tokens',
+    'cleanup-data',
+    'cleanup-jobs',
+    'check-alerts',
+    'daily-report',
+    'weekly-report',
+    'process-reports',
+    'fetch-social-analytics',
+    'snapshot-social-accounts',
+    'aggregate',
+  ];
+
+  for (const route of cronRoutes) {
+    it(`/api/cron/${route} devrait exporter un handler GET`, () => {
+      const routePath = join(CRON_DIR, route, 'route.ts');
+      expect(routeExportsGetHandler(routePath)).toBe(true);
+    });
+
+    it(`/api/cron/${route} devrait exporter un handler POST (QStash compatibilité)`, () => {
+      const routePath = join(CRON_DIR, route, 'route.ts');
+      expect(routeExportsPostHandler(routePath)).toBe(true);
+    });
+  }
+});
+
+// ─── Test 2 : markPostAsFailed sans double incrémentation ──────────
+
+describe('markPostAsFailed - pas de double incrémentation retryCount', () => {
+  it('ne devrait PAS contenir retryCount: { increment } dans markPostAsFailed', () => {
+    const storePath = join(__dirname, '../../lib/social/store.ts');
+    const content = readFileSync(storePath, 'utf-8');
+
+    // Extraire le corps de la fonction markPostAsFailed
+    const funcStart = content.indexOf('export async function markPostAsFailed');
+    expect(funcStart).toBeGreaterThan(-1);
+
+    // Trouver la fin de la fonction (première occurrence de "export" après le début)
+    const afterFunc = content.slice(funcStart + 50);
+    const funcEnd = afterFunc.indexOf('\nexport ');
+    const funcBody = funcEnd > 0 ? afterFunc.slice(0, funcEnd) : afterFunc;
+
+    // Vérifier que retryCount n'est PAS incrémenté dans cette fonction
+    expect(funcBody).not.toContain('retryCount');
+  });
+
+  it('devrait toujours contenir status: FAILED et errorMessage', () => {
+    const storePath = join(__dirname, '../../lib/social/store.ts');
+    const content = readFileSync(storePath, 'utf-8');
+
+    const funcStart = content.indexOf('export async function markPostAsFailed');
+    const afterFunc = content.slice(funcStart);
+    const funcEnd = afterFunc.indexOf('\nexport ');
+    const funcBody = funcEnd > 0 ? afterFunc.slice(0, funcEnd) : afterFunc;
+
+    expect(funcBody).toContain("status: 'FAILED'");
+    expect(funcBody).toContain('errorMessage');
+  });
+});
+
+// ─── Test 3 : Script setup-qstash-schedules ────────────────────────
+
+describe('setup-qstash-schedules - méthode HTTP', () => {
+  it('devrait spécifier method: GET dans schedules.create', () => {
+    const scriptPath = join(__dirname, '../../../../scripts/setup-qstash-schedules.ts');
+    const content = readFileSync(scriptPath, 'utf-8');
+
+    // Vérifier que le script passe method: 'GET' lors de la création
+    expect(content).toContain("method: 'GET'");
+  });
+});

--- a/apps/psypnos/app/api/cron/check-alerts/route.ts
+++ b/apps/psypnos/app/api/cron/check-alerts/route.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-import { verifyCronAuth } from "@kairn/core/scheduler";
-import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
 
 import {
   getAlerts,
@@ -12,9 +12,9 @@ import {
   addAlertHistory,
   type Alert,
   type AlertHistory,
-} from "../../analytics/store-index";
+} from '../../analytics/store-index';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 // GET - Check all enabled alerts (called by QStash)
 export async function GET(request: NextRequest) {
@@ -22,10 +22,7 @@ export async function GET(request: NextRequest) {
     // Verify authentication (QStash signature or CRON_SECRET)
     const authResult = await verifyCronAuth(request);
     if (!authResult.valid) {
-      return NextResponse.json(
-        { error: "Non autorise" },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Non autorise' }, { status: 401 });
     }
 
     const alerts = await getAlerts(true); // Get only enabled alerts
@@ -66,7 +63,7 @@ export async function GET(request: NextRequest) {
           const notificationResults = await sendAlertNotifications(normalizedAlert, currentValue);
 
           // Record in history
-          const historyEntry: Omit<AlertHistory, "id"> = {
+          const historyEntry: Omit<AlertHistory, 'id'> = {
             alertId: normalizedAlert.id,
             alertName: normalizedAlert.name,
             triggeredAt: new Date().toISOString(),
@@ -106,12 +103,12 @@ export async function GET(request: NextRequest) {
           alertId: alert.id,
           alertName: alert.name,
           triggered: false,
-          error: error instanceof Error ? error.message : "Erreur inconnue",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
         });
       }
     }
 
-    const triggeredCount = results.filter((r) => r.triggered).length;
+    const triggeredCount = results.filter(r => r.triggered).length;
 
     return NextResponse.json({
       checked: alerts.length,
@@ -120,9 +117,9 @@ export async function GET(request: NextRequest) {
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
-    console.error("Error checking alerts:", error);
+    console.error('Error checking alerts:', error);
     return NextResponse.json(
-      { error: "Erreur lors de la verification des alertes" },
+      { error: 'Erreur lors de la verification des alertes' },
       { status: 500 }
     );
   }
@@ -131,26 +128,26 @@ export async function GET(request: NextRequest) {
 // Generate alert message
 function generateAlertMessage(alert: Alert, currentValue: number): string {
   const metricLabels: Record<string, string> = {
-    visits: "visites",
-    sessions: "sessions",
-    conversions: "conversions",
-    conversion_rate: "taux de conversion",
-    avg_time: "temps moyen (secondes)",
-    bounce_rate: "taux de rebond",
+    visits: 'visites',
+    sessions: 'sessions',
+    conversions: 'conversions',
+    conversion_rate: 'taux de conversion',
+    avg_time: 'temps moyen (secondes)',
+    bounce_rate: 'taux de rebond',
   };
 
   const conditionLabels: Record<string, string> = {
-    greater_than: "superieur a",
-    less_than: "inferieur a",
-    equals: "egal a",
-    change_percent: "varie de plus de",
+    greater_than: 'superieur a',
+    less_than: 'inferieur a',
+    equals: 'egal a',
+    change_percent: 'varie de plus de',
   };
 
   const timeWindowLabels: Record<string, string> = {
-    hour: "derniere heure",
-    day: "dernieres 24h",
-    week: "derniere semaine",
-    month: "dernier mois",
+    hour: 'derniere heure',
+    day: 'dernieres 24h',
+    week: 'derniere semaine',
+    month: 'dernier mois',
   };
 
   const metric = metricLabels[alert.metric] || alert.metric;
@@ -158,9 +155,9 @@ function generateAlertMessage(alert: Alert, currentValue: number): string {
   const timeWindow = timeWindowLabels[alert.timeWindow] || alert.timeWindow;
 
   let thresholdDisplay = alert.threshold.toString();
-  if (alert.condition === "change_percent") {
+  if (alert.condition === 'change_percent') {
     thresholdDisplay = `${alert.threshold}%`;
-  } else if (alert.metric === "conversion_rate" || alert.metric === "bounce_rate") {
+  } else if (alert.metric === 'conversion_rate' || alert.metric === 'bounce_rate') {
     thresholdDisplay = `${alert.threshold}%`;
   }
 
@@ -178,32 +175,32 @@ async function sendAlertNotifications(
   for (const channel of alert.channels) {
     try {
       switch (channel) {
-        case "email":
+        case 'email':
           if (alert.emailRecipients && alert.emailRecipients.length > 0) {
             await sendEmailNotification(alert.emailRecipients, alert.name, message);
-            results.push({ channel: "email", success: true });
+            results.push({ channel: 'email', success: true });
           } else {
-            results.push({ channel: "email", success: false, error: "Pas de destinataires" });
+            results.push({ channel: 'email', success: false, error: 'Pas de destinataires' });
           }
           break;
 
-        case "webhook":
+        case 'webhook':
           if (alert.webhookUrl) {
             await sendWebhookNotification(alert.webhookUrl, alert, currentValue, message);
-            results.push({ channel: "webhook", success: true });
+            results.push({ channel: 'webhook', success: true });
           } else {
-            results.push({ channel: "webhook", success: false, error: "Pas d'URL webhook" });
+            results.push({ channel: 'webhook', success: false, error: "Pas d'URL webhook" });
           }
           break;
 
         default:
-          results.push({ channel, success: false, error: "Canal non supporte" });
+          results.push({ channel, success: false, error: 'Canal non supporte' });
       }
     } catch (error) {
       results.push({
         channel,
         success: false,
-        error: error instanceof Error ? error.message : "Erreur inconnue",
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
       });
     }
   }
@@ -221,18 +218,18 @@ async function sendEmailNotification(
   const resendApiKey = process.env.RESEND_API_KEY;
 
   if (!resendApiKey) {
-    console.warn("RESEND_API_KEY not configured, skipping email notification");
-    throw new Error("Service email non configure");
+    console.warn('RESEND_API_KEY not configured, skipping email notification');
+    throw new Error('Service email non configure');
   }
 
-  const response = await fetch("https://api.resend.com/emails", {
-    method: "POST",
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${resendApiKey}`,
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: process.env.ALERT_EMAIL_FROM || "Psypnos Analytics <analytics@psypnos.fr>",
+      from: process.env.ALERT_EMAIL_FROM || 'Psypnos Analytics <analytics@psypnos.fr>',
       to: recipients,
       subject: `[Alerte] ${alertName} - Psypnos Analytics`,
       html: `
@@ -245,9 +242,9 @@ async function sendEmailNotification(
             <p style="color: #333; font-size: 16px; line-height: 1.6;">${message}</p>
             <hr style="border: none; border-top: 1px solid #ddd; margin: 20px 0;">
             <p style="color: #666; font-size: 14px;">
-              Date: ${new Date().toLocaleString("fr-FR", { timeZone: "Europe/Paris" })}
+              Date: ${new Date().toLocaleString('fr-FR', { timeZone: 'Europe/Paris' })}
             </p>
-            <a href="${process.env.NEXT_PUBLIC_SITE_URL || "https://psypnos.fr"}/admin/analytics"
+            <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'https://psypnos.fr'}/admin/analytics"
                style="display: inline-block; padding: 10px 20px; background-color: #D4AF37; color: #1a1a2e; text-decoration: none; border-radius: 5px; margin-top: 15px;">
               Voir le Dashboard
             </a>
@@ -276,7 +273,7 @@ async function sendWebhookNotification(
   message: string
 ): Promise<void> {
   const payload = {
-    type: "alert_triggered",
+    type: 'alert_triggered',
     alert: {
       id: alert.id,
       name: alert.name,
@@ -294,9 +291,9 @@ async function sendWebhookNotification(
   };
 
   const response = await fetch(webhookUrl, {
-    method: "POST",
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify(payload),
   });
@@ -305,3 +302,6 @@ async function sendWebhookNotification(
     throw new Error(`Webhook returned ${response.status}`);
   }
 }
+
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };

--- a/apps/psypnos/app/api/cron/cleanup-data/route.ts
+++ b/apps/psypnos/app/api/cron/cleanup-data/route.ts
@@ -189,3 +189,6 @@ export async function GET(request: NextRequest) {
     );
   }
 }
+
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };

--- a/apps/psypnos/app/api/cron/cleanup-jobs/route.ts
+++ b/apps/psypnos/app/api/cron/cleanup-jobs/route.ts
@@ -16,10 +16,10 @@
  * Security: QStash signature or CRON_SECRET
  */
 
-import { verifyCronAuth } from "@kairn/core/scheduler";
-import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { prisma } from "@/lib/db/prisma";
+import { prisma } from '@/lib/db/prisma';
 
 // Configuration
 const ORPHAN_TIMEOUT_MINUTES = 30;
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
   // Verify authentication (QStash signature or CRON_SECRET)
   const authResult = await verifyCronAuth(request);
   if (!authResult.valid) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const startTime = Date.now();
@@ -46,13 +46,13 @@ export async function GET(request: NextRequest) {
 
     const orphanedJobs = await prisma.blogGenerationJob.updateMany({
       where: {
-        status: "PROCESSING",
+        status: 'PROCESSING',
         startedAt: {
           lt: orphanCutoff,
         },
       },
       data: {
-        status: "FAILED",
+        status: 'FAILED',
         error: `Job orphelin - timeout après ${ORPHAN_TIMEOUT_MINUTES} minutes sans activité`,
         completedAt: new Date(),
       },
@@ -69,7 +69,7 @@ export async function GET(request: NextRequest) {
     const deletedJobs = await prisma.blogGenerationJob.deleteMany({
       where: {
         status: {
-          in: ["COMPLETED", "FAILED"],
+          in: ['COMPLETED', 'FAILED'],
         },
         completedAt: {
           lt: retentionCutoff,
@@ -79,7 +79,9 @@ export async function GET(request: NextRequest) {
     results.deletedJobs = deletedJobs.count;
 
     if (deletedJobs.count > 0) {
-      console.log(`[Cron:cleanup-jobs] ${deletedJobs.count} vieux jobs supprimés (>${RETENTION_DAYS} jours)`);
+      console.log(
+        `[Cron:cleanup-jobs] ${deletedJobs.count} vieux jobs supprimés (>${RETENTION_DAYS} jours)`
+      );
     }
 
     // 3. Supprimer les anciens logs de génération sociale
@@ -95,26 +97,31 @@ export async function GET(request: NextRequest) {
     results.deletedSocialLogs = deletedSocialLogs.count;
 
     if (deletedSocialLogs.count > 0) {
-      console.log(`[Cron:cleanup-jobs] ${deletedSocialLogs.count} logs de génération sociale supprimés (>${SOCIAL_LOG_RETENTION_DAYS} jours)`);
+      console.log(
+        `[Cron:cleanup-jobs] ${deletedSocialLogs.count} logs de génération sociale supprimés (>${SOCIAL_LOG_RETENTION_DAYS} jours)`
+      );
     }
 
     const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 
     return NextResponse.json({
       success: true,
-      message: "Nettoyage des jobs terminé",
+      message: 'Nettoyage des jobs terminé',
       duration: `${duration}s`,
       processed: orphanedJobs.count + deletedJobs.count + deletedSocialLogs.count,
       results,
     });
   } catch (error) {
-    console.error("[Cron:cleanup-jobs] Erreur:", error);
+    console.error('[Cron:cleanup-jobs] Erreur:', error);
     return NextResponse.json(
       {
-        error: "Cleanup failed",
-        message: error instanceof Error ? error.message : "Unknown error",
+        error: 'Cleanup failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }
     );
   }
 }
+
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };

--- a/apps/psypnos/app/api/cron/daily-report/route.ts
+++ b/apps/psypnos/app/api/cron/daily-report/route.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-import { verifyCronAuth } from "@kairn/core/scheduler";
-import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
 
 import {
   getAnalyticsSummary,
@@ -13,9 +13,12 @@ import {
   getAnomalies,
   getScheduledReports,
   updateScheduledReport,
-} from "../../analytics/store-index";
+} from '../../analytics/store-index';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
+
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };
 
 // GET - Generate and send daily reports (called by QStash)
 export async function GET(request: NextRequest) {
@@ -23,14 +26,14 @@ export async function GET(request: NextRequest) {
     // Verify authentication (QStash signature or CRON_SECRET)
     const authResult = await verifyCronAuth(request);
     if (!authResult.valid) {
-      return NextResponse.json({ error: "Non autorise" }, { status: 401 });
+      return NextResponse.json({ error: 'Non autorise' }, { status: 401 });
     }
 
     // Get scheduled reports that need to run
     const reports = await getScheduledReports(true);
     const now = new Date();
-    const dailyReports = reports.filter((r) => {
-      if (r.frequency !== "daily") return false;
+    const dailyReports = reports.filter(r => {
+      if (r.frequency !== 'daily') return false;
       if (!r.nextScheduled) return true;
       return new Date(r.nextScheduled) <= now;
     });
@@ -51,10 +54,7 @@ export async function GET(request: NextRequest) {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    const reportData = await generateReportData(
-      yesterday.toISOString(),
-      today.toISOString()
-    );
+    const reportData = await generateReportData(yesterday.toISOString(), today.toISOString());
 
     for (const report of dailyReports) {
       try {
@@ -66,20 +66,20 @@ export async function GET(request: NextRequest) {
           report.name,
           filteredData,
           yesterday,
-          "quotidien"
+          'quotidien'
         );
 
         // Send email
         await sendReportEmail(
           report.recipients,
-          `Rapport Quotidien - ${yesterday.toLocaleDateString("fr-FR")}`,
+          `Rapport Quotidien - ${yesterday.toLocaleDateString('fr-FR')}`,
           emailHtml
         );
 
         // Update next scheduled time
         const nextScheduled = new Date();
         nextScheduled.setDate(nextScheduled.getDate() + 1);
-        const [hours, minutes] = report.timeOfDay.split(":").map(Number);
+        const [hours, minutes] = report.timeOfDay.split(':').map(Number);
         nextScheduled.setHours(hours, minutes, 0, 0);
 
         await updateScheduledReport(report.id, {
@@ -100,21 +100,21 @@ export async function GET(request: NextRequest) {
           reportName: report.name,
           sent: false,
           recipients: 0,
-          error: error instanceof Error ? error.message : "Erreur inconnue",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
         });
       }
     }
 
     return NextResponse.json({
       processed: dailyReports.length,
-      sent: results.filter((r) => r.sent).length,
+      sent: results.filter(r => r.sent).length,
       results,
       timestamp: now.toISOString(),
     });
   } catch (error) {
-    console.error("Error generating daily reports:", error);
+    console.error('Error generating daily reports:', error);
     return NextResponse.json(
-      { error: "Erreur lors de la generation des rapports" },
+      { error: 'Erreur lors de la generation des rapports' },
       { status: 500 }
     );
   }
@@ -124,7 +124,7 @@ export async function GET(request: NextRequest) {
 async function generateReportData(startDate: string, endDate: string) {
   const [summary, comparison, trafficSources, devices, heatmap, anomalies] = await Promise.all([
     getAnalyticsSummary(startDate, endDate),
-    getAnalyticsSummaryWithComparison("day"),
+    getAnalyticsSummaryWithComparison('day'),
     getTrafficSources(startDate, endDate),
     getDeviceBreakdown(startDate, endDate),
     getSectionHeatmap(startDate, endDate),
@@ -137,7 +137,7 @@ async function generateReportData(startDate: string, endDate: string) {
     trafficSources: trafficSources.slice(0, 5),
     devices,
     sections: heatmap.slice(0, 5),
-    anomalies: anomalies.filter((a) => !a.acknowledged).slice(0, 5),
+    anomalies: anomalies.filter(a => !a.acknowledged).slice(0, 5),
   };
 }
 
@@ -148,20 +148,20 @@ function filterReportSections(
 ) {
   const filtered: Partial<typeof data> = {};
 
-  if (sections.includes("summary")) {
+  if (sections.includes('summary')) {
     filtered.summary = data.summary;
     filtered.comparison = data.comparison;
   }
-  if (sections.includes("traffic")) {
+  if (sections.includes('traffic')) {
     filtered.trafficSources = data.trafficSources;
   }
-  if (sections.includes("devices")) {
+  if (sections.includes('devices')) {
     filtered.devices = data.devices;
   }
-  if (sections.includes("sections")) {
+  if (sections.includes('sections')) {
     filtered.sections = data.sections;
   }
-  if (sections.includes("conversions")) {
+  if (sections.includes('conversions')) {
     // Already included in summary.conversionByType
   }
 
@@ -175,7 +175,7 @@ function generateReportEmailHtml(
   date: Date,
   periodLabel: string
 ): string {
-  const formatNumber = (n: number) => n.toLocaleString("fr-FR");
+  const formatNumber = (n: number) => n.toLocaleString('fr-FR');
   const formatPercent = (n: number) => `${n.toFixed(1)}%`;
   const formatTime = (ms: number) => {
     const seconds = Math.round(ms / 1000);
@@ -184,8 +184,8 @@ function generateReportEmailHtml(
     return `${minutes}m ${remainingSeconds}s`;
   };
 
-  const changeArrow = (change: number) => (change >= 0 ? "↑" : "↓");
-  const changeColor = (change: number) => (change >= 0 ? "#28a745" : "#dc3545");
+  const changeArrow = (change: number) => (change >= 0 ? '↑' : '↓');
+  const changeColor = (change: number) => (change >= 0 ? '#28a745' : '#dc3545');
 
   return `
     <!DOCTYPE html>
@@ -197,25 +197,27 @@ function generateReportEmailHtml(
     <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 700px; margin: 0 auto; padding: 20px;">
       <div style="background-color: #1a1a2e; padding: 30px; text-align: center; border-radius: 10px 10px 0 0;">
         <h1 style="color: #D4AF37; margin: 0; font-size: 24px;">Psypnos Analytics</h1>
-        <p style="color: #fff; margin: 10px 0 0 0; font-size: 14px;">Rapport ${periodLabel} - ${date.toLocaleDateString("fr-FR")}</p>
+        <p style="color: #fff; margin: 10px 0 0 0; font-size: 14px;">Rapport ${periodLabel} - ${date.toLocaleDateString('fr-FR')}</p>
       </div>
 
       <div style="background-color: #f8f9fa; padding: 25px; border-radius: 0 0 10px 10px;">
         <!-- Summary Section -->
-        ${data.summary ? `
+        ${
+          data.summary
+            ? `
         <h2 style="color: #1a1a2e; border-bottom: 2px solid #D4AF37; padding-bottom: 10px;">Resume</h2>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 25px;">
           <tr>
             <td style="padding: 15px; background: white; border-radius: 8px; text-align: center; width: 25%;">
               <div style="font-size: 28px; font-weight: bold; color: #1a1a2e;">${formatNumber(data.summary.totalVisits)}</div>
               <div style="color: #666; font-size: 12px;">Visites</div>
-              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.totalVisitsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.totalVisitsChange)} ${formatPercent(Math.abs(data.comparison.comparison.totalVisitsChange))}</div>` : ""}
+              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.totalVisitsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.totalVisitsChange)} ${formatPercent(Math.abs(data.comparison.comparison.totalVisitsChange))}</div>` : ''}
             </td>
             <td style="width: 2%;"></td>
             <td style="padding: 15px; background: white; border-radius: 8px; text-align: center; width: 25%;">
               <div style="font-size: 28px; font-weight: bold; color: #1a1a2e;">${formatNumber(data.summary.uniqueSessions)}</div>
               <div style="color: #666; font-size: 12px;">Sessions</div>
-              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.uniqueSessionsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.uniqueSessionsChange)} ${formatPercent(Math.abs(data.comparison.comparison.uniqueSessionsChange))}</div>` : ""}
+              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.uniqueSessionsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.uniqueSessionsChange)} ${formatPercent(Math.abs(data.comparison.comparison.uniqueSessionsChange))}</div>` : ''}
             </td>
             <td style="width: 2%;"></td>
             <td style="padding: 15px; background: white; border-radius: 8px; text-align: center; width: 25%;">
@@ -229,10 +231,14 @@ function generateReportEmailHtml(
             </td>
           </tr>
         </table>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Conversions Section -->
-        ${data.summary && Object.keys(data.summary.conversionByType).length > 0 ? `
+        ${
+          data.summary && Object.keys(data.summary.conversionByType).length > 0
+            ? `
         <h2 style="color: #1a1a2e; border-bottom: 2px solid #D4AF37; padding-bottom: 10px;">Conversions</h2>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 25px; background: white; border-radius: 8px;">
           <thead>
@@ -244,20 +250,28 @@ function generateReportEmailHtml(
             </tr>
           </thead>
           <tbody>
-            ${Object.entries(data.summary.conversionByType).map(([type, conv]) => `
+            ${Object.entries(data.summary.conversionByType)
+              .map(
+                ([type, conv]) => `
             <tr>
-              <td style="padding: 12px; border-bottom: 1px solid #eee;">${type.replace(/_/g, " ")}</td>
+              <td style="padding: 12px; border-bottom: 1px solid #eee;">${type.replace(/_/g, ' ')}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(conv.clicks)}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(conv.completed)}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee; color: #D4AF37; font-weight: bold;">${formatPercent(conv.rate)}</td>
             </tr>
-            `).join("")}
+            `
+              )
+              .join('')}
           </tbody>
         </table>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Traffic Sources Section -->
-        ${data.trafficSources && data.trafficSources.length > 0 ? `
+        ${
+          data.trafficSources && data.trafficSources.length > 0
+            ? `
         <h2 style="color: #1a1a2e; border-bottom: 2px solid #D4AF37; padding-bottom: 10px;">Top Sources de Trafic</h2>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 25px; background: white; border-radius: 8px;">
           <thead>
@@ -268,19 +282,27 @@ function generateReportEmailHtml(
             </tr>
           </thead>
           <tbody>
-            ${data.trafficSources.map((source) => `
+            ${data.trafficSources
+              .map(
+                source => `
             <tr>
               <td style="padding: 12px; border-bottom: 1px solid #eee;">${source.source} / ${source.medium}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(source.visits)}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatPercent(source.conversionRate)}</td>
             </tr>
-            `).join("")}
+            `
+              )
+              .join('')}
           </tbody>
         </table>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Devices Section -->
-        ${data.devices && data.devices.length > 0 ? `
+        ${
+          data.devices && data.devices.length > 0
+            ? `
         <h2 style="color: #1a1a2e; border-bottom: 2px solid #D4AF37; padding-bottom: 10px;">Repartition par Appareil</h2>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 25px; background: white; border-radius: 8px;">
           <thead>
@@ -291,33 +313,47 @@ function generateReportEmailHtml(
             </tr>
           </thead>
           <tbody>
-            ${data.devices.map((device) => `
+            ${data.devices
+              .map(
+                device => `
             <tr>
               <td style="padding: 12px; border-bottom: 1px solid #eee; text-transform: capitalize;">${device.deviceType}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(device.visits)}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatTime(device.avgTimeOnSite)}</td>
             </tr>
-            `).join("")}
+            `
+              )
+              .join('')}
           </tbody>
         </table>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Anomalies Section -->
-        ${data.anomalies && data.anomalies.length > 0 ? `
+        ${
+          data.anomalies && data.anomalies.length > 0
+            ? `
         <h2 style="color: #dc3545; border-bottom: 2px solid #dc3545; padding-bottom: 10px;">Anomalies Detectees</h2>
         <div style="background: #fff3cd; border-left: 4px solid #ffc107; padding: 15px; margin-bottom: 25px; border-radius: 4px;">
-          ${data.anomalies.map((anomaly) => `
+          ${data.anomalies
+            .map(
+              anomaly => `
           <div style="margin-bottom: 10px;">
-            <span style="display: inline-block; padding: 2px 8px; background: ${anomaly.severity === "high" ? "#dc3545" : anomaly.severity === "medium" ? "#ffc107" : "#6c757d"}; color: white; border-radius: 4px; font-size: 11px; margin-right: 8px;">${anomaly.severity.toUpperCase()}</span>
+            <span style="display: inline-block; padding: 2px 8px; background: ${anomaly.severity === 'high' ? '#dc3545' : anomaly.severity === 'medium' ? '#ffc107' : '#6c757d'}; color: white; border-radius: 4px; font-size: 11px; margin-right: 8px;">${anomaly.severity.toUpperCase()}</span>
             ${anomaly.message}
           </div>
-          `).join("")}
+          `
+            )
+            .join('')}
         </div>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Footer -->
         <div style="text-align: center; padding-top: 20px; border-top: 1px solid #ddd;">
-          <a href="${process.env.NEXT_PUBLIC_SITE_URL || "https://psypnos.fr"}/admin/analytics"
+          <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'https://psypnos.fr'}/admin/analytics"
              style="display: inline-block; padding: 12px 30px; background-color: #D4AF37; color: #1a1a2e; text-decoration: none; border-radius: 5px; font-weight: bold;">
             Voir le Dashboard Complet
           </a>
@@ -333,26 +369,22 @@ function generateReportEmailHtml(
 }
 
 // Send report email
-async function sendReportEmail(
-  recipients: string[],
-  subject: string,
-  html: string
-): Promise<void> {
+async function sendReportEmail(recipients: string[], subject: string, html: string): Promise<void> {
   const resendApiKey = process.env.RESEND_API_KEY;
 
   if (!resendApiKey) {
-    console.warn("RESEND_API_KEY not configured, skipping report email");
-    throw new Error("Service email non configure");
+    console.warn('RESEND_API_KEY not configured, skipping report email');
+    throw new Error('Service email non configure');
   }
 
-  const response = await fetch("https://api.resend.com/emails", {
-    method: "POST",
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${resendApiKey}`,
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: process.env.REPORT_EMAIL_FROM || "Psypnos Analytics <analytics@psypnos.fr>",
+      from: process.env.REPORT_EMAIL_FROM || 'Psypnos Analytics <analytics@psypnos.fr>',
       to: recipients,
       subject: `[Psypnos] ${subject}`,
       html,

--- a/apps/psypnos/app/api/cron/process-reports/route.ts
+++ b/apps/psypnos/app/api/cron/process-reports/route.ts
@@ -21,10 +21,10 @@
  * Security: QStash signature or CRON_SECRET
  */
 
-import { verifyCronAuth } from "@kairn/core/scheduler";
-import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { prisma } from "@/lib/db/prisma";
+import { prisma } from '@/lib/db/prisma';
 
 import {
   getAnalyticsSummary,
@@ -33,7 +33,7 @@ import {
   getDeviceBreakdown,
   getSectionHeatmap,
   getAnomalies,
-} from "../../analytics/store-index";
+} from '../../analytics/store-index';
 
 interface ReportResult {
   reportId: string;
@@ -44,11 +44,14 @@ interface ReportResult {
   error?: string;
 }
 
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };
+
 export async function GET(request: NextRequest) {
   // Verify authentication (QStash signature or CRON_SECRET)
   const authResult = await verifyCronAuth(request);
   if (!authResult.valid) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const startTime = Date.now();
@@ -71,7 +74,7 @@ export async function GET(request: NextRequest) {
     if (reports.length === 0) {
       return NextResponse.json({
         success: true,
-        message: "Aucun rapport à envoyer",
+        message: 'Aucun rapport à envoyer',
         processed: 0,
         results: [],
       });
@@ -101,7 +104,7 @@ export async function GET(request: NextRequest) {
         // Envoyer l'email
         await sendReportEmail(
           report.recipients,
-          `Rapport ${periodLabel} - ${new Date(startDate).toLocaleDateString("fr-FR")}`,
+          `Rapport ${periodLabel} - ${new Date(startDate).toLocaleDateString('fr-FR')}`,
           emailHtml
         );
 
@@ -125,7 +128,9 @@ export async function GET(request: NextRequest) {
           recipients: report.recipients.length,
         });
 
-        console.log(`[Cron:process-reports] Rapport "${report.name}" envoyé à ${report.recipients.length} destinataire(s)`);
+        console.log(
+          `[Cron:process-reports] Rapport "${report.name}" envoyé à ${report.recipients.length} destinataire(s)`
+        );
       } catch (error) {
         console.error(`[Cron:process-reports] Erreur rapport "${report.name}":`, error);
         results.push({
@@ -134,13 +139,13 @@ export async function GET(request: NextRequest) {
           frequency: report.frequency,
           sent: false,
           recipients: 0,
-          error: error instanceof Error ? error.message : "Erreur inconnue",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
         });
       }
     }
 
     const duration = ((Date.now() - startTime) / 1000).toFixed(2);
-    const sentCount = results.filter((r) => r.sent).length;
+    const sentCount = results.filter(r => r.sent).length;
 
     return NextResponse.json({
       success: true,
@@ -150,11 +155,11 @@ export async function GET(request: NextRequest) {
       results,
     });
   } catch (error) {
-    console.error("[Cron:process-reports] Erreur:", error);
+    console.error('[Cron:process-reports] Erreur:', error);
     return NextResponse.json(
       {
-        error: "Report processing failed",
-        message: error instanceof Error ? error.message : "Unknown error",
+        error: 'Report processing failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }
     );
@@ -177,28 +182,28 @@ function calculateReportPeriod(frequency: string): {
   let periodLabel: string;
 
   switch (frequency) {
-    case "daily":
+    case 'daily':
       startDate = new Date(endDate);
       startDate.setDate(startDate.getDate() - 1);
-      periodLabel = "quotidien";
+      periodLabel = 'quotidien';
       break;
 
-    case "weekly":
+    case 'weekly':
       startDate = new Date(endDate);
       startDate.setDate(startDate.getDate() - 7);
-      periodLabel = "hebdomadaire";
+      periodLabel = 'hebdomadaire';
       break;
 
-    case "monthly":
+    case 'monthly':
       startDate = new Date(endDate);
       startDate.setMonth(startDate.getMonth() - 1);
-      periodLabel = "mensuel";
+      periodLabel = 'mensuel';
       break;
 
     default:
       startDate = new Date(endDate);
       startDate.setDate(startDate.getDate() - 1);
-      periodLabel = "quotidien";
+      periodLabel = 'quotidien';
   }
 
   return {
@@ -217,17 +222,17 @@ function calculateNextScheduled(report: {
   dayOfWeek: number | null;
   dayOfMonth: number | null;
 }): Date {
-  const [hours, minutes] = report.timeOfDay.split(":").map(Number);
+  const [hours, minutes] = report.timeOfDay.split(':').map(Number);
   const next = new Date();
 
   next.setHours(hours, minutes, 0, 0);
 
   switch (report.frequency) {
-    case "daily":
+    case 'daily':
       next.setDate(next.getDate() + 1);
       break;
 
-    case "weekly":
+    case 'weekly':
       const targetDay = report.dayOfWeek || 1; // Lundi par défaut
       const currentDay = next.getDay();
       let daysUntilTarget = targetDay - currentDay;
@@ -235,7 +240,7 @@ function calculateNextScheduled(report: {
       next.setDate(next.getDate() + daysUntilTarget);
       break;
 
-    case "monthly":
+    case 'monthly':
       const targetDate = report.dayOfMonth || 1;
       next.setMonth(next.getMonth() + 1);
       next.setDate(Math.min(targetDate, getDaysInMonth(next.getFullYear(), next.getMonth())));
@@ -258,7 +263,7 @@ function getDaysInMonth(year: number, month: number): number {
 async function generateReportData(startDate: string, endDate: string) {
   const [summary, comparison, trafficSources, devices, heatmap, anomalies] = await Promise.all([
     getAnalyticsSummary(startDate, endDate),
-    getAnalyticsSummaryWithComparison("day"),
+    getAnalyticsSummaryWithComparison('day'),
     getTrafficSources(startDate, endDate),
     getDeviceBreakdown(startDate, endDate),
     getSectionHeatmap(startDate, endDate),
@@ -271,7 +276,7 @@ async function generateReportData(startDate: string, endDate: string) {
     trafficSources: trafficSources.slice(0, 10),
     devices,
     sections: heatmap.slice(0, 10),
-    anomalies: anomalies.filter((a) => !a.acknowledged).slice(0, 10),
+    anomalies: anomalies.filter(a => !a.acknowledged).slice(0, 10),
   };
 }
 
@@ -284,20 +289,20 @@ function filterReportSections(
 ) {
   const filtered: Partial<typeof data> = {};
 
-  if (sections.includes("summary")) {
+  if (sections.includes('summary')) {
     filtered.summary = data.summary;
     filtered.comparison = data.comparison;
   }
-  if (sections.includes("traffic")) {
+  if (sections.includes('traffic')) {
     filtered.trafficSources = data.trafficSources;
   }
-  if (sections.includes("devices")) {
+  if (sections.includes('devices')) {
     filtered.devices = data.devices;
   }
-  if (sections.includes("sections")) {
+  if (sections.includes('sections')) {
     filtered.sections = data.sections;
   }
-  if (sections.includes("insights") || sections.includes("cohorts")) {
+  if (sections.includes('insights') || sections.includes('cohorts')) {
     filtered.anomalies = data.anomalies;
   }
 
@@ -314,7 +319,7 @@ function generateReportEmailHtml(
   periodLabel: string,
   frequency: string
 ): string {
-  const formatNumber = (n: number) => n.toLocaleString("fr-FR");
+  const formatNumber = (n: number) => n.toLocaleString('fr-FR');
   const formatPercent = (n: number) => `${n.toFixed(1)}%`;
   const formatTime = (ms: number) => {
     const seconds = Math.round(ms / 1000);
@@ -323,10 +328,10 @@ function generateReportEmailHtml(
     return `${minutes}m ${remainingSeconds}s`;
   };
 
-  const changeArrow = (change: number) => (change >= 0 ? "↑" : "↓");
-  const changeColor = (change: number) => (change >= 0 ? "#28a745" : "#dc3545");
+  const changeArrow = (change: number) => (change >= 0 ? '↑' : '↓');
+  const changeColor = (change: number) => (change >= 0 ? '#28a745' : '#dc3545');
 
-  const frequencyEmoji = frequency === "daily" ? "📊" : frequency === "weekly" ? "📈" : "📉";
+  const frequencyEmoji = frequency === 'daily' ? '📊' : frequency === 'weekly' ? '📈' : '📉';
 
   return `
     <!DOCTYPE html>
@@ -338,25 +343,27 @@ function generateReportEmailHtml(
     <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 700px; margin: 0 auto; padding: 20px;">
       <div style="background-color: #1a1a2e; padding: 30px; text-align: center; border-radius: 10px 10px 0 0;">
         <h1 style="color: #D4AF37; margin: 0; font-size: 24px;">${frequencyEmoji} Psypnos Analytics</h1>
-        <p style="color: #fff; margin: 10px 0 0 0; font-size: 14px;">Rapport ${periodLabel} - ${date.toLocaleDateString("fr-FR")}</p>
+        <p style="color: #fff; margin: 10px 0 0 0; font-size: 14px;">Rapport ${periodLabel} - ${date.toLocaleDateString('fr-FR')}</p>
         <p style="color: #aaa; margin: 5px 0 0 0; font-size: 12px;">${reportName}</p>
       </div>
 
       <div style="background-color: #f8f9fa; padding: 25px; border-radius: 0 0 10px 10px;">
-        ${data.summary ? `
+        ${
+          data.summary
+            ? `
         <h2 style="color: #1a1a2e; border-bottom: 2px solid #D4AF37; padding-bottom: 10px;">📌 Résumé</h2>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 25px;">
           <tr>
             <td style="padding: 15px; background: white; border-radius: 8px; text-align: center; width: 25%;">
               <div style="font-size: 28px; font-weight: bold; color: #1a1a2e;">${formatNumber(data.summary.totalVisits)}</div>
               <div style="color: #666; font-size: 12px;">Visites</div>
-              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.totalVisitsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.totalVisitsChange)} ${formatPercent(Math.abs(data.comparison.comparison.totalVisitsChange))}</div>` : ""}
+              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.totalVisitsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.totalVisitsChange)} ${formatPercent(Math.abs(data.comparison.comparison.totalVisitsChange))}</div>` : ''}
             </td>
             <td style="width: 2%;"></td>
             <td style="padding: 15px; background: white; border-radius: 8px; text-align: center; width: 25%;">
               <div style="font-size: 28px; font-weight: bold; color: #1a1a2e;">${formatNumber(data.summary.uniqueSessions)}</div>
               <div style="color: #666; font-size: 12px;">Sessions</div>
-              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.uniqueSessionsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.uniqueSessionsChange)} ${formatPercent(Math.abs(data.comparison.comparison.uniqueSessionsChange))}</div>` : ""}
+              ${data.comparison ? `<div style="color: ${changeColor(data.comparison.comparison.uniqueSessionsChange)}; font-size: 12px;">${changeArrow(data.comparison.comparison.uniqueSessionsChange)} ${formatPercent(Math.abs(data.comparison.comparison.uniqueSessionsChange))}</div>` : ''}
             </td>
             <td style="width: 2%;"></td>
             <td style="padding: 15px; background: white; border-radius: 8px; text-align: center; width: 25%;">
@@ -370,9 +377,13 @@ function generateReportEmailHtml(
             </td>
           </tr>
         </table>
-        ` : ""}
+        `
+            : ''
+        }
 
-        ${data.trafficSources && data.trafficSources.length > 0 ? `
+        ${
+          data.trafficSources && data.trafficSources.length > 0
+            ? `
         <h2 style="color: #1a1a2e; border-bottom: 2px solid #D4AF37; padding-bottom: 10px;">🌐 Sources de Trafic</h2>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 25px; background: white; border-radius: 8px;">
           <thead>
@@ -383,18 +394,26 @@ function generateReportEmailHtml(
             </tr>
           </thead>
           <tbody>
-            ${data.trafficSources.map((source) => `
+            ${data.trafficSources
+              .map(
+                source => `
             <tr>
               <td style="padding: 12px; border-bottom: 1px solid #eee;">${source.source} / ${source.medium}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(source.visits)}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatPercent(source.conversionRate)}</td>
             </tr>
-            `).join("")}
+            `
+              )
+              .join('')}
           </tbody>
         </table>
-        ` : ""}
+        `
+            : ''
+        }
 
-        ${data.devices && data.devices.length > 0 ? `
+        ${
+          data.devices && data.devices.length > 0
+            ? `
         <h2 style="color: #1a1a2e; border-bottom: 2px solid #D4AF37; padding-bottom: 10px;">📱 Appareils</h2>
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 25px; background: white; border-radius: 8px;">
           <thead>
@@ -405,31 +424,45 @@ function generateReportEmailHtml(
             </tr>
           </thead>
           <tbody>
-            ${data.devices.map((device) => `
+            ${data.devices
+              .map(
+                device => `
             <tr>
               <td style="padding: 12px; border-bottom: 1px solid #eee; text-transform: capitalize;">${device.deviceType}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(device.visits)}</td>
               <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatTime(device.avgTimeOnSite)}</td>
             </tr>
-            `).join("")}
+            `
+              )
+              .join('')}
           </tbody>
         </table>
-        ` : ""}
+        `
+            : ''
+        }
 
-        ${data.anomalies && data.anomalies.length > 0 ? `
+        ${
+          data.anomalies && data.anomalies.length > 0
+            ? `
         <h2 style="color: #dc3545; border-bottom: 2px solid #dc3545; padding-bottom: 10px;">⚠️ Alertes</h2>
         <div style="background: #fff3cd; border-left: 4px solid #ffc107; padding: 15px; margin-bottom: 25px; border-radius: 4px;">
-          ${data.anomalies.map((anomaly) => `
+          ${data.anomalies
+            .map(
+              anomaly => `
           <div style="margin-bottom: 10px;">
-            <span style="display: inline-block; padding: 2px 8px; background: ${anomaly.severity === "high" ? "#dc3545" : anomaly.severity === "medium" ? "#ffc107" : "#6c757d"}; color: white; border-radius: 4px; font-size: 11px; margin-right: 8px;">${anomaly.severity.toUpperCase()}</span>
+            <span style="display: inline-block; padding: 2px 8px; background: ${anomaly.severity === 'high' ? '#dc3545' : anomaly.severity === 'medium' ? '#ffc107' : '#6c757d'}; color: white; border-radius: 4px; font-size: 11px; margin-right: 8px;">${anomaly.severity.toUpperCase()}</span>
             ${anomaly.message}
           </div>
-          `).join("")}
+          `
+            )
+            .join('')}
         </div>
-        ` : ""}
+        `
+            : ''
+        }
 
         <div style="text-align: center; padding-top: 20px; border-top: 1px solid #ddd;">
-          <a href="${process.env.NEXT_PUBLIC_SITE_URL || "https://psypnos.fr"}/admin/analytics"
+          <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'https://psypnos.fr'}/admin/analytics"
              style="display: inline-block; padding: 12px 30px; background-color: #D4AF37; color: #1a1a2e; text-decoration: none; border-radius: 5px; font-weight: bold;">
             Voir le Dashboard
           </a>
@@ -446,25 +479,21 @@ function generateReportEmailHtml(
 /**
  * Envoie l'email du rapport
  */
-async function sendReportEmail(
-  recipients: string[],
-  subject: string,
-  html: string
-): Promise<void> {
+async function sendReportEmail(recipients: string[], subject: string, html: string): Promise<void> {
   const resendApiKey = process.env.RESEND_API_KEY;
 
   if (!resendApiKey) {
-    throw new Error("RESEND_API_KEY non configuré");
+    throw new Error('RESEND_API_KEY non configuré');
   }
 
-  const response = await fetch("https://api.resend.com/emails", {
-    method: "POST",
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${resendApiKey}`,
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: process.env.REPORT_EMAIL_FROM || "Psypnos Analytics <analytics@psypnos.fr>",
+      from: process.env.REPORT_EMAIL_FROM || 'Psypnos Analytics <analytics@psypnos.fr>',
       to: recipients,
       subject: `[Psypnos] ${subject}`,
       html,

--- a/apps/psypnos/app/api/cron/refresh-tokens/route.ts
+++ b/apps/psypnos/app/api/cron/refresh-tokens/route.ts
@@ -17,14 +17,11 @@
  * Security: QStash signature or CRON_SECRET
  */
 
-import { verifyCronAuth } from "@kairn/core/scheduler";
-import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { prisma } from "@/lib/db/prisma";
-import {
-  refreshAllExpiringTokens,
-  getAccountsNeedingRefresh,
-} from "@/lib/social/oauth/refresh";
+import { prisma } from '@/lib/db/prisma';
+import { refreshAllExpiringTokens, getAccountsNeedingRefresh } from '@/lib/social/oauth/refresh';
 
 /**
  * Envoie une notification pour les comptes nécessitant une reconnexion
@@ -38,32 +35,32 @@ async function notifyAccountsNeedingReconnection(
   const resendApiKey = process.env.RESEND_API_KEY;
 
   if (!adminEmail || !resendApiKey) {
-    console.warn("[Cron:refresh-tokens] Impossible d'envoyer la notification - ADMIN_EMAIL ou RESEND_API_KEY manquant");
+    console.warn(
+      "[Cron:refresh-tokens] Impossible d'envoyer la notification - ADMIN_EMAIL ou RESEND_API_KEY manquant"
+    );
     return;
   }
 
   try {
-    const accountsList = failedAccounts
-      .map((a) => `- ${a.platform}: ${a.message}`)
-      .join("\n");
+    const accountsList = failedAccounts.map(a => `- ${a.platform}: ${a.message}`).join('\n');
 
-    const response = await fetch("https://api.resend.com/emails", {
-      method: "POST",
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         Authorization: `Bearer ${resendApiKey}`,
       },
       body: JSON.stringify({
-        from: process.env.ALERT_EMAIL_FROM || "Psypnos <notifications@psypnos.fr>",
+        from: process.env.ALERT_EMAIL_FROM || 'Psypnos <notifications@psypnos.fr>',
         to: [adminEmail],
-        subject: "⚠️ Psypnos - Comptes sociaux nécessitant reconnexion",
+        subject: '⚠️ Psypnos - Comptes sociaux nécessitant reconnexion',
         html: `
           <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
             <h2 style="color: #e74c3c;">🔐 Reconnexion nécessaire</h2>
             <p>Les comptes suivants ont besoin d'être reconnectés car leurs tokens n'ont pas pu être rafraîchis automatiquement:</p>
             <pre style="background: #f5f5f5; padding: 15px; border-radius: 5px;">${accountsList}</pre>
             <p style="margin-top: 20px;">
-              <a href="${process.env.NEXT_PUBLIC_APP_URL || "https://psypnos.fr"}/admin/social/accounts"
+              <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://psypnos.fr'}/admin/social/accounts"
                  style="background: #3498db; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">
                 Gérer les comptes
               </a>
@@ -77,10 +74,10 @@ async function notifyAccountsNeedingReconnection(
     });
 
     if (!response.ok) {
-      console.error("[Cron:refresh-tokens] Erreur envoi email:", await response.text());
+      console.error('[Cron:refresh-tokens] Erreur envoi email:', await response.text());
     }
   } catch (error) {
-    console.error("[Cron:refresh-tokens] Erreur notification:", error);
+    console.error('[Cron:refresh-tokens] Erreur notification:', error);
   }
 }
 
@@ -88,7 +85,7 @@ export async function GET(request: NextRequest) {
   // Verify authentication (QStash signature or CRON_SECRET)
   const authResult = await verifyCronAuth(request);
   if (!authResult.valid) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const startTime = Date.now();
@@ -101,7 +98,7 @@ export async function GET(request: NextRequest) {
     if (accountsNeedingRefresh.length === 0) {
       return NextResponse.json({
         success: true,
-        message: "Aucun token à rafraîchir",
+        message: 'Aucun token à rafraîchir',
         processed: 0,
         results: {
           total: 0,
@@ -117,8 +114,8 @@ export async function GET(request: NextRequest) {
 
     // 3. Identifier les comptes en échec qui nécessitent une reconnexion
     const failedAccounts = result.results
-      .filter((r) => !r.success && r.platform !== "FACEBOOK" && r.platform !== "INSTAGRAM")
-      .map((r) => ({
+      .filter(r => !r.success && r.platform !== 'FACEBOOK' && r.platform !== 'INSTAGRAM')
+      .map(r => ({
         accountId: r.accountId,
         platform: r.platform,
         message: r.message,
@@ -133,7 +130,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      message: "Rafraîchissement des tokens terminé",
+      message: 'Rafraîchissement des tokens terminé',
       duration: `${duration}s`,
       processed: result.total,
       results: {
@@ -145,13 +142,16 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    console.error("[Cron:refresh-tokens] Erreur:", error);
+    console.error('[Cron:refresh-tokens] Erreur:', error);
     return NextResponse.json(
       {
-        error: "Token refresh failed",
-        message: error instanceof Error ? error.message : "Unknown error",
+        error: 'Token refresh failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }
     );
   }
 }
+
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };

--- a/apps/psypnos/app/api/cron/social-publish/route.ts
+++ b/apps/psypnos/app/api/cron/social-publish/route.ts
@@ -111,8 +111,8 @@ async function publishPostWithRetry(post: SocialPost): Promise<{
     const errorMessage = error instanceof Error ? error.message : 'Erreur inconnue';
 
     // Vérifier si c'est une erreur retryable
-    const isRetryable = DEFAULT_RETRY_CONFIG.retryableErrors.some(
-      (retryableError) => errorMessage.includes(retryableError)
+    const isRetryable = DEFAULT_RETRY_CONFIG.retryableErrors.some(retryableError =>
+      errorMessage.includes(retryableError)
     );
 
     await incrementRetryCount(post.id);
@@ -136,12 +136,11 @@ async function publishPostWithRetry(post: SocialPost): Promise<{
 // Notification par email
 // ===========================================
 
-async function sendFailureNotification(
-  post: SocialPost,
-  error: string
-): Promise<void> {
+async function sendFailureNotification(post: SocialPost, error: string): Promise<void> {
   if (!RESEND_API_KEY) {
-    console.warn('[Cron Social Publish] RESEND_API_KEY not configured - skipping email notification');
+    console.warn(
+      '[Cron Social Publish] RESEND_API_KEY not configured - skipping email notification'
+    );
     return;
   }
 
@@ -184,7 +183,7 @@ ${error}
     const response = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${RESEND_API_KEY}`,
+        Authorization: `Bearer ${RESEND_API_KEY}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -234,8 +233,8 @@ export async function GET(request: NextRequest) {
     const posts = await getScheduledPosts(now);
 
     // Compter les posts par statut pour le logging
-    const scheduledPosts = posts.filter((p) => p.status === 'SCHEDULED');
-    const stuckPosts = posts.filter((p) => p.status === 'PUBLISHING');
+    const scheduledPosts = posts.filter(p => p.status === 'SCHEDULED');
+    const stuckPosts = posts.filter(p => p.status === 'PUBLISHING');
 
     console.log(
       `[Cron Social Publish] Found ${posts.length} posts to publish ` +
@@ -245,7 +244,7 @@ export async function GET(request: NextRequest) {
     if (stuckPosts.length > 0) {
       console.warn(
         `[Cron Social Publish] Recovering ${stuckPosts.length} stuck posts: ` +
-          stuckPosts.map((p) => `${p.id} (${p.platform})`).join(', ')
+          stuckPosts.map(p => `${p.id} (${p.platform})`).join(', ')
       );
     }
 
@@ -278,16 +277,14 @@ export async function GET(request: NextRequest) {
       }
 
       // Petit délai entre les publications pour éviter le rate limiting
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise(resolve => setTimeout(resolve, 1000));
     }
 
     // Résumé
-    const successCount = results.filter((r) => r.success).length;
-    const failCount = results.filter((r) => !r.success).length;
+    const successCount = results.filter(r => r.success).length;
+    const failCount = results.filter(r => !r.success).length;
 
-    console.log(
-      `[Cron Social Publish] Completed: ${successCount} success, ${failCount} failed`
-    );
+    console.log(`[Cron Social Publish] Completed: ${successCount} success, ${failCount} failed`);
 
     return NextResponse.json({
       success: true,
@@ -312,6 +309,9 @@ export async function GET(request: NextRequest) {
     );
   }
 }
+
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };
 
 // Configuration pour Vercel Cron
 export const runtime = 'nodejs';

--- a/apps/psypnos/app/api/cron/weekly-report/route.ts
+++ b/apps/psypnos/app/api/cron/weekly-report/route.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-import { verifyCronAuth } from "@kairn/core/scheduler";
-import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
 
 import {
   getAnalyticsSummary,
@@ -14,9 +14,12 @@ import {
   getAnomalies,
   getScheduledReports,
   updateScheduledReport,
-} from "../../analytics/store-index";
+} from '../../analytics/store-index';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
+
+// Accepter aussi POST car QStash envoie POST par défaut
+export { GET as POST };
 
 // GET - Generate and send weekly reports (called by QStash)
 export async function GET(request: NextRequest) {
@@ -24,14 +27,14 @@ export async function GET(request: NextRequest) {
     // Verify authentication (QStash signature or CRON_SECRET)
     const authResult = await verifyCronAuth(request);
     if (!authResult.valid) {
-      return NextResponse.json({ error: "Non autorise" }, { status: 401 });
+      return NextResponse.json({ error: 'Non autorise' }, { status: 401 });
     }
 
     // Get scheduled reports that need to run
     const reports = await getScheduledReports(true);
     const now = new Date();
-    const weeklyReports = reports.filter((r) => {
-      if (r.frequency !== "weekly") return false;
+    const weeklyReports = reports.filter(r => {
+      if (r.frequency !== 'weekly') return false;
       if (!r.nextScheduled) return true;
       return new Date(r.nextScheduled) <= now;
     });
@@ -52,32 +55,24 @@ export async function GET(request: NextRequest) {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    const reportData = await generateWeeklyReportData(
-      weekAgo.toISOString(),
-      today.toISOString()
-    );
+    const reportData = await generateWeeklyReportData(weekAgo.toISOString(), today.toISOString());
 
     for (const report of weeklyReports) {
       try {
         // Generate HTML email
-        const emailHtml = generateWeeklyReportEmailHtml(
-          report.name,
-          reportData,
-          weekAgo,
-          today
-        );
+        const emailHtml = generateWeeklyReportEmailHtml(report.name, reportData, weekAgo, today);
 
         // Send email
         await sendReportEmail(
           report.recipients,
-          `Rapport Hebdomadaire - Semaine du ${weekAgo.toLocaleDateString("fr-FR")}`,
+          `Rapport Hebdomadaire - Semaine du ${weekAgo.toLocaleDateString('fr-FR')}`,
           emailHtml
         );
 
         // Update next scheduled time (next week, same day)
         const nextScheduled = new Date();
         nextScheduled.setDate(nextScheduled.getDate() + 7);
-        const [hours, minutes] = report.timeOfDay.split(":").map(Number);
+        const [hours, minutes] = report.timeOfDay.split(':').map(Number);
         nextScheduled.setHours(hours, minutes, 0, 0);
 
         await updateScheduledReport(report.id, {
@@ -98,21 +93,21 @@ export async function GET(request: NextRequest) {
           reportName: report.name,
           sent: false,
           recipients: 0,
-          error: error instanceof Error ? error.message : "Erreur inconnue",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
         });
       }
     }
 
     return NextResponse.json({
       processed: weeklyReports.length,
-      sent: results.filter((r) => r.sent).length,
+      sent: results.filter(r => r.sent).length,
       results,
       timestamp: now.toISOString(),
     });
   } catch (error) {
-    console.error("Error generating weekly reports:", error);
+    console.error('Error generating weekly reports:', error);
     return NextResponse.json(
-      { error: "Erreur lors de la generation des rapports" },
+      { error: 'Erreur lors de la generation des rapports' },
       { status: 500 }
     );
   }
@@ -120,15 +115,16 @@ export async function GET(request: NextRequest) {
 
 // Generate weekly report data
 async function generateWeeklyReportData(startDate: string, endDate: string) {
-  const [summary, comparison, trafficSources, devices, heatmap, cohorts, anomalies] = await Promise.all([
-    getAnalyticsSummary(startDate, endDate),
-    getAnalyticsSummaryWithComparison("week"),
-    getTrafficSources(startDate, endDate),
-    getDeviceBreakdown(startDate, endDate),
-    getSectionHeatmap(startDate, endDate),
-    getCohortAnalysis("week", startDate, endDate),
-    getAnomalies(startDate, endDate),
-  ]);
+  const [summary, comparison, trafficSources, devices, heatmap, cohorts, anomalies] =
+    await Promise.all([
+      getAnalyticsSummary(startDate, endDate),
+      getAnalyticsSummaryWithComparison('week'),
+      getTrafficSources(startDate, endDate),
+      getDeviceBreakdown(startDate, endDate),
+      getSectionHeatmap(startDate, endDate),
+      getCohortAnalysis('week', startDate, endDate),
+      getAnomalies(startDate, endDate),
+    ]);
 
   return {
     summary,
@@ -148,7 +144,7 @@ function generateWeeklyReportEmailHtml(
   startDate: Date,
   endDate: Date
 ): string {
-  const formatNumber = (n: number) => n.toLocaleString("fr-FR");
+  const formatNumber = (n: number) => n.toLocaleString('fr-FR');
   const formatPercent = (n: number) => `${n.toFixed(1)}%`;
   const formatTime = (ms: number) => {
     const seconds = Math.round(ms / 1000);
@@ -157,8 +153,8 @@ function generateWeeklyReportEmailHtml(
     return `${minutes}m ${remainingSeconds}s`;
   };
 
-  const changeArrow = (change: number) => (change >= 0 ? "↑" : "↓");
-  const changeColor = (change: number) => (change >= 0 ? "#28a745" : "#dc3545");
+  const changeArrow = (change: number) => (change >= 0 ? '↑' : '↓');
+  const changeColor = (change: number) => (change >= 0 ? '#28a745' : '#dc3545');
 
   return `
     <!DOCTYPE html>
@@ -172,7 +168,7 @@ function generateWeeklyReportEmailHtml(
         <h1 style="color: #D4AF37; margin: 0; font-size: 28px;">Psypnos Analytics</h1>
         <p style="color: #fff; margin: 10px 0 0 0; font-size: 16px;">Rapport Hebdomadaire</p>
         <p style="color: #aaa; margin: 5px 0 0 0; font-size: 14px;">
-          ${startDate.toLocaleDateString("fr-FR")} - ${endDate.toLocaleDateString("fr-FR")}
+          ${startDate.toLocaleDateString('fr-FR')} - ${endDate.toLocaleDateString('fr-FR')}
         </p>
       </div>
 
@@ -210,7 +206,9 @@ function generateWeeklyReportEmailHtml(
         </div>
 
         <!-- Conversions Detail -->
-        ${Object.keys(data.summary.conversionByType).length > 0 ? `
+        ${
+          Object.keys(data.summary.conversionByType).length > 0
+            ? `
         <div style="background: white; padding: 20px; border-radius: 10px; margin-bottom: 25px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
           <h2 style="color: #1a1a2e; margin-top: 0;">Performance des Conversions</h2>
           <table style="width: 100%; border-collapse: collapse;">
@@ -223,21 +221,29 @@ function generateWeeklyReportEmailHtml(
               </tr>
             </thead>
             <tbody>
-              ${Object.entries(data.summary.conversionByType).map(([type, conv]) => `
+              ${Object.entries(data.summary.conversionByType)
+                .map(
+                  ([type, conv]) => `
               <tr>
-                <td style="padding: 12px; border-bottom: 1px solid #eee; text-transform: capitalize;">${type.replace(/_/g, " ")}</td>
+                <td style="padding: 12px; border-bottom: 1px solid #eee; text-transform: capitalize;">${type.replace(/_/g, ' ')}</td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(conv.clicks)}</td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee; font-weight: bold;">${formatNumber(conv.completed)}</td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee; color: #D4AF37; font-weight: bold;">${formatPercent(conv.rate)}</td>
               </tr>
-              `).join("")}
+              `
+                )
+                .join('')}
             </tbody>
           </table>
         </div>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Top Traffic Sources -->
-        ${data.trafficSources.length > 0 ? `
+        ${
+          data.trafficSources.length > 0
+            ? `
         <div style="background: white; padding: 20px; border-radius: 10px; margin-bottom: 25px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
           <h2 style="color: #1a1a2e; margin-top: 0;">Top 10 Sources de Trafic</h2>
           <table style="width: 100%; border-collapse: collapse;">
@@ -250,23 +256,31 @@ function generateWeeklyReportEmailHtml(
               </tr>
             </thead>
             <tbody>
-              ${data.trafficSources.map((source, i) => `
-              <tr style="background: ${i % 2 === 0 ? "white" : "#f8f9fa"};">
+              ${data.trafficSources
+                .map(
+                  (source, i) => `
+              <tr style="background: ${i % 2 === 0 ? 'white' : '#f8f9fa'};">
                 <td style="padding: 12px; border-bottom: 1px solid #eee;">
                   <strong>${source.source}</strong> / ${source.medium}
                 </td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(source.visits)}</td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(source.uniqueSessions)}</td>
-                <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee; color: ${source.conversionRate > 0 ? "#28a745" : "#666"};">${formatPercent(source.conversionRate)}</td>
+                <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee; color: ${source.conversionRate > 0 ? '#28a745' : '#666'};">${formatPercent(source.conversionRate)}</td>
               </tr>
-              `).join("")}
+              `
+                )
+                .join('')}
             </tbody>
           </table>
         </div>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Top Sections -->
-        ${data.sections.length > 0 ? `
+        ${
+          data.sections.length > 0
+            ? `
         <div style="background: white; padding: 20px; border-radius: 10px; margin-bottom: 25px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
           <h2 style="color: #1a1a2e; margin-top: 0;">Performance des Sections</h2>
           <table style="width: 100%; border-collapse: collapse;">
@@ -279,27 +293,39 @@ function generateWeeklyReportEmailHtml(
               </tr>
             </thead>
             <tbody>
-              ${data.sections.map((section) => `
+              ${data.sections
+                .map(
+                  section => `
               <tr>
                 <td style="padding: 12px; border-bottom: 1px solid #eee;">${section.section}</td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${formatNumber(section.visitors)}</td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee;">${section.avgTimeSeconds}s</td>
                 <td style="padding: 12px; text-align: center; border-bottom: 1px solid #eee; font-weight: bold; color: #D4AF37;">${formatNumber(section.conversionsFromSection)}</td>
               </tr>
-              `).join("")}
+              `
+                )
+                .join('')}
             </tbody>
           </table>
         </div>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Device Breakdown -->
-        ${data.devices.length > 0 ? `
+        ${
+          data.devices.length > 0
+            ? `
         <div style="background: white; padding: 20px; border-radius: 10px; margin-bottom: 25px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
           <h2 style="color: #1a1a2e; margin-top: 0;">Repartition par Appareil</h2>
           <table style="width: 100%; border-collapse: collapse;">
-            ${data.devices.map((device) => {
-              const percentage = data.summary.totalVisits > 0 ? (device.visits / data.summary.totalVisits) * 100 : 0;
-              return `
+            ${data.devices
+              .map(device => {
+                const percentage =
+                  data.summary.totalVisits > 0
+                    ? (device.visits / data.summary.totalVisits) * 100
+                    : 0;
+                return `
               <tr>
                 <td style="padding: 15px 12px; border-bottom: 1px solid #eee; width: 120px; text-transform: capitalize; font-weight: bold;">${device.deviceType}</td>
                 <td style="padding: 15px 12px; border-bottom: 1px solid #eee;">
@@ -312,28 +338,40 @@ function generateWeeklyReportEmailHtml(
                 </td>
               </tr>
               `;
-            }).join("")}
+              })
+              .join('')}
           </table>
         </div>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Anomalies Alert -->
-        ${data.anomalies.length > 0 ? `
+        ${
+          data.anomalies.length > 0
+            ? `
         <div style="background: #fff3cd; border: 1px solid #ffc107; padding: 20px; border-radius: 10px; margin-bottom: 25px;">
           <h2 style="color: #856404; margin-top: 0;">⚠️ ${data.anomalies.length} Anomalie(s) Detectee(s)</h2>
-          ${data.anomalies.slice(0, 5).map((anomaly) => `
-          <div style="background: white; padding: 12px; border-radius: 5px; margin-bottom: 10px; border-left: 4px solid ${anomaly.severity === "high" ? "#dc3545" : anomaly.severity === "medium" ? "#ffc107" : "#6c757d"};">
-            <span style="display: inline-block; padding: 2px 8px; background: ${anomaly.severity === "high" ? "#dc3545" : anomaly.severity === "medium" ? "#ffc107" : "#6c757d"}; color: white; border-radius: 4px; font-size: 11px; margin-right: 8px; text-transform: uppercase;">${anomaly.severity}</span>
+          ${data.anomalies
+            .slice(0, 5)
+            .map(
+              anomaly => `
+          <div style="background: white; padding: 12px; border-radius: 5px; margin-bottom: 10px; border-left: 4px solid ${anomaly.severity === 'high' ? '#dc3545' : anomaly.severity === 'medium' ? '#ffc107' : '#6c757d'};">
+            <span style="display: inline-block; padding: 2px 8px; background: ${anomaly.severity === 'high' ? '#dc3545' : anomaly.severity === 'medium' ? '#ffc107' : '#6c757d'}; color: white; border-radius: 4px; font-size: 11px; margin-right: 8px; text-transform: uppercase;">${anomaly.severity}</span>
             <span style="color: #333;">${anomaly.message}</span>
-            <div style="color: #666; font-size: 12px; margin-top: 5px;">${new Date(anomaly.timestamp).toLocaleString("fr-FR")}</div>
+            <div style="color: #666; font-size: 12px; margin-top: 5px;">${new Date(anomaly.timestamp).toLocaleString('fr-FR')}</div>
           </div>
-          `).join("")}
+          `
+            )
+            .join('')}
         </div>
-        ` : ""}
+        `
+            : ''
+        }
 
         <!-- Call to Action -->
         <div style="text-align: center; padding: 25px 0;">
-          <a href="${process.env.NEXT_PUBLIC_SITE_URL || "https://psypnos.fr"}/admin/analytics"
+          <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'https://psypnos.fr'}/admin/analytics"
              style="display: inline-block; padding: 15px 40px; background: linear-gradient(135deg, #D4AF37, #f0d78c); color: #1a1a2e; text-decoration: none; border-radius: 8px; font-weight: bold; font-size: 16px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
             Voir le Dashboard Complet
           </a>
@@ -353,26 +391,22 @@ function generateWeeklyReportEmailHtml(
 }
 
 // Send report email
-async function sendReportEmail(
-  recipients: string[],
-  subject: string,
-  html: string
-): Promise<void> {
+async function sendReportEmail(recipients: string[], subject: string, html: string): Promise<void> {
   const resendApiKey = process.env.RESEND_API_KEY;
 
   if (!resendApiKey) {
-    console.warn("RESEND_API_KEY not configured, skipping report email");
-    throw new Error("Service email non configure");
+    console.warn('RESEND_API_KEY not configured, skipping report email');
+    throw new Error('Service email non configure');
   }
 
-  const response = await fetch("https://api.resend.com/emails", {
-    method: "POST",
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${resendApiKey}`,
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: process.env.REPORT_EMAIL_FROM || "Psypnos Analytics <analytics@psypnos.fr>",
+      from: process.env.REPORT_EMAIL_FROM || 'Psypnos Analytics <analytics@psypnos.fr>',
       to: recipients,
       subject: `[Psypnos] ${subject}`,
       html,

--- a/apps/psypnos/lib/social/store.ts
+++ b/apps/psypnos/lib/social/store.ts
@@ -376,6 +376,9 @@ export async function markPostAsPublished(
 
 /**
  * Marque un post comme échoué
+ *
+ * Note : ne pas incrémenter retryCount ici car il est déjà incrémenté
+ * par incrementRetryCount() appelé en amont dans le flux de publication.
  */
 export async function markPostAsFailed(id: string, errorMessage: string): Promise<SocialPost> {
   const post = await prisma.socialPost.update({
@@ -383,7 +386,6 @@ export async function markPostAsFailed(id: string, errorMessage: string): Promis
     data: {
       status: 'FAILED',
       errorMessage,
-      retryCount: { increment: 1 },
     },
   });
 

--- a/scripts/setup-qstash-schedules.ts
+++ b/scripts/setup-qstash-schedules.ts
@@ -160,6 +160,7 @@ async function main() {
         destination,
         cron,
         retries: 3,
+        method: 'GET',
       });
 
       results.push({


### PR DESCRIPTION
QStash envoie des requêtes POST par défaut, mais les routes CRON
n'exportaient qu'un handler GET, résultant en 405 Method Not Allowed.
Ajoute `export { GET as POST }` à toutes les routes CRON GET-only.

Corrige aussi la double incrémentation de retryCount dans
markPostAsFailed (déjà incrémenté par incrementRetryCount en amont).

Met à jour setup-qstash-schedules.ts pour passer method: 'GET' explicitement.

Fixes #160

https://claude.ai/code/session_01JojF6XJTqQMdYTexq5Qzf1