### PR TITLE
fix(blog): sécuriser les routes de génération IA et corriger la confirmation d'image

### DIFF
--- a/apps/psypnos/app/api/blog/confirm-image-selection/route.ts
+++ b/apps/psypnos/app/api/blog/confirm-image-selection/route.ts
@@ -1,25 +1,33 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
-import { copyFile } from "fs/promises";
-import { join, basename } from "path";
+/**
+ * API pour confirmer la sélection d'une image générée
+ *
+ * POST /api/blog/confirm-image-selection
+ *
+ * Copie l'image sélectionnée depuis le dossier temporaire vers sa
+ * destination finale en utilisant le module de stockage (Supabase ou local).
+ */
 
-import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
-import { withAdminAuth } from "../../auth/middleware";
+import { uploadImage, BUCKETS } from '@/lib/supabase/storage';
+
+import { withAdminAuth } from '../../auth/middleware';
 
 const confirmSelectionSchema = z.object({
   selectedProposalId: z.string(),
   tempPath: z.string(),
-  slug: z.string().trim().min(1, "Le slug est requis"),
+  slug: z.string().trim().min(1, 'Le slug est requis'),
 });
 
 /**
  * Confirme la sélection d'une image et la sauvegarde définitivement
+ *
+ * Télécharge l'image depuis l'emplacement temporaire (Supabase URL ou
+ * chemin local) et la re-upload vers l'emplacement final via le module
+ * de stockage unifié.
  */
 export async function POST(request: NextRequest) {
-  // Vérifier l'authentification admin
   const authResult = await withAdminAuth();
   if (authResult.error) return authResult.error;
 
@@ -30,49 +38,63 @@ export async function POST(request: NextRequest) {
     if (!parsed.success) {
       const firstError = parsed.error.issues[0];
       return NextResponse.json(
-        { message: firstError?.message ?? "Données invalides." },
+        { message: firstError?.message ?? 'Données invalides.' },
         { status: 400 }
       );
     }
 
     const { tempPath, slug } = parsed.data;
 
-    // Chemins des dossiers
-    const publicDir = join(process.cwd(), "public");
-    const tempDir = join(publicDir, "images", "blog", "temp");
-    const blogImagesDir = join(publicDir, "images", "blog");
-
-    // Extraire le nom du fichier depuis tempPath
-    const tempFileName = basename(tempPath);
-    const sourcePath = join(tempDir, tempFileName);
-    const destinationPath = join(blogImagesDir, `${slug}.webp`);
+    // Télécharger l'image depuis son emplacement temporaire
+    // tempPath peut être une URL Supabase ou un chemin local
+    let imageBuffer: Buffer;
 
     try {
-      // Copier le fichier sélectionné vers le dossier final
-      await copyFile(sourcePath, destinationPath);
+      if (tempPath.startsWith('http://') || tempPath.startsWith('https://')) {
+        // Image sur Supabase Storage — télécharger via HTTP
+        const response = await fetch(tempPath);
+        if (!response.ok) {
+          throw new Error(`Impossible de télécharger l'image: ${response.status}`);
+        }
+        imageBuffer = Buffer.from(await response.arrayBuffer());
+      } else {
+        // Image sur le filesystem local — lire le fichier
+        const { promises: fs } = await import('fs');
+        const { join } = await import('path');
+        const publicDir = join(process.cwd(), 'public');
+        const fullPath = join(publicDir, tempPath.replace(/^\//, ''));
+        imageBuffer = await fs.readFile(fullPath);
+      }
     } catch (error) {
-      console.error("Erreur lors de la copie du fichier:", error);
+      console.error("Erreur lors de la lecture de l'image temporaire:", error);
+      return NextResponse.json(
+        { message: "Impossible de lire l'image sélectionnée." },
+        { status: 500 }
+      );
+    }
+
+    // Upload vers l'emplacement final via le module de stockage unifié
+    const finalFilename = `${slug}.webp`;
+    const result = await uploadImage(BUCKETS.BLOG_IMAGES, finalFilename, imageBuffer, 'image/webp');
+
+    if (!result.success) {
+      console.error("Erreur lors de l'upload de l'image finale:", result.error);
       return NextResponse.json(
         { message: "Impossible de sauvegarder l'image sélectionnée." },
         { status: 500 }
       );
     }
 
-    // NOTE: On ne supprime PAS les fichiers temporaires ici pour permettre
-    // à l'utilisateur de changer d'avis jusqu'à l'enregistrement final.
-    // Les fichiers temporaires seront nettoyés lors de la prochaine génération.
-
-    // Retourner le chemin propre - le cache-busting est géré par le composant BlogImage
     return NextResponse.json({
       success: true,
       finalPath: `/images/blog/${slug}.webp`,
     });
   } catch (error) {
-    console.error("Erreur lors de la confirmation de la sélection:", error);
+    console.error('Erreur lors de la confirmation de la sélection:', error);
     return NextResponse.json(
       {
-        message: "Une erreur est survenue lors de la sauvegarde. Veuillez réessayer.",
-        error: error instanceof Error ? error.message : "Unknown error",
+        message: 'Une erreur est survenue lors de la sauvegarde. Veuillez réessayer.',
+        error: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }
     );

--- a/apps/psypnos/app/api/blog/generate-multi-step/route.ts
+++ b/apps/psypnos/app/api/blog/generate-multi-step/route.ts
@@ -20,6 +20,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
+import { withAdminAuth } from '../../auth/middleware';
 import {
   generateArticleMultiStep,
   type GenerationStep,
@@ -71,6 +72,9 @@ function encodeSSE(event: string, data: unknown): string {
  * 2. Mode streaming (useStreaming: true): Utilise SSE pour les mises à jour en temps réel
  */
 export async function POST(request: NextRequest) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
   let payload: GenerateArticlePayload;
 
   try {

--- a/apps/psypnos/app/api/blog/generate-sectional/route.ts
+++ b/apps/psypnos/app/api/blog/generate-sectional/route.ts
@@ -23,6 +23,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
+import { withAdminAuth } from '../../auth/middleware';
 import {
   generateArticleSectional,
   type GenerationProgress,
@@ -80,6 +81,9 @@ function encodeSSE(event: string, data: unknown): string {
  * 2. Mode streaming (useStreaming: true): Utilise SSE pour les mises à jour en temps réel
  */
 export async function POST(request: NextRequest) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
   let payload: GenerateArticlePayload;
 
   try {

--- a/apps/psypnos/app/api/blog/generate/route.ts
+++ b/apps/psypnos/app/api/blog/generate/route.ts
@@ -13,6 +13,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
+import { withAdminAuth } from '../../auth/middleware';
 import {
   generateArticleWithClaude,
   type ArticleGenerationOptions,
@@ -88,6 +89,9 @@ type GenerateArticlePayload = z.infer<typeof generateArticleSchema>;
  * 4. Return generated article with title, content, FAQ items, etc.
  */
 export async function POST(request: Request) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+
   let payload: GenerateArticlePayload;
 
   try {


### PR DESCRIPTION
- Ajout de withAdminAuth() sur /api/blog/generate (Fixes #176)
- Ajout de withAdminAuth() sur /api/blog/generate-multi-step (Fixes #176)
- Ajout de withAdminAuth() sur /api/blog/generate-sectional (Fixes #176)
- Réécriture de confirm-image-selection pour utiliser le module de stockage
  unifié (Supabase ou local) au lieu de fs.copyFile direct (Fixes #177)
- Suppression du @ts-nocheck sur confirm-image-selection
- Vérification de la génération IA des posts séminaires (Fixes #178)
- Vérification de la publication des séminaires (Fixes #179)

https://claude.ai/code/session_01MNvpvHv5B5cJaba7eXiSpg