### PR TITLE
fix(analytics): corriger le tracking des posts et bots, traduire GeoPage

### DIFF
--- a/apps/psypnos/app/api/analytics/bots/route.ts
+++ b/apps/psypnos/app/api/analytics/bots/route.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - BotVisit model not available in Kairn schema
 /**
  * Bot Analytics API
  *
@@ -154,7 +151,8 @@ export async function GET(request: NextRequest): Promise<Response> {
     // Calculate summary stats
     const uniqueBots = new Set(visits.map(v => v.botName)).size;
     const uniquePages = new Set(visits.map(v => v.page)).size;
-    const lastVisit = visits.length > 0 ? visits[0].timestamp.toISOString() : null;
+    const lastVisit =
+      visits.length > 0 ? (visits[0] as BotVisitRecord).timestamp.toISOString() : null;
 
     // Group by bot type
     const byTypeMap = new Map<string, number>();
@@ -173,11 +171,15 @@ export async function GET(request: NextRequest): Promise<Response> {
       .sort((a, b) => b.count - a.count);
 
     // Group by bot name
-    const byBotMap = new Map<string, { type: string; count: number; lastVisit: Date }>();
+    const byBotMap = new Map<
+      string,
+      { type: string; count: number; lastVisit: Date; pages: Set<string> }
+    >();
     visits.forEach(v => {
       const existing = byBotMap.get(v.botName);
       if (existing) {
         existing.count++;
+        existing.pages.add(v.page);
         if (v.timestamp > existing.lastVisit) {
           existing.lastVisit = v.timestamp;
         }
@@ -186,6 +188,7 @@ export async function GET(request: NextRequest): Promise<Response> {
           type: v.botType,
           count: 1,
           lastVisit: v.timestamp,
+          pages: new Set([v.page]),
         });
       }
     });
@@ -196,19 +199,32 @@ export async function GET(request: NextRequest): Promise<Response> {
         type: data.type,
         count: data.count,
         lastVisit: data.lastVisit.toISOString(),
+        pages: data.pages.size,
       }))
       .sort((a, b) => b.count - a.count)
       .slice(0, 20);
 
     // Group by page
-    const byPageMap = new Map<string, { visits: number; bots: Set<string> }>();
+    const byPageMap = new Map<
+      string,
+      { visits: number; bots: Set<string>; botTypes: Set<string>; lastCrawled: Date }
+    >();
     visits.forEach(v => {
       const existing = byPageMap.get(v.page);
       if (existing) {
         existing.visits++;
         existing.bots.add(v.botName);
+        existing.botTypes.add(v.botType);
+        if (v.timestamp > existing.lastCrawled) {
+          existing.lastCrawled = v.timestamp;
+        }
       } else {
-        byPageMap.set(v.page, { visits: 1, bots: new Set([v.botName]) });
+        byPageMap.set(v.page, {
+          visits: 1,
+          bots: new Set([v.botName]),
+          botTypes: new Set([v.botType]),
+          lastCrawled: v.timestamp,
+        });
       }
     });
 
@@ -217,6 +233,8 @@ export async function GET(request: NextRequest): Promise<Response> {
         page,
         visits: data.visits,
         uniqueBots: data.bots.size,
+        lastCrawled: data.lastCrawled.toISOString(),
+        botTypes: Array.from(data.botTypes),
       }))
       .sort((a, b) => b.visits - a.visits)
       .slice(0, 20);
@@ -235,7 +253,7 @@ export async function GET(request: NextRequest): Promise<Response> {
     >();
 
     visits.forEach(v => {
-      const dateKey = v.timestamp.toISOString().split('T')[0];
+      const dateKey = v.timestamp.toISOString().split('T')[0] ?? '';
       const existing = timelineMap.get(dateKey) || {
         count: 0,
         searchEngine: 0,

--- a/apps/psypnos/app/api/analytics/bots/track/route.ts
+++ b/apps/psypnos/app/api/analytics/bots/track/route.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - BotVisit model not available in Kairn schema
 /**
  * Bot Tracking API
  *
@@ -10,15 +7,15 @@
  * @endpoint POST /api/analytics/bots/track
  */
 
-import { NextRequest } from "next/server";
-import { z } from "zod";
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 // Validation schema
 const BotVisitSchema = z.object({
   botName: z.string().min(1),
-  botType: z.enum(["search_engine", "social", "seo_tool", "monitor", "other"]),
+  botType: z.enum(['search_engine', 'social', 'seo_tool', 'monitor', 'other']),
   userAgent: z.string().optional(),
   page: z.string().min(1),
   referrer: z.string().optional().nullable(),
@@ -29,25 +26,25 @@ const BotVisitSchema = z.object({
 
 // Country code to name mapping
 const COUNTRY_NAMES: Record<string, string> = {
-  FR: "France",
-  BE: "Belgique",
-  CH: "Suisse",
-  CA: "Canada",
-  US: "United States",
-  GB: "United Kingdom",
-  DE: "Germany",
-  ES: "Spain",
-  IT: "Italy",
-  PT: "Portugal",
-  NL: "Netherlands",
-  LU: "Luxembourg",
+  FR: 'France',
+  BE: 'Belgique',
+  CH: 'Suisse',
+  CA: 'Canada',
+  US: 'United States',
+  GB: 'United Kingdom',
+  DE: 'Germany',
+  ES: 'Spain',
+  IT: 'Italy',
+  PT: 'Portugal',
+  NL: 'Netherlands',
+  LU: 'Luxembourg',
 };
 
 export async function POST(request: NextRequest) {
   // Only accept internal requests
-  const isInternal = request.headers.get("X-Internal-Request") === "true";
+  const isInternal = request.headers.get('X-Internal-Request') === 'true';
   if (!isInternal) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
@@ -56,7 +53,7 @@ export async function POST(request: NextRequest) {
 
     if (!validationResult.success) {
       return Response.json(
-        { error: "Invalid payload", details: validationResult.error.flatten() },
+        { error: 'Invalid payload', details: validationResult.error.flatten() },
         { status: 400 }
       );
     }
@@ -64,7 +61,7 @@ export async function POST(request: NextRequest) {
     const data = validationResult.data;
 
     // Import Prisma dynamically
-    const { prisma } = await import("@/lib/db/prisma");
+    const { prisma } = await import('@/lib/db/prisma');
 
     // Determine country code and name
     let countryCode: string | undefined;
@@ -101,9 +98,9 @@ export async function POST(request: NextRequest) {
 
     return Response.json({ success: true });
   } catch (error) {
-    console.error("[Bot Track API] Error:", error);
+    console.error('[Bot Track API] Error:', error);
     return Response.json(
-      { error: error instanceof Error ? error.message : "Internal server error" },
+      { error: error instanceof Error ? error.message : 'Internal server error' },
       { status: 500 }
     );
   }

--- a/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
@@ -152,6 +152,10 @@ export async function GET(request: NextRequest) {
       engagementRateChange: comparison.engagementRateChange,
       totalFollowers: platforms.reduce((sum, p) => sum + p.followers, 0),
       followersChange: platforms.reduce((sum, p) => sum + p.followersChange, 0),
+      totalLikes: stats.totalLikes,
+      totalComments: stats.totalComments,
+      totalShares: stats.totalShares,
+      totalSaves: stats.totalSaves,
       platforms,
       topPosts: formattedTopPosts,
       postTypes: postTypes.map(pt => ({

--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -101,7 +101,7 @@ interface BotVisit {
 
 interface BotType {
   name: string;
-  type: 'search_engine' | 'social' | 'seo_tool' | 'monitoring' | 'other';
+  type: 'search_engine' | 'social' | 'seo_tool' | 'monitor' | 'other';
   visits: number;
   lastSeen: string;
   pages: number;
@@ -174,7 +174,7 @@ interface BlogPanelData {
 // Posts Panel Types (Social Media)
 interface SocialPost {
   id: string;
-  platform: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'tiktok';
+  platform: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'threads';
   type: 'image' | 'video' | 'carousel' | 'story' | 'reel' | 'text';
   content: string;
   publishedAt: string;
@@ -189,7 +189,7 @@ interface SocialPost {
 
 interface PlatformStats {
   platform: string;
-  icon: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'tiktok';
+  icon: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'threads';
   followers: number;
   followersChange: number;
   posts: number;
@@ -230,6 +230,10 @@ interface PostsPanelData {
   engagementRateChange: number;
   totalFollowers: number;
   followersChange: number;
+  totalLikes: number;
+  totalComments: number;
+  totalShares: number;
+  totalSaves: number;
   platforms: PlatformStats[];
   topPosts: SocialPost[];
   postTypes: PostTypeStats[];
@@ -480,7 +484,7 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
       const blogFaqData = dashboardData.blogFaqData || { summary: {}, clicks: [] };
 
       const botsData =
-        botsRes && botsRes.ok ? await botsRes.json() : { bots: [], timeline: [], pages: [] };
+        botsRes && botsRes.ok ? await botsRes.json() : { byBot: [], timeline: [], byPage: [] };
 
       // Social media posts data — null if API fails (graceful degradation)
       const postsData: PostsPanelData | null =
@@ -509,11 +513,21 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
       trafficSources.forEach((source: any) => {
         const medium = source.medium?.toLowerCase() || '';
         const sourceName = source.source?.toLowerCase() || '';
-        if (medium === 'direct' || medium === '(none)' || medium === 'none' || (medium === '' && sourceName === 'direct')) {
+        if (
+          medium === 'direct' ||
+          medium === '(none)' ||
+          medium === 'none' ||
+          (medium === '' && sourceName === 'direct')
+        ) {
           directTraffic += source.visits || 0;
         } else if (medium === 'organic') {
           organicTraffic += source.visits || 0;
-        } else if (medium === 'referral' || medium === 'email' || medium === 'cpc' || medium === 'cpm') {
+        } else if (
+          medium === 'referral' ||
+          medium === 'email' ||
+          medium === 'cpc' ||
+          medium === 'cpm'
+        ) {
           referralTraffic += source.visits || 0;
         } else if (medium === 'social') {
           socialTraffic += source.visits || 0;
@@ -654,11 +668,11 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
       }));
 
       // Build bot data
-      const botTypes: BotType[] = (botsData.bots || []).map((bot: any) => ({
+      const botTypes: BotType[] = (botsData.byBot || []).map((bot: any) => ({
         name: bot.name || 'Unknown',
         type: bot.type || 'other',
-        visits: bot.visits || 0,
-        lastSeen: bot.lastSeen || new Date().toISOString(),
+        visits: bot.count || 0,
+        lastSeen: bot.lastVisit || new Date().toISOString(),
         pages: bot.pages || 0,
       }));
 
@@ -679,9 +693,9 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
         };
       });
 
-      const crawledPages: CrawledPage[] = (botsData.pages || []).map((p: any) => ({
-        path: p.path || '',
-        crawlCount: p.crawlCount || 0,
+      const crawledPages: CrawledPage[] = (botsData.byPage || []).map((p: any) => ({
+        path: p.page || '',
+        crawlCount: p.visits || 0,
         lastCrawled: p.lastCrawled || new Date().toISOString(),
         botTypes: p.botTypes || [],
       }));
@@ -806,9 +820,10 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
         organicTraffic,
         referralTraffic,
         socialTraffic,
-        totalBotVisits: botTypes.reduce((sum, b) => sum + b.visits, 0),
-        uniqueBots: botTypes.length,
-        crawledPages: crawledPages.length,
+        totalBotVisits:
+          botsData.summary?.totalVisits ?? botTypes.reduce((sum, b) => sum + b.visits, 0),
+        uniqueBots: botsData.summary?.uniqueBots ?? botTypes.length,
+        crawledPages: botsData.summary?.uniquePages ?? crawledPages.length,
         avgCrawlRate:
           botTimeline.length > 0
             ? botTimeline.reduce((sum, t) => sum + t.visits, 0) / botTimeline.length

--- a/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
+++ b/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
@@ -36,7 +36,7 @@ import {
 // Types
 export interface SocialPost {
   id: string;
-  platform: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'tiktok';
+  platform: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'threads';
   type: 'image' | 'video' | 'carousel' | 'story' | 'reel' | 'text';
   content: string;
   publishedAt: string;
@@ -52,7 +52,7 @@ export interface SocialPost {
 
 export interface PlatformStats {
   platform: string;
-  icon: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'tiktok';
+  icon: 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'threads';
   followers: number;
   followersChange: number;
   posts: number;
@@ -93,6 +93,10 @@ export interface PostsPanelData {
   engagementRateChange: number;
   totalFollowers: number;
   followersChange: number;
+  totalLikes: number;
+  totalComments: number;
+  totalShares: number;
+  totalSaves: number;
   platforms: PlatformStats[];
   topPosts: SocialPost[];
   postTypes: PostTypeStats[];
@@ -144,7 +148,7 @@ const PlatformIcon = ({
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
         </svg>
       );
-    case 'tiktok':
+    case 'threads':
       return (
         <svg
           viewBox="0 0 24 24"
@@ -153,7 +157,7 @@ const PlatformIcon = ({
           className={className}
           fill="currentColor"
         >
-          <path d="M19.59 6.69a4.83 4.83 0 01-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 01-5.2 1.74 2.89 2.89 0 012.31-4.64 2.93 2.93 0 01.88.13V9.4a6.84 6.84 0 00-1-.05A6.33 6.33 0 005 20.1a6.34 6.34 0 0010.86-4.43v-7a8.16 8.16 0 004.77 1.52v-3.4a4.85 4.85 0 01-1-.1z" />
+          <path d="M12.186 24h-.007c-3.581-.024-6.334-1.205-8.184-3.509C2.35 18.44 1.5 15.586 1.472 12.01v-.017C1.5 8.418 2.35 5.564 3.995 3.516 5.845 1.205 8.598.024 12.179 0h.014c2.746.02 5.043.725 6.826 2.098 1.677 1.29 2.858 3.13 3.509 5.467l-2.04.569c-1.104-3.96-3.898-5.984-8.304-6.015-2.91.022-5.11.936-6.54 2.717C4.307 6.504 3.616 8.914 3.589 12c.027 3.086.718 5.496 2.057 7.164 1.43 1.783 3.631 2.698 6.54 2.717 2.623-.02 4.358-.631 5.8-2.045 1.647-1.613 1.618-3.593 1.09-4.798-.31-.71-.873-1.3-1.634-1.75-.192 1.352-.622 2.446-1.284 3.272-.886 1.102-2.14 1.704-3.73 1.79-1.202.065-2.361-.218-3.259-.801-1.063-.689-1.685-1.74-1.752-2.96-.065-1.187.408-2.26 1.33-3.017.88-.724 2.107-1.127 3.461-1.137.96-.007 1.83.137 2.594.432 0-.497-.016-.949-.048-1.357h2.044c.105 1.028.105 2.201.043 3.08.397.202.783.42 1.217.606 1.06.587 1.886 1.416 2.378 2.445.716 1.502.813 4.157-1.248 6.173-1.794 1.755-4.02 2.545-7.205 2.57z" />
         </svg>
       );
     default:
@@ -186,7 +190,7 @@ const platformColors: Record<string, string> = {
   facebook: '#1877F2',
   linkedin: '#0A66C2',
   twitter: '#1DA1F2',
-  tiktok: '#000000',
+  threads: '#000000',
 };
 
 // Custom tooltip for charts
@@ -867,7 +871,7 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
             {[
               {
                 label: "J'aime",
-                value: data?.topPosts?.reduce((sum, p) => sum + p.likes, 0) || 0,
+                value: data?.totalLikes ?? 0,
                 icon: Heart,
                 color: 'text-pink-400',
                 bgColor: 'bg-pink-500/10',
@@ -875,7 +879,7 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
               },
               {
                 label: 'Commentaires',
-                value: data?.topPosts?.reduce((sum, p) => sum + p.comments, 0) || 0,
+                value: data?.totalComments ?? 0,
                 icon: MessageCircle,
                 color: 'text-blue-400',
                 bgColor: 'bg-blue-500/10',
@@ -883,7 +887,7 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
               },
               {
                 label: 'Partages',
-                value: data?.topPosts?.reduce((sum, p) => sum + p.shares, 0) || 0,
+                value: data?.totalShares ?? 0,
                 icon: Repeat2,
                 color: 'text-green-400',
                 bgColor: 'bg-green-500/10',
@@ -891,7 +895,7 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
               },
               {
                 label: 'Enregistrements',
-                value: data?.topPosts?.reduce((sum, p) => sum + (p.saves || 0), 0) || 0,
+                value: data?.totalSaves ?? 0,
                 icon: Calendar,
                 color: 'text-purple-400',
                 bgColor: 'bg-purple-500/10',

--- a/apps/psypnos/components/analytics/v2/panels/SEOPanel.tsx
+++ b/apps/psypnos/components/analytics/v2/panels/SEOPanel.tsx
@@ -19,7 +19,7 @@ interface BotVisit {
 
 interface BotType {
   name: string;
-  type: 'search_engine' | 'social' | 'seo_tool' | 'monitoring' | 'other';
+  type: 'search_engine' | 'social' | 'seo_tool' | 'monitor' | 'other';
   visits: number;
   lastSeen: string;
   pages: number;
@@ -51,7 +51,7 @@ const getBotIcon = (type: BotType['type']) => {
       return <Globe size={16} className="text-blue-400" />;
     case 'seo_tool':
       return <FileSearch size={16} className="text-purple-400" />;
-    case 'monitoring':
+    case 'monitor':
       return <Activity size={16} className="text-yellow-400" />;
     default:
       return <Bot size={16} className="text-ivory/50" />;
@@ -66,7 +66,7 @@ const getBotTypeLabel = (type: BotType['type']) => {
       return 'Réseau social';
     case 'seo_tool':
       return 'Outil SEO';
-    case 'monitoring':
+    case 'monitor':
       return 'Monitoring';
     default:
       return 'Autre';

--- a/apps/psypnos/lib/social/analytics.ts
+++ b/apps/psypnos/lib/social/analytics.ts
@@ -28,6 +28,7 @@ export interface SocialDashboardStats {
   totalLikes: number;
   totalComments: number;
   totalShares: number;
+  totalSaves: number;
   averageEngagementRate: number;
 }
 
@@ -170,6 +171,7 @@ export async function getDashboardStats(
       likes: true,
       comments: true,
       shares: true,
+      saves: true,
     },
     where: {
       post: publishedFilter,
@@ -198,6 +200,7 @@ export async function getDashboardStats(
     totalLikes: analyticsAgg._sum.likes || 0,
     totalComments: analyticsAgg._sum.comments || 0,
     totalShares: analyticsAgg._sum.shares || 0,
+    totalSaves: analyticsAgg._sum.saves || 0,
     averageEngagementRate: totalImpressions > 0 ? (totalEngagements / totalImpressions) * 100 : 0,
   };
 }

--- a/packages/ui/src/components/seo/GeoPage.tsx
+++ b/packages/ui/src/components/seo/GeoPage.tsx
@@ -235,7 +235,7 @@ export function GeoPage({
                 <section
                   className={`border-${border}/10 bg-${background}/30 rounded-2xl border p-6`}
                 >
-                  <h3 className="font-display mb-4 text-xl font-semibold">Why choose us?</h3>
+                  <h3 className="font-display mb-4 text-xl font-semibold">Pourquoi consulter ?</h3>
                   <ul className="grid gap-3 sm:grid-cols-2">
                     {benefits.map((benefit, index) => (
                       <li key={index} className="flex items-start gap-3">


### PR DESCRIPTION
## Résumé

Corrige trois issues liées aux analytics et à la traduction :

### Issue #182 — Tracking des posts
- **Type mismatch plateforme** : remplacement de `tiktok` (absent du schéma Prisma) par `threads` dans les types, icônes et couleurs du `PostsPanel`
- **Données d'engagement incomplètes** : la section « Répartition des interactions » ne comptait que les top 10 posts. Ajout de `totalLikes/totalComments/totalShares/totalSaves` dans l'API et utilisation de ces agrégats dans le composant

### Issue #183 — Tracking des bots
- **Mismatch de noms de champs** : le hook `useAnalytics` utilisait `botsData.bots`/`botsData.pages` alors que l'API retourne `byBot`/`byPage` → données bots toujours vides
- **Propriétés manquantes** : mapping corrigé (`count→visits`, `lastVisit→lastSeen`, `page→path`, `visits→crawlCount`) et enrichissement de l'API avec `pages/bot`, `lastCrawled` et `botTypes` par page
- **Type 'monitoring' vs 'monitor'** : corrigé dans `SEOPanel` pour correspondre à ce que stocke l'API
- **@ts-nocheck obsolète** : retiré des deux routes bots (le modèle `BotVisit` existe bien dans le schéma)
- **KPIs recalculés** : utilisation des données `summary` de l'API au lieu de recalculer depuis les tableaux tronqués (top 20)

### Issue #184 — Why choose us?
- Remplacement de « Why choose us? » par « Pourquoi consulter ? » dans `GeoPage.tsx`

Fixes #182, Fixes #183, Fixes #184

## Fichiers modifiés
- `apps/psypnos/app/api/analytics/dashboard/posts/route.ts`
- `apps/psypnos/app/api/analytics/bots/route.ts`
- `apps/psypnos/app/api/analytics/bots/track/route.ts`
- `apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts`
- `apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx`
- `apps/psypnos/components/analytics/v2/panels/SEOPanel.tsx`
- `apps/psypnos/lib/social/analytics.ts`
- `packages/ui/src/components/seo/GeoPage.tsx`

## Test plan
- [x] Lint : 0 erreurs
- [x] Type-check : passé
- [x] Tests : 423 + 97 passés (couverture 89.78%)
- [x] Build : passé
- [ ] Vérifier l'onglet Posts dans /admin/analytics avec des données réelles
- [ ] Vérifier l'onglet SEO (bots) dans /admin/analytics avec des données réelles
- [ ] Vérifier les pages géo (ex: /hypnose-auxerre) pour le texte « Pourquoi consulter ? »

https://claude.ai/code/session_013QJTaHVfxEggPyiJHTr6NU