### PR TITLE
fix(ui): traduire les textes anglais du composant GeoPage en français

### DIFF
--- a/packages/ui/src/components/seo/GeoPage.tsx
+++ b/packages/ui/src/components/seo/GeoPage.tsx
@@ -122,7 +122,7 @@ export function GeoPage({
   className,
   colors = {},
   ctaHref = '/contact',
-  ctaLabel = 'Book Now',
+  ctaLabel = 'Prendre rendez-vous',
   ctaSubtext,
   linkComponent: LinkComp,
 }: GeoPageComponentProps) {
@@ -148,14 +148,14 @@ export function GeoPage({
 
   // Build breadcrumb items for the UI component
   const uiBreadcrumbItems = [
-    { label: 'Home', href: '/' },
+    { label: 'Accueil', href: '/' },
     ...breadcrumbItems.map(item => ({ label: item.name, href: item.href })),
     { label: title },
   ];
 
   // Build breadcrumb items for structured data
   const structuredDataItems = [
-    { name: 'Home', url: baseUrl },
+    { name: 'Accueil', url: baseUrl },
     ...breadcrumbItems.map(item => ({ name: item.name, url: `${baseUrl}${item.href}` })),
     { name: title, url: `${baseUrl}${breadcrumbItems[breadcrumbItems.length - 1]?.href || '/'}` },
   ];
@@ -219,7 +219,7 @@ export function GeoPage({
               {/* Main section */}
               <section>
                 <h2 className={`font-display text-${primary} mb-6 text-2xl font-bold`}>
-                  {service.label} in {location.city}
+                  {service.label} à {location.city}
                 </h2>
 
                 <div className="prose prose-invert max-w-none">
@@ -253,7 +253,7 @@ export function GeoPage({
               {testimonials.length > 0 && (
                 <section>
                   <h3 className={`font-display text-${primary} mb-6 text-xl font-semibold`}>
-                    Testimonials from {location.city}
+                    Témoignages de {location.city}
                   </h3>
 
                   <div className="grid gap-6 md:grid-cols-2">
@@ -282,7 +282,7 @@ export function GeoPage({
               {/* Google Maps */}
               {mapsEmbedUrl && (
                 <section>
-                  <h3 className="font-display mb-4 text-xl font-semibold">Location</h3>
+                  <h3 className="font-display mb-4 text-xl font-semibold">Localisation</h3>
                   <div className="overflow-hidden rounded-xl">
                     <div className={`bg-${background}/50 aspect-video w-full`}>
                       <iframe
@@ -293,7 +293,7 @@ export function GeoPage({
                         allowFullScreen
                         loading="lazy"
                         referrerPolicy="no-referrer-when-downgrade"
-                        title={`Location for ${service.label} near ${location.city}`}
+                        title={`Localisation pour ${service.label} près de ${location.city}`}
                         className="h-full w-full"
                       />
                     </div>
@@ -322,7 +322,7 @@ export function GeoPage({
 
               {/* Practical information */}
               <div className={`border-${border}/10 bg-${background}/30 rounded-2xl border p-6`}>
-                <h3 className="font-display mb-4 text-lg font-semibold">Practical Information</h3>
+                <h3 className="font-display mb-4 text-lg font-semibold">Informations pratiques</h3>
 
                 <div className="space-y-4">
                   {/* Distance from city */}
@@ -331,7 +331,7 @@ export function GeoPage({
                       <CarIcon />
                     </span>
                     <div>
-                      <p className="font-medium">From {location.city}</p>
+                      <p className="font-medium">Depuis {location.city}</p>
                       <p className={`text-${text}/60 text-sm`}>
                         {practicalInfo.distance} &bull; {practicalInfo.duration}
                       </p>
@@ -344,7 +344,7 @@ export function GeoPage({
                       <MapPinIcon />
                     </span>
                     <div>
-                      <p className="font-medium">Address</p>
+                      <p className="font-medium">Adresse</p>
                       <p className={`text-${text}/60 text-sm`}>
                         {contactInfo.address}
                         {contactInfo.addressLine2 && <br />}
@@ -362,7 +362,7 @@ export function GeoPage({
                         <ClockIcon />
                       </span>
                       <div>
-                        <p className="font-medium">Hours</p>
+                        <p className="font-medium">Horaires</p>
                         <div className={`text-${text}/60 text-sm`}>
                           {contactInfo.hours.map((schedule, index) => (
                             <p key={index}>
@@ -384,7 +384,7 @@ export function GeoPage({
               {/* Pricing */}
               {pricing.length > 0 && (
                 <div className={`border-${border}/10 bg-${background}/30 rounded-2xl border p-6`}>
-                  <h3 className="font-display mb-4 text-lg font-semibold">Pricing</h3>
+                  <h3 className="font-display mb-4 text-lg font-semibold">Tarifs</h3>
                   <div className="space-y-3">
                     {pricing.map((tier, index) => (
                       <div key={index} className="flex items-baseline justify-between">
@@ -404,7 +404,7 @@ export function GeoPage({
               {/* Related links */}
               {relatedLinks.length > 0 && (
                 <div className={`border-${border}/10 bg-${background}/30 rounded-2xl border p-6`}>
-                  <h3 className="font-display mb-4 text-lg font-semibold">See Also</h3>
+                  <h3 className="font-display mb-4 text-lg font-semibold">Voir aussi</h3>
                   <ul className="space-y-2">
                     <li>
                       <Link
@@ -412,7 +412,7 @@ export function GeoPage({
                         className={`text-${text}/70 hover:text-${primary} flex items-center gap-2 text-sm transition-colors`}
                       >
                         <span className={`bg-${primary}/20 h-1.5 w-1.5 rounded-full`} />
-                        Learn more about {service.label.toLowerCase()}
+                        En savoir plus sur {service.label.toLowerCase()}
                       </Link>
                     </li>
                     {relatedLinks.map((link, index) => (

--- a/packages/ui/src/components/seo/__tests__/GeoPage.test.tsx
+++ b/packages/ui/src/components/seo/__tests__/GeoPage.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests du composant GeoPage
+ *
+ * Vérifie que tous les libellés sont bien en français.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { GeoPage } from '../GeoPage';
+import type { GeoPageProps } from '../types';
+
+/** Props minimales pour rendre le composant */
+function createDefaultProps(
+  overrides: Partial<GeoPageProps> = {}
+): GeoPageProps & { linkComponent?: undefined } {
+  return {
+    title: 'Psychothérapie à Auxerre',
+    subtitle: 'Séances de psychothérapie près de chez vous',
+    description: 'Trouvez un psychothérapeute qualifié.',
+    service: {
+      type: 'psychotherapie',
+      label: 'Psychothérapie',
+      href: '/psychotherapie',
+    },
+    location: { city: 'Auxerre', department: '89', region: 'Bourgogne' },
+    breadcrumbItems: [{ name: 'Psychothérapie', href: '/psychotherapie' }],
+    baseUrl: 'https://example.fr',
+    mainContent: '<p>Contenu principal</p>',
+    benefits: ['Réduction du stress', 'Meilleur sommeil'],
+    practicalInfo: {
+      distance: '30 km',
+      duration: '25 min',
+      directions: 'Prendre la N6 direction Sens.',
+    },
+    contactInfo: {
+      address: '1 rue du Test',
+      city: 'Saint-Julien-du-Sault',
+      postalCode: '89330',
+      hours: [
+        { days: 'Lun-Ven', hours: '9h-19h' },
+        { days: 'Sam', hours: '9h-17h' },
+      ],
+    },
+    pricing: [{ label: 'Séance standard', price: '70 €' }],
+    relatedLinks: [{ label: 'Hypnose à Auxerre', href: '/hypnose-auxerre' }],
+    mapsEmbedUrl: 'https://www.google.com/maps/embed?pb=test',
+    ...overrides,
+  };
+}
+
+describe('GeoPage — libellés en français', () => {
+  it('affiche "Localisation" comme titre de la section carte', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByRole('heading', { name: 'Localisation' })).toBeInTheDocument();
+  });
+
+  it('affiche "Informations pratiques"', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByRole('heading', { name: 'Informations pratiques' })).toBeInTheDocument();
+  });
+
+  it('affiche "Adresse"', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByText('Adresse')).toBeInTheDocument();
+  });
+
+  it('affiche "Horaires"', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByText('Horaires')).toBeInTheDocument();
+  });
+
+  it('affiche "Tarifs"', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByRole('heading', { name: 'Tarifs' })).toBeInTheDocument();
+  });
+
+  it('affiche "Voir aussi"', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByRole('heading', { name: 'Voir aussi' })).toBeInTheDocument();
+  });
+
+  it('affiche "Depuis {ville}" dans les informations pratiques', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByText('Depuis Auxerre')).toBeInTheDocument();
+  });
+
+  it('affiche "{service} à {ville}" comme titre de section h2', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    const h2 = screen.getByRole('heading', {
+      name: 'Psychothérapie à Auxerre',
+      level: 2,
+    });
+    expect(h2).toBeInTheDocument();
+  });
+
+  it('affiche "En savoir plus sur" dans les liens connexes', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByText(/en savoir plus sur psychothérapie/i)).toBeInTheDocument();
+  });
+
+  it('affiche "Accueil" dans le breadcrumb', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByText('Accueil')).toBeInTheDocument();
+  });
+
+  it('utilise "Prendre rendez-vous" comme CTA par défaut', () => {
+    render(<GeoPage {...createDefaultProps()} />);
+
+    expect(screen.getByRole('heading', { name: 'Prendre rendez-vous' })).toBeInTheDocument();
+  });
+
+  it('affiche "Témoignages de {ville}" quand des témoignages sont fournis', () => {
+    render(
+      <GeoPage
+        {...createDefaultProps({
+          testimonials: [
+            {
+              content: 'Très bonne expérience.',
+              author: 'Marie D.',
+              location: 'Auxerre',
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Témoignages de Auxerre' })).toBeInTheDocument();
+  });
+
+  it("n'affiche aucun texte anglais résiduel parmi les libellés traduits", () => {
+    render(
+      <GeoPage
+        {...createDefaultProps({
+          testimonials: [
+            {
+              content: 'Super.',
+              author: 'Jean P.',
+              location: 'Auxerre',
+            },
+          ],
+        })}
+      />
+    );
+
+    const englishLabels = [
+      'Location',
+      'Practical Information',
+      'Address',
+      'Hours',
+      'Pricing',
+      'See Also',
+      'Testimonials from',
+      'Learn more about',
+      'Book Now',
+    ];
+
+    for (const label of englishLabels) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
## Résumé

- Traduit les 14 chaînes anglaises codées en dur dans le composant partagé `GeoPage` (`@kairn/ui`)
- Ajoute 13 tests unitaires vérifiant que tous les libellés sont bien en français
- Aucun texte anglais résiduel dans les pages `/psychotherapie-*` et `/hypnose-*`

### Traductions effectuées
| Anglais | Français |
|---------|----------|
| Location | Localisation |
| Practical Information | Informations pratiques |
| Address | Adresse |
| Hours | Horaires |
| Pricing | Tarifs |
| See Also | Voir aussi |
| Home | Accueil |
| Testimonials from | Témoignages de |
| Learn more about | En savoir plus sur |
| From | Depuis |
| in | à |
| Book Now | Prendre rendez-vous |

Fixes #186

## Plan de test
- [x] 13 tests unitaires (vitest) vérifiant chaque libellé traduit
- [x] Test négatif : aucun texte anglais résiduel
- [x] Lint passé
- [x] Type-check passé
- [x] Build complet passé

https://claude.ai/code/session_01BCTHG5y8Q9cxws8bETuRjD