### PR TITLE
fix(analytics): afficher visiteurs au lieu de visites dans Toutes les sources

### DIFF
--- a/apps/psypnos/components/analytics/v2/panels/SourcesPanel.tsx
+++ b/apps/psypnos/components/analytics/v2/panels/SourcesPanel.tsx
@@ -297,10 +297,7 @@ export function SourcesPanel({
                     Medium
                   </th>
                   <th className="text-right py-2 sm:py-3 px-2 sm:px-4 text-[10px] sm:text-xs font-medium text-ivory/50 uppercase tracking-wider">
-                    Visites
-                  </th>
-                  <th className="text-right py-2 sm:py-3 px-2 sm:px-4 text-[10px] sm:text-xs font-medium text-ivory/50 uppercase tracking-wider hidden md:table-cell">
-                    Sessions
+                    Visiteurs
                   </th>
                   <th className="text-right py-2 sm:py-3 px-2 sm:px-4 text-[10px] sm:text-xs font-medium text-ivory/50 uppercase tracking-wider">
                     Conv.
@@ -334,11 +331,6 @@ export function SourcesPanel({
                     </td>
                     <td className="py-2 sm:py-3 px-2 sm:px-4 text-right">
                       <span className="text-xs sm:text-sm text-ivory">
-                        {source.visits.toLocaleString("fr-FR")}
-                      </span>
-                    </td>
-                    <td className="py-2 sm:py-3 px-2 sm:px-4 text-right hidden md:table-cell">
-                      <span className="text-xs sm:text-sm text-ivory/60">
                         {source.uniqueSessions.toLocaleString("fr-FR")}
                       </span>
                     </td>


### PR DESCRIPTION
Remplace la colonne « Visites » (COUNT page views) par « Visiteurs »
(COUNT DISTINCT sessionId) dans le tableau « Toutes les sources » de
l'onglet Sources de /admin/analytics.

Fixes #187

https://claude.ai/code/session_01YU2MuA9Kiwj1p7xrGqGYoA