### PR TITLE
fix(social): corriger le stockage des analytics des posts sociaux

### DIFF
--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -462,7 +462,10 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
       const [dashboardRes, botsRes, postsRes] = await Promise.all([
         fetch(`/api/analytics/dashboard?${params}`, { cache: 'no-store' }),
         fetch(`/api/analytics/bots?${params}`).catch(() => null),
-        fetch(`/api/analytics/dashboard/posts?${params}`).catch(() => null),
+        fetch(`/api/analytics/dashboard/posts?${params}`).catch(err => {
+          console.error('[Analytics] Erreur réseau récupération posts sociaux:', err);
+          return null;
+        }),
       ]);
 
       if (!dashboardRes.ok) {
@@ -487,6 +490,9 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
         botsRes && botsRes.ok ? await botsRes.json() : { byBot: [], timeline: [], byPage: [] };
 
       // Social media posts data — null if API fails (graceful degradation)
+      if (postsRes && !postsRes.ok) {
+        console.warn(`[Analytics] API posts sociaux: HTTP ${postsRes.status}`);
+      }
       const postsData: PostsPanelData | null =
         postsRes && postsRes.ok ? await postsRes.json() : null;
 

--- a/apps/psypnos/lib/social/clients/index.ts
+++ b/apps/psypnos/lib/social/clients/index.ts
@@ -40,16 +40,15 @@ export interface GetAnalyticsInput {
 
 export interface AnalyticsResult {
   success: boolean;
-  data?: {
-    impressions?: number;
-    reach?: number;
-    engagements?: number;
-    likes?: number;
-    comments?: number;
-    shares?: number;
-    saves?: number;
-    clicks?: number;
-  };
+  impressions?: number;
+  reach?: number;
+  engagements?: number;
+  likes?: number;
+  comments?: number;
+  shares?: number;
+  saves?: number;
+  clicks?: number;
+  rawData?: Record<string, unknown>;
   error?: string;
 }
 

--- a/apps/psypnos/lib/social/store.ts
+++ b/apps/psypnos/lib/social/store.ts
@@ -518,7 +518,7 @@ export async function updatePostAnalytics(
   const updateData = {
     ...rest,
     rawData: rawData ? (rawData as PrismaJsonValue) : undefined,
-    fetchedAt: new Date(),
+    lastSyncAt: new Date(),
   };
 
   const analytics = await prisma.socialPostAnalytics.upsert({
@@ -783,7 +783,7 @@ function mapAnalytics(analytics: Record<string, unknown>): SocialPostAnalytics {
     saves: analytics.saves as number,
     clicks: analytics.clicks as number,
     rawData: analytics.rawData as Record<string, unknown> | null,
-    fetchedAt: analytics.fetchedAt as Date,
+    lastSyncAt: analytics.lastSyncAt as Date,
     updatedAt: analytics.updatedAt as Date,
   };
 }

--- a/apps/psypnos/lib/social/types.ts
+++ b/apps/psypnos/lib/social/types.ts
@@ -414,7 +414,7 @@ export interface SocialPostAnalytics {
   saves: number;
   clicks: number;
   rawData: Record<string, unknown> | null;
-  fetchedAt: Date;
+  lastSyncAt: Date;
   updatedAt: Date;
 }
 

--- a/packages/social/src/types.ts
+++ b/packages/social/src/types.ts
@@ -237,7 +237,7 @@ export interface SocialPostAnalytics {
   saves: number;
   clicks: number;
   rawData: Record<string, unknown> | null;
-  fetchedAt: Date;
+  lastSyncAt: Date;
   updatedAt: Date;
 }
 


### PR DESCRIPTION
## Résumé

- Corrige le champ `fetchedAt` (inexistant dans le modèle Prisma) → `lastSyncAt` dans `store.ts`, `types.ts` et `packages/social/src/types.ts`
- Aligne l'interface `AnalyticsResult` dans `clients/index.ts` (métriques au top-level au lieu d'être encapsulées dans `data`)
- Ajoute des logs d'erreur explicites dans `useAnalytics` pour le fetch posts sociaux

## Cause racine

Le champ `fetchedAt` utilisé dans `updatePostAnalytics()` n'existe pas dans le modèle Prisma `SocialPostAnalytics` (le champ correct est `lastSyncAt`). Prisma lève une `PrismaClientValidationError` à chaque appel, empêchant tout stockage de métriques d'interactions sociales.

## Test plan

- [ ] Vérifier que le cron `fetch-social-analytics` stocke correctement les métriques
- [ ] Vérifier que l'onglet Posts de /admin/analytics affiche les données
- [ ] Vérifier qu'aucune régression n'apparaît sur les autres onglets analytics

Fixes #189

https://claude.ai/code/session_01V7HMyT6t4oETT28QPrtD5i