### PR TITLE
fix(analytics): ajouter logging structuré multi-couches pour diagnostic onglet Posts

### DIFF
--- a/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
@@ -34,8 +34,19 @@ const PLATFORM_CONFIG: Record<string, { name: string; icon: string; color: strin
 };
 
 export async function GET(request: NextRequest) {
+  console.log('[PostsPanel:Debug][API] ══════════════════════════════════════');
+  console.log('[PostsPanel:Debug][API] Début traitement GET /api/analytics/dashboard/posts');
+  console.log('[PostsPanel:Debug][API] URL complète:', request.url);
+
   const authResult = await withAdminAuth();
-  if (authResult.error) return authResult.error;
+  if (authResult.error) {
+    console.error('[PostsPanel:Debug][API] ❌ Auth échouée — retour erreur 401/403');
+    return authResult.error;
+  }
+  console.log(
+    '[PostsPanel:Debug][API] ✅ Auth réussie, user:',
+    authResult.user?.email ?? authResult.user?.sub ?? 'inconnu'
+  );
 
   try {
     const { searchParams } = new URL(request.url);
@@ -43,6 +54,8 @@ export async function GET(request: NextRequest) {
     const startDateStr = searchParams.get('startDate');
     const endDateStr = searchParams.get('endDate');
     const days = searchParams.get('days');
+
+    console.log('[PostsPanel:Debug][API] Params reçus:', { startDateStr, endDateStr, days });
 
     let startDate: Date | undefined;
     let endDate: Date | undefined;
@@ -65,6 +78,14 @@ export async function GET(request: NextRequest) {
       endDate = new Date();
       startDate = new Date(endDate.getTime() - 30 * 24 * 60 * 60 * 1000);
     }
+
+    console.log('[PostsPanel:Debug][API] Dates finales:', {
+      startDate: startDate?.toISOString(),
+      endDate: endDate?.toISOString(),
+    });
+
+    console.log('[PostsPanel:Debug][API] Lancement des 9 requêtes service en parallèle...');
+    const fetchStart = Date.now();
 
     // Fetch all data in parallel
     const [
@@ -95,6 +116,23 @@ export async function GET(request: NextRequest) {
       getTotalFollowersByPlatform(),
       getHashtagPerformance(startDate, endDate, 20),
     ]);
+
+    console.log(`[PostsPanel:Debug][API] 9 requêtes terminées en ${Date.now() - fetchStart}ms`);
+    console.log('[PostsPanel:Debug][API] Résumé des résultats:', {
+      'stats.publishedPosts': stats.publishedPosts,
+      'stats.totalPosts': stats.totalPosts,
+      'stats.totalImpressions': stats.totalImpressions,
+      'stats.totalEngagements': stats.totalEngagements,
+      'stats.totalReach': stats.totalReach,
+      'platformStats.length': platformStats.length,
+      'topPosts.length': topPosts.length,
+      'trendData.length': trendData.length,
+      comparison,
+      'bestTimes.length': bestTimes.length,
+      'postTypes.length': postTypes.length,
+      'followersByPlatform.size': followersByPlatform.size,
+      'hashtagPerformance.length': hashtagPerformance.length,
+    });
 
     // Format platform stats for PostsPanel
     const platforms = platformStats.map(p => {
@@ -179,9 +217,26 @@ export async function GET(request: NextRequest) {
       })),
     };
 
+    console.log('[PostsPanel:Debug][API] Réponse finale construite:', {
+      totalPosts: response.totalPosts,
+      totalReach: response.totalReach,
+      totalEngagement: response.totalEngagement,
+      avgEngagementRate: response.avgEngagementRate,
+      totalFollowers: response.totalFollowers,
+      'platforms.length': response.platforms.length,
+      'topPosts.length': response.topPosts.length,
+      'postTypes.length': response.postTypes.length,
+      'engagementTrends.length': response.engagementTrends.length,
+      'bestPostingTimes.length': response.bestPostingTimes.length,
+    });
+    console.log('[PostsPanel:Debug][API] ✅ Retour HTTP 200');
+    console.log('[PostsPanel:Debug][API] ══════════════════════════════════════');
+
     return NextResponse.json(response);
   } catch (error) {
-    console.error('[Dashboard Posts API] Error:', error);
+    console.error('[PostsPanel:Debug][API] ❌ ERREUR CATCH GLOBAL:', error);
+    console.error('[PostsPanel:Debug][API] Stack:', error instanceof Error ? error.stack : 'N/A');
+    console.error('[PostsPanel:Debug][API] ══════════════════════════════════════');
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Erreur interne' },
       { status: 500 }

--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -459,14 +459,31 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
       // Geo, goals, alerts, blog analytics, CTA clicks, FAQ clicks are all
       // included in the dashboard response. Only bots (requires admin auth)
       // is fetched separately.
+      const postsUrl = `/api/analytics/dashboard/posts?${params}`;
+      console.log('[PostsPanel:Debug][Client] ══════════════════════════════════════');
+      console.log('[PostsPanel:Debug][Client] Fetch démarré pour 3 endpoints');
+      console.log('[PostsPanel:Debug][Client] Posts URL:', postsUrl);
+      console.log('[PostsPanel:Debug][Client] Params:', { timeRange, startDate, endDate });
+      const clientFetchStart = Date.now();
+
       const [dashboardRes, botsRes, postsRes] = await Promise.all([
         fetch(`/api/analytics/dashboard?${params}`, { cache: 'no-store' }),
         fetch(`/api/analytics/bots?${params}`).catch(() => null),
-        fetch(`/api/analytics/dashboard/posts?${params}`).catch(err => {
-          console.error('[Analytics] Erreur réseau récupération posts sociaux:', err);
+        fetch(postsUrl).catch(err => {
+          console.error(
+            '[PostsPanel:Debug][Client] ❌ Erreur RÉSEAU fetch posts:',
+            err?.message ?? err
+          );
           return null;
         }),
       ]);
+
+      console.log(`[PostsPanel:Debug][Client] Fetch terminé en ${Date.now() - clientFetchStart}ms`);
+      console.log('[PostsPanel:Debug][Client] Statuts HTTP:', {
+        dashboard: dashboardRes.status,
+        bots: botsRes?.status ?? 'null (erreur réseau)',
+        posts: postsRes?.status ?? 'null (erreur réseau)',
+      });
 
       if (!dashboardRes.ok) {
         throw new Error('Erreur lors de la récupération des données');
@@ -490,11 +507,46 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
         botsRes && botsRes.ok ? await botsRes.json() : { byBot: [], timeline: [], byPage: [] };
 
       // Social media posts data — null if API fails (graceful degradation)
-      if (postsRes && !postsRes.ok) {
-        console.warn(`[Analytics] API posts sociaux: HTTP ${postsRes.status}`);
+      let postsData: PostsPanelData | null = null;
+      if (!postsRes) {
+        console.error('[PostsPanel:Debug][Client] ❌ postsRes est null — fetch réseau échoué');
+      } else if (!postsRes.ok) {
+        let errorBody = '';
+        try {
+          errorBody = await postsRes.text();
+        } catch {
+          errorBody = '(impossible de lire le body)';
+        }
+        console.error(
+          `[PostsPanel:Debug][Client] ❌ API posts: HTTP ${postsRes.status} ${postsRes.statusText}`
+        );
+        console.error('[PostsPanel:Debug][Client] ❌ Body erreur:', errorBody);
+      } else {
+        postsData = await postsRes.json();
+        console.log('[PostsPanel:Debug][Client] ✅ Posts data reçue:', {
+          totalPosts: postsData?.totalPosts,
+          totalReach: postsData?.totalReach,
+          totalEngagement: postsData?.totalEngagement,
+          avgEngagementRate: postsData?.avgEngagementRate,
+          totalFollowers: postsData?.totalFollowers,
+          platformsCount: postsData?.platforms?.length ?? 0,
+          topPostsCount: postsData?.topPosts?.length ?? 0,
+          postTypesCount: postsData?.postTypes?.length ?? 0,
+          engagementTrendsCount: postsData?.engagementTrends?.length ?? 0,
+          bestPostingTimesCount: postsData?.bestPostingTimes?.length ?? 0,
+        });
+        // Vérifier si toutes les données sont à zéro
+        if (
+          postsData &&
+          postsData.totalPosts === 0 &&
+          postsData.totalReach === 0 &&
+          postsData.totalEngagement === 0
+        ) {
+          console.warn(
+            '[PostsPanel:Debug][Client] ⚠️ ATTENTION: toutes les valeurs sont à 0 — vérifier les données en base ou les filtres de dates'
+          );
+        }
       }
-      const postsData: PostsPanelData | null =
-        postsRes && postsRes.ok ? await postsRes.json() : null;
 
       // Insights are NOT loaded here — they are lazy-loaded on demand
       // via fetchInsights() to avoid the 3-15s Claude API call latency
@@ -843,11 +895,17 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
         postsData,
       };
 
+      console.log(
+        '[PostsPanel:Debug][Client] postsData assigné au state:',
+        postsData ? 'objet non-null' : 'NULL'
+      );
+      console.log('[PostsPanel:Debug][Client] ══════════════════════════════════════');
+
       setData(analyticsData);
       setLastUpdated(new Date());
       setError(null);
     } catch (err) {
-      console.error('Error fetching analytics:', err);
+      console.error('[PostsPanel:Debug][Client] ❌ ERREUR CATCH GLOBAL fetchData:', err);
       setError(err instanceof Error ? err.message : 'Erreur inconnue');
     }
   }, [period, customStartDate, customEndDate, isSimulationMode, generateSimulatedData]);

--- a/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
+++ b/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
@@ -223,6 +223,16 @@ const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
 };
 
 export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
+  console.log('[PostsPanel:Debug][Render] PostsPanel rendu avec:', {
+    isLoading,
+    dataIsNull: data === null,
+    totalPosts: data?.totalPosts ?? 'N/A',
+    totalReach: data?.totalReach ?? 'N/A',
+    totalEngagement: data?.totalEngagement ?? 'N/A',
+    platformsCount: data?.platforms?.length ?? 'N/A',
+    topPostsCount: data?.topPosts?.length ?? 'N/A',
+  });
+
   const formatNumber = (num: number): string => {
     if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
     if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;

--- a/apps/psypnos/lib/social/analytics.ts
+++ b/apps/psypnos/lib/social/analytics.ts
@@ -146,10 +146,20 @@ export async function getDashboardStats(
   startDate?: Date,
   endDate?: Date
 ): Promise<SocialDashboardStats> {
+  console.log('[PostsPanel:Debug][getDashboardStats] Appelé avec:', {
+    startDate: startDate?.toISOString() ?? 'undefined',
+    endDate: endDate?.toISOString() ?? 'undefined',
+  });
+
   // Post counts use createdAt (includes drafts/scheduled without publishedAt)
   const createdFilter = buildDateFilter(startDate, endDate, 'createdAt');
   // Analytics aggregate uses publishedAt (only published posts have analytics)
   const publishedFilter = buildDateFilter(startDate, endDate);
+
+  console.log('[PostsPanel:Debug][getDashboardStats] Filtres Prisma:', {
+    createdFilter: JSON.stringify(createdFilter),
+    publishedFilter: JSON.stringify(publishedFilter),
+  });
 
   // Compter les posts par statut
   const postCounts = await prisma.socialPost.groupBy({
@@ -160,6 +170,15 @@ export async function getDashboardStats(
 
   const countByStatus = Object.fromEntries(
     postCounts.map((c: { status: string; _count: { _all: number } }) => [c.status, c._count._all])
+  );
+
+  console.log('[PostsPanel:Debug][getDashboardStats] Posts par statut:', countByStatus);
+
+  // Vérifier aussi le nombre total de posts sans filtre de date
+  const totalPostsNoFilter = await prisma.socialPost.count();
+  console.log(
+    '[PostsPanel:Debug][getDashboardStats] Total posts en base (sans filtre):',
+    totalPostsNoFilter
   );
 
   // Récupérer les analytics agrégés
@@ -178,6 +197,23 @@ export async function getDashboardStats(
     },
   });
 
+  console.log('[PostsPanel:Debug][getDashboardStats] Analytics agrégés:', {
+    impressions: analyticsAgg._sum.impressions,
+    reach: analyticsAgg._sum.reach,
+    engagements: analyticsAgg._sum.engagements,
+    likes: analyticsAgg._sum.likes,
+    comments: analyticsAgg._sum.comments,
+    shares: analyticsAgg._sum.shares,
+    saves: analyticsAgg._sum.saves,
+  });
+
+  // Vérifier aussi le nombre d'analytics en base
+  const totalAnalyticsNoFilter = await prisma.socialPostAnalytics.count();
+  console.log(
+    '[PostsPanel:Debug][getDashboardStats] Total analytics en base (sans filtre):',
+    totalAnalyticsNoFilter
+  );
+
   const totalPosts =
     (countByStatus.PUBLISHED || 0) +
     (countByStatus.SCHEDULED || 0) +
@@ -188,7 +224,7 @@ export async function getDashboardStats(
   const totalImpressions = analyticsAgg._sum.impressions || 0;
   const totalEngagements = analyticsAgg._sum.engagements || 0;
 
-  return {
+  const result = {
     totalPosts,
     publishedPosts,
     scheduledPosts: countByStatus.SCHEDULED || 0,
@@ -203,6 +239,9 @@ export async function getDashboardStats(
     totalSaves: analyticsAgg._sum.saves || 0,
     averageEngagementRate: totalImpressions > 0 ? (totalEngagements / totalImpressions) * 100 : 0,
   };
+
+  console.log('[PostsPanel:Debug][getDashboardStats] Résultat final:', result);
+  return result;
 }
 
 // ===========================================
@@ -218,6 +257,8 @@ export async function getStatsByPlatform(
 ): Promise<PlatformStats[]> {
   const dateFilter = buildDateFilter(startDate, endDate);
 
+  console.log('[PostsPanel:Debug][getStatsByPlatform] Filtre date:', JSON.stringify(dateFilter));
+
   // Récupérer les posts avec leurs analytics groupés par plateforme
   const platformData = await prisma.socialPost.groupBy({
     by: ['platform'],
@@ -227,6 +268,12 @@ export async function getStatsByPlatform(
       status: 'PUBLISHED',
     },
   });
+
+  console.log(
+    '[PostsPanel:Debug][getStatsByPlatform] Plateformes trouvées:',
+    platformData.length,
+    platformData.map(p => `${p.platform}=${p._count}`)
+  );
 
   const results: PlatformStats[] = [];
 
@@ -253,6 +300,13 @@ export async function getStatsByPlatform(
     const impressions = analytics._sum.impressions || 0;
     const engagements = analytics._sum.engagements || 0;
 
+    console.log(`[PostsPanel:Debug][getStatsByPlatform] ${platform.platform}:`, {
+      posts: platform._count,
+      impressions,
+      reach: analytics._sum.reach,
+      engagements,
+    });
+
     results.push({
       platform: platform.platform as SocialPlatform,
       postsCount: platform._count,
@@ -266,6 +320,7 @@ export async function getStatsByPlatform(
     });
   }
 
+  console.log('[PostsPanel:Debug][getStatsByPlatform] Total résultats:', results.length);
   return results;
 }
 
@@ -282,6 +337,13 @@ export async function getTopPerformingPosts(
   endDate?: Date
 ): Promise<PostPerformance[]> {
   const dateFilter = buildDateFilter(startDate, endDate);
+
+  console.log(
+    '[PostsPanel:Debug][getTopPerformingPosts] Filtre:',
+    JSON.stringify(dateFilter),
+    'limit:',
+    limit
+  );
 
   const posts: Array<{
     id: string;
@@ -314,6 +376,14 @@ export async function getTopPerformingPosts(
     },
     take: limit,
   });
+
+  console.log(
+    '[PostsPanel:Debug][getTopPerformingPosts] Posts trouvés:',
+    posts.length,
+    posts.length > 0
+      ? `Premier: id=${posts[0]?.id}, platform=${posts[0]?.platform}, hasAnalytics=${!!posts[0]?.analytics}`
+      : '(aucun)'
+  );
 
   return posts.map((post: (typeof posts)[number]) => {
     const impressions = post.analytics?.impressions || 0;
@@ -355,6 +425,12 @@ export async function getTrendData(
   const end = endDate || new Date();
   const start = startDate || new Date(end.getTime() - days * 24 * 60 * 60 * 1000);
 
+  console.log('[PostsPanel:Debug][getTrendData] Période:', {
+    start: start.toISOString(),
+    end: end.toISOString(),
+    days,
+  });
+
   // Récupérer les posts publiés dans la période
   const posts = await prisma.socialPost.findMany({
     where: {
@@ -371,6 +447,12 @@ export async function getTrendData(
       publishedAt: 'asc',
     },
   });
+
+  console.log(
+    '[PostsPanel:Debug][getTrendData] Posts publiés dans la période:',
+    posts.length,
+    posts.length > 0 ? `(avec analytics: ${posts.filter(p => p.analytics).length})` : ''
+  );
 
   // Grouper par jour
   const dataByDate: Map<string, TrendDataPoint> = new Map();
@@ -410,7 +492,15 @@ export async function getTrendData(
     }
   }
 
-  return Array.from(dataByDate.values());
+  const trendResults = Array.from(dataByDate.values());
+  const nonZeroDays = trendResults.filter(d => d.posts > 0 || d.engagements > 0);
+  console.log(
+    '[PostsPanel:Debug][getTrendData] Jours générés:',
+    trendResults.length,
+    'Jours avec données:',
+    nonZeroDays.length
+  );
+  return trendResults;
 }
 
 // ===========================================
@@ -576,6 +666,19 @@ export async function getComparisonStats(startDate: Date, endDate: Date): Promis
   const prevStart = new Date(startDate.getTime() - durationMs);
   const prevEnd = new Date(startDate.getTime());
 
+  console.log(
+    '[PostsPanel:Debug][getComparisonStats] Période courante:',
+    startDate.toISOString(),
+    '->',
+    endDate.toISOString()
+  );
+  console.log(
+    '[PostsPanel:Debug][getComparisonStats] Période précédente:',
+    prevStart.toISOString(),
+    '->',
+    prevEnd.toISOString()
+  );
+
   const [currentStats, previousStats] = await Promise.all([
     getDashboardStats(startDate, endDate),
     getDashboardStats(prevStart, prevEnd),
@@ -586,12 +689,15 @@ export async function getComparisonStats(startDate: Date, endDate: Date): Promis
     return ((current - previous) / previous) * 100;
   };
 
-  return {
+  const compResult = {
     postsChange: pctChange(currentStats.publishedPosts, previousStats.publishedPosts),
     reachChange: pctChange(currentStats.totalReach, previousStats.totalReach),
     engagementChange: pctChange(currentStats.totalEngagements, previousStats.totalEngagements),
     engagementRateChange: currentStats.averageEngagementRate - previousStats.averageEngagementRate,
   };
+
+  console.log('[PostsPanel:Debug][getComparisonStats] Résultat:', compResult);
+  return compResult;
 }
 
 // ===========================================
@@ -616,6 +722,8 @@ export async function getBestPostingTimes(
 ): Promise<BestPostingTimeData[]> {
   const dateFilter = buildDateFilter(startDate, endDate);
 
+  console.log('[PostsPanel:Debug][getBestPostingTimes] Filtre:', JSON.stringify(dateFilter));
+
   const posts: Array<{
     publishedAt: Date | null;
     analytics: { engagements: number } | null;
@@ -632,6 +740,8 @@ export async function getBestPostingTimes(
       },
     },
   });
+
+  console.log('[PostsPanel:Debug][getBestPostingTimes] Posts trouvés:', posts.length);
 
   // Aggregate engagements by day/hour bucket
   const buckets: Map<string, { total: number; count: number }> = new Map();
@@ -692,6 +802,8 @@ export async function getPostTypeStats(
 ): Promise<PostTypeStatsData[]> {
   const dateFilter = buildDateFilter(startDate, endDate);
 
+  console.log('[PostsPanel:Debug][getPostTypeStats] Filtre:', JSON.stringify(dateFilter));
+
   const posts: Array<{
     platform: string;
     mediaUrls: unknown;
@@ -711,6 +823,8 @@ export async function getPostTypeStats(
       },
     },
   });
+
+  console.log('[PostsPanel:Debug][getPostTypeStats] Posts trouvés:', posts.length);
 
   const typeBuckets: Map<string, { count: number; totalEngRate: number }> = new Map();
 
@@ -741,6 +855,11 @@ export async function getPostTypeStats(
 
   // Sort by count descending
   results.sort((a, b) => b.count - a.count);
+
+  console.log(
+    '[PostsPanel:Debug][getPostTypeStats] Types trouvés:',
+    results.map(r => `${r.type}=${r.count}`)
+  );
   return results;
 }
 
@@ -776,6 +895,13 @@ export async function getHashtagPerformance(
 ): Promise<HashtagPerformance[]> {
   const dateFilter = buildDateFilter(startDate, endDate);
 
+  console.log(
+    '[PostsPanel:Debug][getHashtagPerformance] Filtre:',
+    JSON.stringify(dateFilter),
+    'limit:',
+    limit
+  );
+
   const posts: Array<{
     content: string;
     analytics: {
@@ -795,6 +921,8 @@ export async function getHashtagPerformance(
       },
     },
   });
+
+  console.log('[PostsPanel:Debug][getHashtagPerformance] Posts trouvés:', posts.length);
 
   const hashtagBuckets: Map<
     string,
@@ -844,7 +972,14 @@ export async function getHashtagPerformance(
     return rateCompare;
   });
 
-  return results.slice(0, limit);
+  const finalResults = results.slice(0, limit);
+  console.log(
+    '[PostsPanel:Debug][getHashtagPerformance] Hashtags uniques trouvés:',
+    results.length,
+    'Retournés (limit):',
+    finalResults.length
+  );
+  return finalResults;
 }
 
 // ===========================================

--- a/apps/psypnos/lib/social/snapshots.ts
+++ b/apps/psypnos/lib/social/snapshots.ts
@@ -283,7 +283,15 @@ export async function getFollowerGrowth(startDate: Date, endDate: Date): Promise
 export async function getTotalFollowersByPlatform(): Promise<
   Map<string, { followers: number; change: number }>
 > {
+  console.log('[PostsPanel:Debug][getTotalFollowersByPlatform] Appelé');
+
   const latestSnapshots = await getLatestSnapshots();
+
+  console.log(
+    '[PostsPanel:Debug][getTotalFollowersByPlatform] Snapshots récents:',
+    latestSnapshots.length,
+    latestSnapshots.map(s => `${s.platform}=${s.followers}`)
+  );
 
   // Get snapshots from 7 days ago for comparison
   const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
@@ -318,6 +326,13 @@ export async function getTotalFollowersByPlatform(): Promise<
 
     result.set(platform, { followers: currentFollowers, change });
   }
+
+  console.log(
+    '[PostsPanel:Debug][getTotalFollowersByPlatform] Résultat Map:',
+    [...result.entries()].map(
+      ([k, v]) => `${k}: followers=${v.followers}, change=${v.change.toFixed(1)}%`
+    )
+  );
 
   return result;
 }


### PR DESCRIPTION
Ajout de logs [PostsPanel:Debug] sur 3 couches pour identifier la cause
du problème d'affichage vide dans l'onglet Posts de /admin/analytics :

- Service (analytics.ts, snapshots.ts) : filtres Prisma, comptage records,
  vérification DB sans filtre, résultats de chaque fonction
- API Route (posts/route.ts) : params reçus, auth, durée des 9 requêtes
  parallèles, résumé des résultats, réponse finale
- Client (useAnalytics.ts, PostsPanel.tsx) : URL fetch, status HTTP,
  body d'erreur, contenu parsé, détection valeurs toutes à 0

Fixes #193

https://claude.ai/code/session_01PUsjLKabvGF2zM4FLr3bdb