### PR TITLE
fix(analytics): corriger dashboard Posts vide (filtre dates + spread overwrite)

### DIFF
--- a/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/posts/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { withAdminAuth } from '@/app/api/auth/middleware';
+import { prisma } from '@/lib/db/prisma';
 import {
   getDashboardStats,
   getStatsByPlatform,
@@ -83,6 +84,37 @@ export async function GET(request: NextRequest) {
       startDate: startDate?.toISOString(),
       endDate: endDate?.toISOString(),
     });
+
+    // ── Fallback: si aucun post publié dans la période, élargir aux données existantes ──
+    let dateRangeExpanded = false;
+    if (startDate && endDate) {
+      const postsInPeriod = await prisma.socialPost.count({
+        where: {
+          status: 'PUBLISHED',
+          publishedAt: { gte: startDate, lte: endDate },
+        },
+      });
+
+      if (postsInPeriod === 0) {
+        const dateRange = await prisma.socialPost.aggregate({
+          _min: { publishedAt: true },
+          _max: { publishedAt: true },
+          where: { status: 'PUBLISHED', publishedAt: { not: null } },
+        });
+
+        if (dateRange._min.publishedAt && dateRange._max.publishedAt) {
+          console.log(
+            '[PostsPanel:Debug][API] ⚠️ Aucun post dans la période sélectionnée. Fallback sur la plage réelle:',
+            dateRange._min.publishedAt.toISOString(),
+            '→',
+            dateRange._max.publishedAt.toISOString()
+          );
+          startDate = dateRange._min.publishedAt;
+          endDate = dateRange._max.publishedAt;
+          dateRangeExpanded = true;
+        }
+      }
+    }
 
     console.log('[PostsPanel:Debug][API] Lancement des 9 requêtes service en parallèle...');
     const fetchStart = Date.now();
@@ -215,6 +247,13 @@ export async function GET(request: NextRequest) {
         totalReach: h.totalReach,
         totalEngagements: h.totalEngagements,
       })),
+      ...(dateRangeExpanded && {
+        dateRangeExpanded: true,
+        effectiveDateRange: {
+          startDate: startDate?.toISOString(),
+          endDate: endDate?.toISOString(),
+        },
+      }),
     };
 
     console.log('[PostsPanel:Debug][API] Réponse finale construite:', {

--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -239,6 +239,8 @@ interface PostsPanelData {
   postTypes: PostTypeStats[];
   engagementTrends: EngagementTrend[];
   bestPostingTimes: BestPostingTime[];
+  dateRangeExpanded?: boolean;
+  effectiveDateRange?: { startDate: string; endDate: string };
 }
 
 interface AnalyticsData {

--- a/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
+++ b/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
@@ -22,6 +22,7 @@ import {
   Video,
   FileText,
   Layers,
+  Info,
 } from 'lucide-react';
 import {
   AreaChart,
@@ -102,6 +103,8 @@ export interface PostsPanelData {
   postTypes: PostTypeStats[];
   engagementTrends: EngagementTrend[];
   bestPostingTimes: BestPostingTime[];
+  dateRangeExpanded?: boolean;
+  effectiveDateRange?: { startDate: string; endDate: string };
 }
 
 interface PostsPanelProps {
@@ -269,6 +272,35 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
 
   return (
     <div className="space-y-4 overflow-x-hidden sm:space-y-6">
+      {/* Bannière quand les données sont élargies au-delà de la période sélectionnée */}
+      {data?.dateRangeExpanded && data.effectiveDateRange && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+        >
+          <Info size={18} className="flex-shrink-0 text-amber-400" />
+          <p className="text-sm text-amber-200">
+            Aucune activité sur la période sélectionnée. Les données affichées couvrent la période{' '}
+            <span className="font-semibold text-amber-100">
+              {new Date(data.effectiveDateRange.startDate).toLocaleDateString('fr-FR', {
+                day: 'numeric',
+                month: 'short',
+                year: 'numeric',
+              })}
+            </span>
+            {' \u2013 '}
+            <span className="font-semibold text-amber-100">
+              {new Date(data.effectiveDateRange.endDate).toLocaleDateString('fr-FR', {
+                day: 'numeric',
+                month: 'short',
+                year: 'numeric',
+              })}
+            </span>
+          </p>
+        </motion.div>
+      )}
+
       {/* Summary Stats Row */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4 lg:grid-cols-5">
         {/* Total Posts */}

--- a/apps/psypnos/lib/social/analytics.ts
+++ b/apps/psypnos/lib/social/analytics.ts
@@ -729,9 +729,8 @@ export async function getBestPostingTimes(
     analytics: { engagements: number } | null;
   }> = await prisma.socialPost.findMany({
     where: {
-      ...dateFilter,
+      AND: [dateFilter, { publishedAt: { not: null } }],
       status: 'PUBLISHED',
-      publishedAt: { not: null },
     },
     select: {
       publishedAt: true,


### PR DESCRIPTION
## Summary

- **Fix getBestPostingTimes spread overwrite** : `publishedAt: { not: null }` écrasait le filtre de dates issu de `...dateFilter`. Corrigé avec `AND[]` Prisma.
- **Fallback automatique quand la période sélectionnée ne contient aucun post** : l'API détecte l'absence de données, élargit la plage aux dates réelles des posts existants, et retourne `dateRangeExpanded: true`. Le PostsPanel affiche une bannière informative.

## Test plan

- [ ] Vérifier que le dashboard Posts affiche les données même quand aucun post n'existe dans les 7 derniers jours
- [ ] Vérifier que la bannière ambrée "Aucune activité sur la période sélectionnée" s'affiche avec les dates effectives
- [ ] Vérifier que `getBestPostingTimes` respecte le filtre de dates
- [ ] Vérifier le fonctionnement normal avec des posts récents (pas de fallback)

https://claude.ai/code/session_01PUsjLKabvGF2zM4FLr3bdb