### PR TITLE
fix(social): corriger publication automatique des posts (#197)

### DIFF
--- a/apps/psypnos/__tests__/unit/social-publish-cron.test.ts
+++ b/apps/psypnos/__tests__/unit/social-publish-cron.test.ts
@@ -110,3 +110,93 @@ describe('setup-qstash-schedules - méthode HTTP', () => {
     expect(content).toContain("method: 'GET'");
   });
 });
+
+// ─── Test 4 : DEFAULT_RETRY_CONFIG — retryableErrors présent ────────
+
+describe('DEFAULT_RETRY_CONFIG - retryableErrors', () => {
+  it('devrait contenir la propriété retryableErrors dans le type RetryConfig', () => {
+    const clientsPath = join(__dirname, '../../lib/social/clients/index.ts');
+    const content = readFileSync(clientsPath, 'utf-8');
+
+    // Vérifier que l'interface RetryConfig définit retryableErrors
+    expect(content).toContain('retryableErrors');
+  });
+
+  it("devrait contenir les patterns d'erreurs réseau classiques", () => {
+    const clientsPath = join(__dirname, '../../lib/social/clients/index.ts');
+    const content = readFileSync(clientsPath, 'utf-8');
+
+    const expectedPatterns = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', '429', '503'];
+    for (const pattern of expectedPatterns) {
+      expect(content).toContain(pattern);
+    }
+  });
+});
+
+// ─── Test 5 : CRON social-publish — isolation par post ──────────────
+
+describe('CRON social-publish - isolation des erreurs par post', () => {
+  const routePath = join(CRON_DIR, 'social-publish', 'route.ts');
+
+  it('devrait avoir un try/catch autour de publishPostWithRetry dans la boucle', () => {
+    const content = readFileSync(routePath, 'utf-8');
+
+    // Vérifier que la boucle for contient un try/catch interne
+    // Le pattern attendu : for ... { try { ... publishPostWithRetry ... } catch
+    const forLoopStart = content.indexOf('for (const post of posts)');
+    expect(forLoopStart).toBeGreaterThan(-1);
+
+    const afterLoop = content.slice(forLoopStart);
+    const publishCall = afterLoop.indexOf('publishPostWithRetry(post)');
+    expect(publishCall).toBeGreaterThan(-1);
+
+    // Le try doit apparaître AVANT publishPostWithRetry dans la boucle
+    const tryBeforePublish = afterLoop.slice(0, publishCall).includes('try {');
+    expect(tryBeforePublish).toBe(true);
+
+    // Le catch doit capturer l'erreur par post (pas juste le catch global)
+    const catchAfterPublish = afterLoop.indexOf('} catch (postError)');
+    expect(catchAfterPublish).toBeGreaterThan(publishCall);
+  });
+
+  it("devrait logger l'erreur et continuer avec les posts suivants", () => {
+    const content = readFileSync(routePath, 'utf-8');
+
+    // Le catch par post doit pousser un résultat d'erreur dans results
+    expect(content).toContain('Unexpected error on post');
+    expect(content).toContain('results.push({');
+  });
+});
+
+// ─── Test 6 : CRON social-publish — protection getSocialAccountById ─
+
+describe('CRON social-publish - protection getSocialAccountById', () => {
+  it('devrait protéger getSocialAccountById avec un try/catch dans publishPostWithRetry', () => {
+    const routePath = join(CRON_DIR, 'social-publish', 'route.ts');
+    const content = readFileSync(routePath, 'utf-8');
+
+    // Trouver la fonction publishPostWithRetry
+    const funcStart = content.indexOf('async function publishPostWithRetry');
+    expect(funcStart).toBeGreaterThan(-1);
+
+    const funcBody = content.slice(funcStart, content.indexOf('\n// ===', funcStart + 1));
+
+    // getSocialAccountById doit être dans un try/catch
+    const accountCallIndex = funcBody.indexOf('getSocialAccountById(post.accountId)');
+    expect(accountCallIndex).toBeGreaterThan(-1);
+
+    // Un try doit précéder l'appel
+    const beforeCall = funcBody.slice(0, accountCallIndex);
+    expect(beforeCall).toContain('try {');
+
+    // Un catch (accountError) doit suivre
+    expect(funcBody).toContain('catch (accountError)');
+  });
+
+  it("devrait retourner une erreur descriptive en cas d'échec de décryptage", () => {
+    const routePath = join(CRON_DIR, 'social-publish', 'route.ts');
+    const content = readFileSync(routePath, 'utf-8');
+
+    expect(content).toContain('Erreur lors de la récupération du compte social');
+  });
+});

--- a/apps/psypnos/app/api/cron/social-publish/route.ts
+++ b/apps/psypnos/app/api/cron/social-publish/route.ts
@@ -38,8 +38,18 @@ async function publishPostWithRetry(post: SocialPost): Promise<{
   platformUrl?: string;
   error?: string;
 }> {
-  // Récupérer le compte
-  const account = await getSocialAccountById(post.accountId);
+  // Récupérer le compte (protégé : decryptToken peut throw si le token est corrompu)
+  let account;
+  try {
+    account = await getSocialAccountById(post.accountId);
+  } catch (accountError) {
+    const msg = accountError instanceof Error ? accountError.message : 'Erreur inconnue';
+    return {
+      success: false,
+      error: `Erreur lors de la récupération du compte social : ${msg}`,
+    };
+  }
+
   if (!account) {
     return {
       success: false,
@@ -257,23 +267,39 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Publier chaque post
+    // Publier chaque post (isolé : une erreur sur un post ne bloque pas les suivants)
     for (const post of posts) {
       console.log(`[Cron Social Publish] Publishing post ${post.id} to ${post.platform}`);
 
-      const result = await publishPostWithRetry(post);
+      try {
+        const result = await publishPostWithRetry(post);
 
-      results.push({
-        postId: post.id,
-        platform: post.platform,
-        success: result.success,
-        externalPostId: result.externalPostId,
-        error: result.error,
-      });
+        results.push({
+          postId: post.id,
+          platform: post.platform,
+          success: result.success,
+          externalPostId: result.externalPostId,
+          error: result.error,
+        });
 
-      // Envoyer une notification si échec définitif
-      if (!result.success && post.retryCount + 1 >= DEFAULT_RETRY_CONFIG.maxRetries) {
-        await sendFailureNotification(post, result.error || 'Erreur inconnue');
+        // Envoyer une notification si échec définitif
+        if (!result.success && post.retryCount + 1 >= DEFAULT_RETRY_CONFIG.maxRetries) {
+          await sendFailureNotification(post, result.error || 'Erreur inconnue');
+        }
+      } catch (postError) {
+        // Erreur inattendue sur ce post — on continue avec les suivants
+        const errorMessage = postError instanceof Error ? postError.message : 'Erreur inconnue';
+        console.error(
+          `[Cron Social Publish] Unexpected error on post ${post.id} (${post.platform}):`,
+          postError
+        );
+
+        results.push({
+          postId: post.id,
+          platform: post.platform,
+          success: false,
+          error: errorMessage,
+        });
       }
 
       // Petit délai entre les publications pour éviter le rate limiting

--- a/apps/psypnos/lib/social/clients/index.ts
+++ b/apps/psypnos/lib/social/clients/index.ts
@@ -71,12 +71,26 @@ export interface RetryConfig {
   maxRetries: number;
   baseDelay: number;
   maxDelay: number;
+  /** Patterns d'erreurs qui justifient un retry automatique */
+  retryableErrors: string[];
 }
 
 export const DEFAULT_RETRY_CONFIG: RetryConfig = {
   maxRetries: 3,
   baseDelay: 1000,
   maxDelay: 10000,
+  retryableErrors: [
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ENOTFOUND',
+    'rate_limit',
+    'temporarily_unavailable',
+    '429',
+    '500',
+    '502',
+    '503',
+    '504',
+  ],
 };
 
 /**


### PR DESCRIPTION
## Résumé

Corrige 3 bugs critiques dans le CRON de publication automatique sur les réseaux sociaux qui empêchaient la publication des posts programmés.

### Bugs corrigés

- **`retryableErrors` manquant** — `DEFAULT_RETRY_CONFIG` dans `clients/index.ts` ne contenait pas `retryableErrors`, causant un `TypeError: Cannot read properties of undefined (reading 'some')` dans le catch block du CRON quand un publisher throw
- **`getSocialAccountById` non protégé** — `decryptToken()` peut throw si un token est corrompu (ex: migration depuis l'ancien site). L'appel n'était pas dans un try/catch, crashant tout le batch
- **Pas d'isolation par post** — Une erreur sur un post stoppait le traitement de TOUS les posts restants dans la boucle du CRON

### Fichiers modifiés

- `apps/psypnos/lib/social/clients/index.ts` — ajout `retryableErrors` au `RetryConfig`
- `apps/psypnos/app/api/cron/social-publish/route.ts` — try/catch autour de `getSocialAccountById` + isolation par post
- `apps/psypnos/__tests__/unit/social-publish-cron.test.ts` — 6 nouveaux tests

## Test plan

- [x] 31 tests unitaires passent (dont 6 nouveaux)
- [x] Lint : 0 erreur
- [x] Type-check : passé
- [x] Build production : passé
- [ ] Vérifier en preview que le CRON social-publish fonctionne

Fixes #197

https://claude.ai/code/session_01TVwJNPR4d1RiGTnhzihn3o