### PR TITLE
fix(deploy): supprimer le CRON natif Vercel qui bloque les déploiements

### DIFF
--- a/apps/psypnos/__tests__/unit/social-publish-vercel-cron.test.ts
+++ b/apps/psypnos/__tests__/unit/social-publish-vercel-cron.test.ts
@@ -1,11 +1,10 @@
 /**
- * Tests unitaires pour la configuration Vercel CRON et le flux de publication.
+ * Tests unitaires pour le flux de publication sociale et l'authentification CRON.
  *
  * Vérifie que :
- * - vercel.json contient la configuration CRON pour social-publish
- * - Le CRON est configuré pour s'exécuter toutes les minutes
- * - L'authentification supporte CRON_SECRET (Vercel CRON natif)
- * - Le handler GET est bien exporté (Vercel CRON envoie GET)
+ * - vercel.json ne contient PAS de bloc crons (scheduling via QStash uniquement)
+ * - L'authentification supporte CRON_SECRET et signature QStash
+ * - Le handler GET est bien exporté
  * - Le handler POST est bien exporté (compatibilité QStash)
  * - Les logs de diagnostic sont présents pour le traçage
  * - Le flux de publication gère correctement les cas limites
@@ -20,30 +19,13 @@ const APP_DIR = join(__dirname, '../..');
 const CRON_ROUTE = join(APP_DIR, 'app/api/cron/social-publish/route.ts');
 const POSTS_ROUTE = join(APP_DIR, 'app/api/social/posts/route.ts');
 
-// ─── Test 1 : Configuration Vercel CRON ──────────────────────────
+// ─── Test 1 : Absence de CRON natif Vercel ──────────────────────
 
-describe('Vercel CRON — configuration vercel.json', () => {
+describe('Vercel CRON — absence de crons natifs dans vercel.json', () => {
   const vercelConfig = JSON.parse(readFileSync(join(APP_DIR, 'vercel.json'), 'utf-8'));
 
-  it('devrait contenir un tableau crons', () => {
-    expect(vercelConfig.crons).toBeDefined();
-    expect(Array.isArray(vercelConfig.crons)).toBe(true);
-    expect(vercelConfig.crons.length).toBeGreaterThan(0);
-  });
-
-  it('devrait inclure social-publish dans les crons', () => {
-    const socialPublishCron = vercelConfig.crons.find(
-      (c: { path: string }) => c.path === '/api/cron/social-publish'
-    );
-    expect(socialPublishCron).toBeDefined();
-  });
-
-  it('devrait exécuter social-publish au moins toutes les minutes', () => {
-    const socialPublishCron = vercelConfig.crons.find(
-      (c: { path: string }) => c.path === '/api/cron/social-publish'
-    );
-    // "* * * * *" = toutes les minutes
-    expect(socialPublishCron.schedule).toBe('* * * * *');
+  it('ne devrait PAS contenir de bloc crons (scheduling via QStash)', () => {
+    expect(vercelConfig.crons).toBeUndefined();
   });
 });
 

--- a/apps/psypnos/vercel.json
+++ b/apps/psypnos/vercel.json
@@ -4,11 +4,5 @@
   "installCommand": "pnpm install",
   "buildCommand": "cd ../.. && pnpm --filter @kairn/db exec prisma generate && pnpm turbo run build --filter=@kairn/psypnos --env-mode=loose",
   "outputDirectory": ".next",
-  "regions": ["cdg1"],
-  "crons": [
-    {
-      "path": "/api/cron/social-publish",
-      "schedule": "* * * * *"
-    }
-  ]
+  "regions": ["cdg1"]
 }


### PR DESCRIPTION
## Résumé

- Supprime le bloc `crons` de `apps/psypnos/vercel.json` qui bloquait les déploiements Vercel (schedule `* * * * *` incompatible avec le plan Hobby)
- Adapte le test unitaire pour vérifier l'**absence** du bloc crons natif (scheduling exclusivement via QStash)
- L'endpoint `/api/cron/social-publish` reste inchangé et fonctionnel

## Contexte

Le bloc `crons` ajouté par la PR #218 (commit `5c41517`) a provoqué l'erreur Vercel :
> Hobby accounts are limited to daily cron jobs. This cron expression (`* * * * *`) would run more than once per day.

QStash est déjà le système de scheduling principal et opérationnel — le CRON natif Vercel était un doublon.

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `apps/psypnos/vercel.json` | Suppression du bloc `crons` |
| `apps/psypnos/__tests__/unit/social-publish-vercel-cron.test.ts` | Test 1 : vérifie l'absence de crons (au lieu de leur présence) |

## Validation locale

- ✅ Lint : passé (0 erreurs)
- ✅ Type-check : passé
- ✅ Tests : 28/28 passés
- ✅ Build : passé

## Test plan

- [ ] Le déploiement Vercel se déclenche et réussit après merge sur `main`
- [ ] Le endpoint `/api/cron/social-publish` reste accessible et fonctionnel
- [ ] Les schedules QStash sont actifs (`verify-qstash-schedules.ts`)
- [ ] Les tests CI passent (lint, type-check, test, build)

Fixes #220

https://claude.ai/code/session_01USVpMMJHHFJQXcCy3NTXJQ