### PR TITLE
Add AI-generated pre-response suggestions to admin notification emails

### DIFF
--- a/apps/psypnos/app/api/common/email-templates.ts
+++ b/apps/psypnos/app/api/common/email-templates.ts
@@ -78,6 +78,8 @@ export type AdminEmailOptions = {
   sections: EmailSection[];
   /** Freeform message block (e.g. user's message) */
   messageBlock?: { label: string; content: string };
+  /** AI-generated pre-response suggestion for the practitioner */
+  preResponse?: { text: string; source: 'ai' | 'fallback' };
   /** JSON metadata for automated processing (embedded as hidden comment) */
   metadata?: Record<string, unknown>;
   /** Submission timestamp ISO string */
@@ -231,7 +233,7 @@ function renderAdminSection(section: EmailSection, c: ResolvedColors): string {
 
 export function buildAdminEmailHtml(options: AdminEmailOptions, branding: EmailBranding): string {
   const c = resolveColors(branding);
-  const { heading, badge, sections, messageBlock, metadata, submittedAt, sourcePage } = options;
+  const { heading, badge, sections, messageBlock, preResponse, metadata, submittedAt, sourcePage } = options;
 
   const siteNameUpper = branding.siteName.toUpperCase();
 
@@ -249,6 +251,23 @@ export function buildAdminEmailHtml(options: AdminEmailOptions, branding: EmailB
       `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border:1px solid ${c.grey200};border-top:none;border-radius:0 0 6px 6px;">` +
       `<tr><td style="padding:16px;color:${c.grey900};font-size:14px;line-height:1.7;white-space:pre-wrap;">${nl2br(messageBlock.content)}</td></tr>` +
       `</table>`
+    )
+    : "";
+
+  const sourceLabel = preResponse?.source === 'ai' ? 'Suggestion IA' : 'Suggestion';
+  const preResponseHtml = preResponse
+    ? (
+      `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:24px;">` +
+      `<tr><td style="padding:8px 14px;background:linear-gradient(135deg,${c.gold},${c.goldLight});color:${c.night};font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:1px;border-radius:6px 6px 0 0;">` +
+      `${escapeHtml(sourceLabel)}` +
+      `</td></tr>` +
+      `</table>` +
+      `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border:1px solid ${c.goldLight};border-top:none;border-radius:0 0 6px 6px;background:${c.grey50};">` +
+      `<tr><td style="padding:16px;color:${c.grey700};font-size:14px;line-height:1.7;white-space:pre-wrap;font-style:italic;">${nl2br(preResponse.text)}</td></tr>` +
+      `</table>` +
+      `<p style="margin:6px 0 0;font-size:11px;color:${c.grey400};font-style:italic;">` +
+      `Cette suggestion est un brouillon à personnaliser avant envoi.` +
+      `</p>`
     )
     : "";
 
@@ -286,6 +305,7 @@ export function buildAdminEmailHtml(options: AdminEmailOptions, branding: EmailB
     `<h1 style="margin:0 0 4px;font-size:20px;color:${c.night};font-weight:700;">${escapeHtml(heading)}${badgeHtml}</h1>` +
     sectionsHtml +
     messageBlockHtml +
+    preResponseHtml +
     footerHtml +
     `</td></tr>` +
     // Footer bar
@@ -299,7 +319,7 @@ export function buildAdminEmailHtml(options: AdminEmailOptions, branding: EmailB
 }
 
 export function buildAdminEmailText(options: AdminEmailOptions): string {
-  const { heading, sections, messageBlock, submittedAt, sourcePage } = options;
+  const { heading, sections, messageBlock, preResponse, submittedAt, sourcePage } = options;
 
   const separator = Array(heading.length + 1).join("═");
   const lines: string[] = [heading, separator, ""];
@@ -315,6 +335,14 @@ export function buildAdminEmailText(options: AdminEmailOptions): string {
   if (messageBlock) {
     lines.push(`── ${messageBlock.label} ──`);
     lines.push(messageBlock.content);
+    lines.push("");
+  }
+
+  if (preResponse) {
+    const sourceLabel = preResponse.source === 'ai' ? 'Suggestion IA' : 'Suggestion';
+    lines.push(`── ${sourceLabel} ──`);
+    lines.push(preResponse.text);
+    lines.push("(Brouillon à personnaliser avant envoi)");
     lines.push("");
   }
 

--- a/apps/psypnos/app/api/common/generate-pre-response.ts
+++ b/apps/psypnos/app/api/common/generate-pre-response.ts
@@ -1,0 +1,158 @@
+/**
+ * Génération de pré-réponse IA pour les emails de notification admin.
+ *
+ * Appelle OpenAI GPT-4o-mini avec un timeout court (5 s).
+ * En cas d'échec (timeout, erreur API, clé absente), retombe sur un
+ * template statique contextuel — le praticien reçoit toujours une suggestion.
+ */
+
+const PRE_RESPONSE_TIMEOUT_MS = 5_000;
+const PRE_RESPONSE_MODEL = 'gpt-4o-mini';
+const PRE_RESPONSE_MAX_TOKENS = 300;
+
+// ─── System Prompt (léger, adapté aux emails) ────────────────────────────────
+
+const SYSTEM_PROMPT = `Tu es David Duquenne, psychopraticien (psychothérapie transpersonnelle, hypnose ericksonienne, respiration holotropique) à Saint-Julien-du-Sault.
+
+Tu rédiges une réponse courte et chaleureuse à un message reçu via ton site psypnos.fr.
+
+Consignes :
+- Vouvoie le correspondant, utilise son prénom si disponible.
+- Ton empathique, bienveillant, professionnel — jamais familier.
+- 3 à 5 phrases maximum.
+- Accuse réception du message, montre que tu as compris la demande.
+- Propose un prochain pas concret (prise de rendez-vous, appel, etc.).
+- Ne fais aucune promesse thérapeutique ni diagnostic.
+- Termine par une formule chaleureuse et ton nom complet.`;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type PreResponseInput = {
+  /** Nom ou prénom du correspondant */
+  name: string;
+  /** Message envoyé */
+  message: string;
+  /** Sujet ou type de demande (optionnel) */
+  subject?: string;
+};
+
+export type PreResponseResult = {
+  /** Texte de la pré-réponse */
+  text: string;
+  /** Source : 'ai' si générée par OpenAI, 'fallback' si template statique */
+  source: 'ai' | 'fallback';
+};
+
+// ─── Fallback statique ───────────────────────────────────────────────────────
+
+function getStaticFallback(input: PreResponseInput): string {
+  const firstName = input.name.split(' ')[0];
+
+  if (input.subject?.toLowerCase().includes('rendez-vous') ||
+      input.subject?.toLowerCase().includes('consultation') ||
+      input.subject === 'premiere_consultation') {
+    return (
+      `Bonjour ${firstName},\n\n` +
+      `Merci pour votre message et votre intérêt pour un accompagnement thérapeutique. ` +
+      `J'ai bien pris note de votre demande et je reviendrai vers vous très prochainement ` +
+      `pour convenir ensemble d'un créneau.\n\n` +
+      `À très bientôt,\nDavid Duquenne`
+    );
+  }
+
+  if (input.subject?.toLowerCase().includes('séminaire') ||
+      input.subject?.toLowerCase().includes('respiration') ||
+      input.subject === 'seminaire') {
+    return (
+      `Bonjour ${firstName},\n\n` +
+      `Merci pour votre message concernant les séminaires de respiration holotropique. ` +
+      `Je reviendrai vers vous rapidement avec toutes les informations pratiques ` +
+      `(dates, lieu, déroulement).\n\n` +
+      `Chaleureusement,\nDavid Duquenne`
+    );
+  }
+
+  return (
+    `Bonjour ${firstName},\n\n` +
+    `Merci d'avoir pris le temps de me contacter. J'ai bien reçu votre message ` +
+    `et je vous répondrai personnellement dans les meilleurs délais.\n\n` +
+    `N'hésitez pas à me rappeler si vous souhaitez échanger par téléphone.\n\n` +
+    `Bien à vous,\nDavid Duquenne`
+  );
+}
+
+// ─── Appel OpenAI ────────────────────────────────────────────────────────────
+
+async function callOpenAI(input: PreResponseInput): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY manquante');
+  }
+
+  const userPrompt = [
+    `Correspondant : ${input.name}`,
+    input.subject ? `Objet : ${input.subject}` : null,
+    `\nMessage :\n${input.message}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PRE_RESPONSE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: PRE_RESPONSE_MODEL,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        max_tokens: PRE_RESPONSE_MAX_TOKENS,
+        temperature: 0.7,
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`OpenAI API ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const text = data.choices?.[0]?.message?.content?.trim();
+    if (!text) {
+      throw new Error('Réponse OpenAI vide');
+    }
+
+    return text;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    throw error;
+  }
+}
+
+// ─── Export principal ────────────────────────────────────────────────────────
+
+/**
+ * Génère une pré-réponse pour l'email de notification admin.
+ * Ne lève jamais d'exception — retombe toujours sur le fallback statique.
+ */
+export async function generatePreResponse(input: PreResponseInput): Promise<PreResponseResult> {
+  try {
+    const text = await callOpenAI(input);
+    return { text, source: 'ai' };
+  } catch (error) {
+    console.warn('[pre-response] Fallback statique utilisé :', (error as Error).message ?? error);
+    return { text: getStaticFallback(input), source: 'fallback' };
+  }
+}

--- a/apps/psypnos/app/api/contact/route.ts
+++ b/apps/psypnos/app/api/contact/route.ts
@@ -12,6 +12,7 @@ import {
   formatSubmittedAt,
   getEmailBranding,
 } from '../common/email-templates';
+import { generatePreResponse } from '../common/generate-pre-response';
 import { recordAttempt, getClientIP } from '../common/rate-limiter';
 import { sendEmailThroughResend, type EmailContent } from '../common/send-email';
 
@@ -37,7 +38,10 @@ const contactSchema = z.object({
 
 type ContactPayload = z.infer<typeof contactSchema>;
 
-const formatAdminEmail = (payload: ContactPayload): EmailContent => {
+const formatAdminEmail = (
+  payload: ContactPayload,
+  preResponse?: { text: string; source: 'ai' | 'fallback' }
+): EmailContent => {
   const options = {
     heading: 'Nouveau message de contact',
     badge: 'Contact',
@@ -56,6 +60,7 @@ const formatAdminEmail = (payload: ContactPayload): EmailContent => {
       label: 'Message',
       content: payload.message,
     },
+    preResponse,
     metadata: {
       type: 'contact',
       name: payload.name,
@@ -153,7 +158,14 @@ export async function POST(request: Request) {
     process.env.CONTACT_FORM_RECIPIENT ??
     process.env.APPOINTMENT_REQUEST_RECIPIENT ??
     branding.contactEmail;
-  const adminContent = formatAdminEmail(payload);
+
+  const preResponse = await generatePreResponse({
+    name: payload.name,
+    message: payload.message,
+    subject: payload.subject,
+  });
+
+  const adminContent = formatAdminEmail(payload, preResponse);
 
   try {
     await sendEmailThroughResend(adminContent, recipient, branding, { replyTo: payload.email });

--- a/apps/psypnos/app/api/quick-contact/route.ts
+++ b/apps/psypnos/app/api/quick-contact/route.ts
@@ -12,6 +12,7 @@ import {
   formatSubmittedAt,
   getEmailBranding,
 } from '../common/email-templates';
+import { generatePreResponse } from '../common/generate-pre-response';
 import { recordAttempt, getClientIP } from '../common/rate-limiter';
 import { sendEmailThroughResend, type EmailContent } from '../common/send-email';
 
@@ -63,7 +64,10 @@ const requestTypeLabels: Record<(typeof requestTypeValues)[number], string> = {
   seminaire: 'Séminaire de respiration holotropique',
 };
 
-const formatAdminEmail = (payload: QuickContactPayload): EmailContent => {
+const formatAdminEmail = (
+  payload: QuickContactPayload,
+  preResponse?: { text: string; source: 'ai' | 'fallback' }
+): EmailContent => {
   const fullName = `${payload.firstName} ${payload.lastName}`;
 
   const options = {
@@ -84,6 +88,7 @@ const formatAdminEmail = (payload: QuickContactPayload): EmailContent => {
       label: 'Message',
       content: payload.message,
     },
+    preResponse,
     metadata: {
       type: 'quick_contact',
       first_name: payload.firstName,
@@ -184,7 +189,14 @@ export async function POST(request: Request) {
     process.env.CONTACT_FORM_RECIPIENT ??
     process.env.APPOINTMENT_REQUEST_RECIPIENT ??
     branding.contactEmail;
-  const adminContent = formatAdminEmail(payload);
+
+  const preResponse = await generatePreResponse({
+    name: `${payload.firstName} ${payload.lastName}`,
+    message: payload.message,
+    subject: payload.requestType,
+  });
+
+  const adminContent = formatAdminEmail(payload, preResponse);
 
   try {
     await sendEmailThroughResend(adminContent, recipient, branding, { replyTo: payload.email });


### PR DESCRIPTION
## Description

Adds AI-powered pre-response generation for admin notification emails on the contact and quick-contact forms. When a user submits a message, the system now calls OpenAI's GPT-4o-mini API to generate a contextual draft response that the practitioner can review and personalize before sending.

### Key Changes

- **New module** `generate-pre-response.ts`: Handles OpenAI API calls with a 5-second timeout and graceful fallback to contextual static templates if the API is unavailable, times out, or lacks credentials
- **Updated email templates**: Admin emails now include a styled "Suggestion" section displaying the AI-generated or fallback pre-response text, clearly marked as a draft for personalization
- **Integration**: Both `/api/contact` and `/api/quick-contact` endpoints now generate and include pre-responses in admin notifications
- **Resilience**: The system never fails due to AI generation—it always provides a suggestion (AI or fallback) without blocking email delivery

### Technical Details

- Uses GPT-4o-mini with `max_tokens: 300` and `temperature: 0.7` for balanced creativity
- System prompt instructs the AI to adopt the practitioner's voice (David Duquenne) with empathetic, professional tone
- Fallback templates are context-aware, responding differently to consultation requests, seminars, or general inquiries
- Pre-response source is tracked (`'ai'` or `'fallback'`) and displayed in the email UI
- HTML and plain-text email formats both supported

## Type de changement

- [x] ✨ Nouvelle fonctionnalité
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles (API key read from env only)

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre

## Test Plan

- Verify that contact and quick-contact form submissions generate pre-response suggestions in admin emails
- Confirm fallback templates appear when `OPENAI_API_KEY` is missing or API calls timeout
- Check that email rendering displays the suggestion section with correct styling and source label
- Validate that missing/invalid API responses gracefully degrade without blocking email delivery

https://claude.ai/code/session_01UPfy7nkEG8gyzRvXbTwJjn