### PR TITLE
fix: add snapshot-social-accounts to REQUIRED_JOBS

### DIFF
--- a/scripts/verify-qstash-schedules.ts
+++ b/scripts/verify-qstash-schedules.ts
@@ -28,6 +28,7 @@ const REQUIRED_JOBS = [
   'weekly-report',
   'cleanup-data',
   'cleanup-jobs',
+  'snapshot-social-accounts',
   'aggregate',
   'check-alerts',
   'process-reports',


### PR DESCRIPTION
## Summary
- Add missing `snapshot-social-accounts` entry to the `REQUIRED_JOBS` list in the QStash verification script
- This job was already defined in `DEFAULT_CRON_SCHEDULES` and has a route handler, but was omitted from the verification checklist, causing false "extra job" warnings

## Test plan
- [ ] Run `pnpm tsx scripts/verify-qstash-schedules.ts --site-url https://psypnos.fr --verbose` and confirm `snapshot-social-accounts` is no longer flagged as extra

https://claude.ai/code/session_01EWjNqx4wh91zntUVP8cisA