### PR TITLE
fix: resolve QStash 401 on social-publish (#232)

### DIFF
--- a/apps/psypnos/app/api/cron/snapshot-social-accounts/route.ts
+++ b/apps/psypnos/app/api/cron/snapshot-social-accounts/route.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
 /**
  * Cron Snapshot Social Accounts API Route
  *
@@ -12,20 +10,20 @@
  * Security: QStash signature or CRON_SECRET
  */
 
-import { verifyCronAuth } from "@kairn/core/scheduler";
-import { NextRequest, NextResponse } from "next/server";
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { captureAllSnapshots } from "@/lib/social/snapshots";
+import { captureAllSnapshots } from '@/lib/social/snapshots';
 
 export async function POST(request: NextRequest) {
   // Vérifier l'authentification CRON
-  const authResult = verifyCronAuth(request);
-  if (!authResult.authorized) {
-    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  const authResult = await verifyCronAuth(request);
+  if (!authResult.valid) {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
   }
 
   try {
-    console.log("[Cron:snapshot-social-accounts] Démarrage de la capture des snapshots...");
+    console.log('[Cron:snapshot-social-accounts] Démarrage de la capture des snapshots...');
 
     const result = await captureAllSnapshots();
 
@@ -35,8 +33,8 @@ export async function POST(request: NextRequest) {
 
     if (result.errors.length > 0) {
       console.warn(
-        "[Cron:snapshot-social-accounts] Erreurs:",
-        result.errors.map((e) => `${e.accountId}: ${e.error}`).join(", ")
+        '[Cron:snapshot-social-accounts] Erreurs:',
+        result.errors.map(e => `${e.accountId}: ${e.error}`).join(', ')
       );
     }
 
@@ -45,10 +43,10 @@ export async function POST(request: NextRequest) {
       ...result,
     });
   } catch (error) {
-    console.error("[Cron:snapshot-social-accounts] Erreur fatale:", error);
+    console.error('[Cron:snapshot-social-accounts] Erreur fatale:', error);
     return NextResponse.json(
       {
-        error: error instanceof Error ? error.message : "Erreur interne",
+        error: error instanceof Error ? error.message : 'Erreur interne',
       },
       { status: 500 }
     );

--- a/packages/core/src/scheduler/verify-qstash.ts
+++ b/packages/core/src/scheduler/verify-qstash.ts
@@ -87,10 +87,11 @@ export async function verifyQStashSignature(
       const clonedRequest = request.clone();
       const body = await clonedRequest.text();
 
+      // Ne pas passer url pour éviter les problèmes de mismatch sur Vercel
+      // (request.url peut différer de l'URL signée par QStash)
       const isValid = await qstashReceiver.verify({
         signature,
         body,
-        url: request.url,
       });
 
       return {


### PR DESCRIPTION
## Summary
- Remove `url` parameter from QStash `Receiver.verify()` call to fix 401 errors on Vercel deployments — `request.url` can differ from the URL QStash signed due to internal routing
- Fix `snapshot-social-accounts` route: add missing `await` on `verifyCronAuth()` and use `.valid` instead of non-existent `.authorized` property

## Test plan
- [x] All 509 unit tests pass
- [ ] Deploy and verify QStash `social-publish` schedule no longer returns 401
- [ ] Verify `snapshot-social-accounts` cron works correctly

Closes #232

https://claude.ai/code/session_016ssGHiEtnEtn5HgQGSwrsX