### PR TITLE
feat(docs): ajouter CLAUDE.md pour Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,127 @@
+# Kairn — Plateforme SaaS multi-tenant pour praticiens bien-être
+
+## Commandes essentielles
+
+```bash
+# Installation
+pnpm install                    # JAMAIS npm/yarn
+
+# Développement
+pnpm dev                        # Tous les packages
+pnpm --filter @kairn/psypnos dev  # Un seul site
+
+# Lint & types
+pnpm turbo run lint --filter='...[HEAD~1]'
+pnpm turbo run type-check --filter='...[HEAD~1]'
+
+# Tests
+pnpm test:coverage              # Unitaires + couverture (seuil : 60%)
+pnpm test:ui                    # Composants UI (jsdom)
+pnpm test:a11y                  # Accessibilité (axe-core)
+
+# Build
+pnpm turbo run build --filter='...[HEAD~1]' --env-mode=loose
+```
+
+## Structure monorepo
+
+```
+apps/psypnos/          → App Next.js (App Router) — site praticien
+packages/core/         → Auth JWT, rate limiting, logger, utils, scheduler QStash
+packages/api/          → Handlers API réutilisables + middlewares (withAuth, withValidation, withCsrf, withRateLimit)
+packages/db/           → Schéma Prisma + client PostgreSQL
+packages/config/       → Types et schémas Zod de configuration site
+packages/ui/           → Composants React partagés (Tailwind CSS)
+packages/admin/        → Composants dashboard administration
+packages/ai/           → Abstraction IA (Claude + OpenAI)
+packages/blog/         → Processing Markdown, SEO, reading time
+packages/analytics/    → Tracking visiteurs, rapports, dashboards
+packages/social/       → Intégration réseaux sociaux (OAuth + posting)
+packages/experiments/  → A/B testing + feature flags
+packages/cli/          → CLI gestion plateforme
+tooling/               → Configs partagées (eslint, typescript, tailwind-preset)
+```
+
+## Conventions TypeScript & code style
+
+- **Prettier** : 100 cols, single quotes, trailing comma ES5, `arrowParens: avoid`
+- **Imports** ordonnés : builtin → external → @kairn/\* → relatifs → types
+- `import/no-cycle` et `import/no-duplicates` sont des erreurs
+- Zéro `any` (warn ESLint) — types explicites
+- Zod uniquement aux frontières système (API routes, Server Actions, inputs externes)
+- `prefer-const`, `no-var` — pas de `console.log` (seuls `console.warn`/`error` autorisés)
+- JSDoc obligatoire sur toute fonction créée ou modifiée
+- Nommage : PascalCase composants/types, camelCase fonctions/variables, SCREAMING_SNAKE_CASE constantes
+
+## Multi-tenancy — Règle critique
+
+**Chaque requête Prisma DOIT filtrer par `siteId`** pour l'isolation des données.
+
+```typescript
+// TOUJOURS
+const posts = await prisma.blogPost.findMany({ where: { siteId, status: 'PUBLISHED' } });
+// JAMAIS de requête sans siteId sur une table tenant-scoped
+```
+
+## Architecture React & Next.js
+
+- **React Server Components par défaut** — `'use client'` uniquement si justifié
+- Pas de `useCallback`/`memo` sans profil de performance prouvé
+- Composants partagés dans `packages/ui/` — configurables via props, injection de dépendances pour hooks
+- Composants spécifiques site dans `apps/<site>/components/` — wrappers des composants partagés
+- ISR via `revalidate` sur les layouts/pages publiques
+
+## Tests
+
+| Config                  | Commande             | Environnement    | Cible                                 |
+| ----------------------- | -------------------- | ---------------- | ------------------------------------- |
+| `vitest.config.ts`      | `pnpm test:coverage` | Node             | `packages/**`, `apps/**/__tests__/**` |
+| `vitest.ui.config.ts`   | `pnpm test:ui`       | jsdom            | `packages/ui/src/**`                  |
+| `vitest.a11y.config.ts` | `pnpm test:a11y`     | jsdom + axe-core | `**/*.a11y.test.*`                    |
+
+- Seuils de couverture : 60% statements/functions/lines, 50% branches
+- Couverture ciblée sur `packages/core/src` et `packages/api/src`
+- Mocks avec `vi.mock()` — déclarer les mocks AVANT les imports
+- Couvrir : cas nominal + cas d'erreur + edge cases
+
+## Sécurité
+
+- Auth JWT avec rotation de clés versionnées (jose) — tokens dans cookies httpOnly
+- CSRF via signed tokens (HMAC-SHA256)
+- Rate limiting hybride Redis/mémoire (graceful degradation)
+- Sanitize HTML entrant avec `isomorphic-dompurify`
+- Headers de sécurité dans `next.config.mjs` : CSP, HSTS, X-Frame-Options
+- Jamais de donnée sensible exposée dans les composants client
+- Variables d'environnement : documenter dans `.env.example`, configurer dans les 3 env Vercel
+
+## Git & CI
+
+- **Package manager** : pnpm exclusivement (Node ≥22, pnpm ≥10)
+- **Commits** : `type(scope): description` — ex. `fix(api): corriger validation contact`
+- **CI** (`.github/workflows/ci.yml`) : lint → type-check → test → security → build → e2e
+- Turbo Remote Cache via Vercel (`TURBO_TOKEN` + `TURBO_TEAM`)
+- Pre-commit hooks : lint-staged (ESLint --fix + Prettier)
+
+## Déploiement Vercel
+
+- Région : CDG1 (Paris)
+- Serverless Functions : `maxDuration: 60s` — pas d'accès filesystem en écriture (sauf `/tmp`)
+- CRON via **Upstash QStash** (pas les CRON natifs Vercel)
+- Preview ≠ Production : URL différente (attention CORS/CSP/OAuth callbacks), cache CDN réduit
+- Utiliser `waitUntil()` pour tâches post-réponse, pas `setTimeout`
+- Headers Vercel disponibles : `x-vercel-ip-country`, `x-vercel-ip-city`, `x-vercel-ip-timezone`
+
+## Gotchas fréquents
+
+- Modifier un package dans `packages/` impacte tous ses consommateurs — vérifier avec `--filter='...[HEAD~1]'`
+- Prisma : exécuter `pnpm --filter @kairn/db db:generate` après toute modification du schéma
+- Redis optionnel : le cache et rate limiting fonctionnent en mémoire locale sans Redis (non partagé entre instances Serverless)
+- Build Vercel ≠ CI : vérifier les deux après un push sur main
+- Les tokens OAuth réseaux sociaux sont chiffrés en base (`SOCIAL_ENCRYPTION_KEY`)
+
+## Documentation existante
+
+@docs/ARCHITECTURE.md — Architecture détaillée, flux de données, packages
+@DEPLOYMENT.md — Guide déploiement Vercel + QStash
+@SECURITY.md — Politique de sécurité
+@.env.example — Variables d'environnement requises

--- a/apps/psypnos/CLAUDE.md
+++ b/apps/psypnos/CLAUDE.md
@@ -1,0 +1,57 @@
+# Psypnos — Site praticien (Next.js App Router)
+
+## Commandes spécifiques
+
+```bash
+pnpm --filter @kairn/psypnos dev        # Dev local (port 3000)
+pnpm --filter @kairn/psypnos build      # Build production
+pnpm --filter @kairn/psypnos test:e2e   # E2E Playwright (chromium)
+```
+
+## Structure de l'app
+
+```
+app/
+├── api/               → API routes (auth, admin, blog, analytics, cron, contact, seminars)
+│   └── common/        → Middlewares partagés (csrf, rate-limiter, error-codes)
+├── admin/             → Dashboard admin (protégé par withAdminAuth)
+├── blog/              → Pages blog publiques
+├── (pages)/           → Pages publiques (accueil, services, contact)
+├── layout.tsx         → Root layout (ISR revalidate=86400, metadata, providers)
+├── providers.tsx      → 'use client' — providers interactifs (analytics, version check)
+components/            → Wrappers spécifiques au site des composants @kairn/ui
+hooks/                 → useCSRF, useFormValidation, useAnalytics
+lib/                   → Prisma singleton, cache Redis, site helpers, tracking
+config/                → site.config.ts + configuration spécifique
+middleware.ts          → Rate limiting par route, headers sécurité, détection IP client
+```
+
+## Patterns API routes
+
+```typescript
+// Pattern standard d'un endpoint admin protégé
+export async function GET(request: Request) {
+  const authResult = await withAdminAuth();
+  if (authResult.error) return authResult.error;
+  const siteId = await getSiteId();
+  // ... logique métier avec filtre siteId obligatoire
+}
+```
+
+- Validation : Zod `safeParse()` → retourner 400 avec message français si invalide
+- Erreurs : utiliser `ErrorCode` enum + `createApiError()` de `app/api/common/error-codes.ts`
+- Pagination : `skip`/`take` avec validation (limit max 100)
+
+## Vercel — Spécificités production
+
+- **vercel.json** : build inclut `prisma generate` avant `next build`
+- **Middleware** : rate limiting différencié (auth: 10/15min, contact: 5/h, admin: 200/15min, API: 100/15min)
+- **IP client** : vérifier `x-forwarded-for`, `x-real-ip`, `x-vercel-forwarded-for`, `cf-connecting-ip`
+- **Cache CDN** : assets statiques (1 an), API publiques (5min + SWR 30min), blog (10min), auth/admin (no-cache)
+- **Images** : formats AVIF/WebP, domaines autorisés Supabase + Unsplash, cache 7 jours
+
+## E2E (Playwright)
+
+- Config : `playwright.config.ts`
+- Navigateur : Chromium uniquement en CI
+- Reports : `playwright-report/` (uploadé en artifact CI, rétention 7 jours)


### PR DESCRIPTION
## Résumé

- Création du fichier `CLAUDE.md` racine (~120 lignes) avec les conventions essentielles du projet : commandes, structure monorepo, conventions TypeScript, multi-tenancy, tests, sécurité, déploiement Vercel, gotchas
- Création du fichier `apps/psypnos/CLAUDE.md` (~50 lignes) avec les spécificités de l'app : patterns API, structure, rate limiting, cache CDN, Playwright
- Application des meilleures pratiques Anthropic : concision (<200 lignes), contenu actionnable, hiérarchie racine + sous-répertoire pour chargement à la demande

Fixes #227

## Test plan

- [x] Fichiers formatés avec Prettier
- [x] lint-staged passé au commit (pre-commit hook)
- [x] Pas d'impact sur lint/type-check/tests/build (fichiers .md uniquement)
- [ ] Vérifier que Claude Code charge correctement les fichiers en début de session

https://claude.ai/code/session_01RoB58sEcx1ZwfwxzZFwZvZ