### PR TITLE
Add seminar thumbnail support and explicit site URLs to prompts

### DIFF
--- a/apps/psypnos/__tests__/unit/seminar-prompt-builder.test.ts
+++ b/apps/psypnos/__tests__/unit/seminar-prompt-builder.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests unitaires pour le constructeur de prompts de séminaires.
+ *
+ * Vérifie que les prompts générés contiennent :
+ * - Les URLs du site (inscription et respiration holotropique)
+ * - Le thumbnail du séminaire quand il est fourni
+ * - Les informations essentielles du séminaire
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildSeminarSystemPrompt,
+  buildSeminarUserPrompt,
+  buildSeminarMultiPlatformPrompt,
+  type SeminarInput,
+  type SeminarGenerationOptions,
+} from '../../lib/social/prompts/seminar-builder';
+
+// ─── Fixtures ────────────────────────────────────────────────────
+
+type SocialPlatform = 'FACEBOOK' | 'LINKEDIN' | 'INSTAGRAM' | 'TWITTER' | 'THREADS';
+
+const BASE_SEMINAR: SeminarInput = {
+  id: 'test-seminar-1',
+  title: "Séminaire Retrouver l'Essentiel",
+  description: 'Un week-end immersif de respiration holotropique.',
+  speakers: [
+    { firstName: 'David', lastName: 'Duquenne' },
+    { firstName: 'Marie', lastName: 'Dupont' },
+  ],
+  startAt: '2026-04-15T09:00:00Z',
+  endAt: '2026-04-16T17:00:00Z',
+  capacity: 18,
+  price: 250,
+  deposit: 125,
+  tags: ['respiration', 'holotropique', 'lieu:Bourgogne'],
+};
+
+const SEMINAR_WITH_THUMBNAIL: SeminarInput = {
+  ...BASE_SEMINAR,
+  thumbnail: 'https://storage.psypnos.fr/seminars/retrouver-essentiel.jpg',
+};
+
+const DEFAULT_OPTIONS: SeminarGenerationOptions = {
+  tone: 'inspirant',
+  angle: 'benefices',
+};
+
+const INSCRIPTION_URL = 'https://www.psypnos.fr/inscription-seminaire';
+const RESPIRATION_URL = 'https://www.psypnos.fr/respiration-holotropique';
+
+// ─── Tests du prompt système ─────────────────────────────────────
+
+describe('buildSeminarSystemPrompt', () => {
+  it('contient les URLs du site', () => {
+    const prompt = buildSeminarSystemPrompt();
+
+    expect(prompt).toContain(RESPIRATION_URL);
+    expect(prompt).toContain(INSCRIPTION_URL);
+  });
+
+  it('contient le contexte Psypnos', () => {
+    const prompt = buildSeminarSystemPrompt();
+
+    expect(prompt).toContain('Psypnos');
+    expect(prompt).toContain('David Duquenne');
+  });
+});
+
+// ─── Tests des prompts par plateforme ────────────────────────────
+
+describe('buildSeminarUserPrompt', () => {
+  const PLATFORMS_WITH_LINKS: SocialPlatform[] = ['FACEBOOK', 'LINKEDIN', 'TWITTER'];
+
+  describe.each(PLATFORMS_WITH_LINKS)('plateforme %s (liens inline)', platform => {
+    it("contient l'URL d'inscription", () => {
+      const prompt = buildSeminarUserPrompt(BASE_SEMINAR, platform, DEFAULT_OPTIONS);
+
+      expect(prompt).toContain(INSCRIPTION_URL);
+    });
+
+    it("contient l'URL respiration holotropique", () => {
+      const prompt = buildSeminarUserPrompt(BASE_SEMINAR, platform, DEFAULT_OPTIONS);
+
+      expect(prompt).toContain(RESPIRATION_URL);
+    });
+
+    it('contient le thumbnail quand il est fourni', () => {
+      const prompt = buildSeminarUserPrompt(SEMINAR_WITH_THUMBNAIL, platform, DEFAULT_OPTIONS);
+
+      expect(prompt).toContain(SEMINAR_WITH_THUMBNAIL.thumbnail);
+    });
+
+    it('ne contient pas de référence au thumbnail quand il est absent', () => {
+      const prompt = buildSeminarUserPrompt(BASE_SEMINAR, platform, DEFAULT_OPTIONS);
+
+      expect(prompt).not.toContain('Image du séminaire: undefined');
+      expect(prompt).not.toContain('Image du séminaire: null');
+    });
+  });
+
+  describe.each(['INSTAGRAM', 'THREADS'] as SocialPlatform[])(
+    'plateforme %s (lien en bio)',
+    platform => {
+      it("référence l'URL d'inscription dans le contexte", () => {
+        const prompt = buildSeminarUserPrompt(BASE_SEMINAR, platform, DEFAULT_OPTIONS);
+
+        expect(prompt).toContain(INSCRIPTION_URL);
+      });
+
+      it('contient le thumbnail quand il est fourni', () => {
+        const prompt = buildSeminarUserPrompt(SEMINAR_WITH_THUMBNAIL, platform, DEFAULT_OPTIONS);
+
+        expect(prompt).toContain(SEMINAR_WITH_THUMBNAIL.thumbnail);
+      });
+    }
+  );
+
+  it('contient les informations essentielles du séminaire', () => {
+    const prompt = buildSeminarUserPrompt(BASE_SEMINAR, 'FACEBOOK', DEFAULT_OPTIONS);
+
+    expect(prompt).toContain(BASE_SEMINAR.title);
+    expect(prompt).toContain(BASE_SEMINAR.description);
+    expect(prompt).toContain('18 places');
+    expect(prompt).toContain('250€');
+  });
+});
+
+// ─── Tests du prompt multi-plateforme ────────────────────────────
+
+describe('buildSeminarMultiPlatformPrompt', () => {
+  it('contient les URLs du site', () => {
+    const platforms: SocialPlatform[] = ['FACEBOOK', 'LINKEDIN', 'INSTAGRAM'];
+    const prompt = buildSeminarMultiPlatformPrompt(BASE_SEMINAR, platforms, DEFAULT_OPTIONS);
+
+    expect(prompt).toContain(INSCRIPTION_URL);
+    expect(prompt).toContain(RESPIRATION_URL);
+  });
+
+  it('contient le thumbnail quand il est fourni', () => {
+    const platforms: SocialPlatform[] = ['FACEBOOK', 'LINKEDIN'];
+    const prompt = buildSeminarMultiPlatformPrompt(
+      SEMINAR_WITH_THUMBNAIL,
+      platforms,
+      DEFAULT_OPTIONS
+    );
+
+    expect(prompt).toContain(SEMINAR_WITH_THUMBNAIL.thumbnail);
+  });
+
+  it('contient les instructions de liens par type de plateforme', () => {
+    const platforms: SocialPlatform[] = ['FACEBOOK', 'INSTAGRAM'];
+    const prompt = buildSeminarMultiPlatformPrompt(BASE_SEMINAR, platforms, DEFAULT_OPTIONS);
+
+    expect(prompt).toContain('Facebook/LinkedIn/Twitter: inclure les vrais liens');
+    expect(prompt).toContain('Instagram/Threads: mentionner "lien en bio"');
+  });
+
+  it('contient les informations essentielles du séminaire', () => {
+    const platforms: SocialPlatform[] = ['FACEBOOK'];
+    const prompt = buildSeminarMultiPlatformPrompt(BASE_SEMINAR, platforms, DEFAULT_OPTIONS);
+
+    expect(prompt).toContain(BASE_SEMINAR.title);
+    expect(prompt).toContain('18 places');
+  });
+});

--- a/apps/psypnos/app/admin/seminars/_components/SeminarSocialModal.tsx
+++ b/apps/psypnos/app/admin/seminars/_components/SeminarSocialModal.tsx
@@ -35,6 +35,7 @@ interface GeneratedContent {
   platform: SocialPlatform;
   content: string;
   hashtags: string[];
+  suggestedMediaUrl?: string;
   characterCount?: number;
 }
 
@@ -380,6 +381,7 @@ export function SeminarSocialModal({ seminar, open, onClose }: SeminarSocialModa
           platform: gen.platform,
           content: gen.content,
           hashtags: gen.hashtags,
+          mediaUrls: gen.suggestedMediaUrl ? [gen.suggestedMediaUrl] : [],
           generatedBy: 'ai',
           aiModel: 'claude-sonnet-4-5-20250929',
           metadata: { seminarId: seminar.id, seminarTitle: seminar.title },

--- a/apps/psypnos/app/api/social/generate-seminar/route.ts
+++ b/apps/psypnos/app/api/social/generate-seminar/route.ts
@@ -252,6 +252,7 @@ function toSeminarInput(seminar: SeminarOutput): SeminarInput {
     price: seminar.price,
     deposit: seminar.deposit,
     tags: seminar.tags,
+    thumbnail: seminar.thumbnail,
   };
 }
 
@@ -271,8 +272,6 @@ async function generateForPlatform(
     const client = getAnthropicClient();
     const systemPrompt = buildSeminarSystemPrompt();
     const userPrompt = buildSeminarUserPrompt(seminar, platform, options);
-
-    console.log(`[SeminarSocialGen] Generating ${platform} content for "${seminar.title}"`);
 
     const response = await client.messages.create({
       model: MODEL,
@@ -306,6 +305,7 @@ async function generateForPlatform(
         platform,
         content: parsed.content,
         hashtags: parsed.hashtags,
+        suggestedMediaUrl: seminar.thumbnail,
         tokensUsed,
       },
       tokensUsed,
@@ -352,8 +352,6 @@ async function generateForMultiplePlatforms(
     const systemPrompt = buildSeminarSystemPrompt();
     const userPrompt = buildSeminarMultiPlatformPrompt(seminar, platforms, options);
 
-    console.log(`[SeminarSocialGen] Generating for ${platforms.join(', ')} for "${seminar.title}"`);
-
     const response = await client.messages.create({
       model: MODEL,
       max_tokens: MAX_TOKENS * platforms.length,
@@ -385,6 +383,7 @@ async function generateForMultiplePlatforms(
       platform: gen.platform,
       content: gen.content,
       hashtags: gen.hashtags,
+      suggestedMediaUrl: seminar.thumbnail,
       tokensUsed: tokensPerPlatform,
     }));
 
@@ -489,8 +488,6 @@ export async function POST(request: NextRequest) {
       urgencyLevel,
       placesRemaining,
     };
-
-    console.log(`[SeminarSocialGen API] Generating for ${platforms.join(', ')}`);
 
     // Générer le contenu
     const result = await generateForMultiplePlatforms(seminarInput, platforms, options);

--- a/apps/psypnos/lib/social/prompts/seminar-builder.ts
+++ b/apps/psypnos/lib/social/prompts/seminar-builder.ts
@@ -56,6 +56,7 @@ export interface SeminarInput {
   price?: number;
   deposit?: number;
   tags: string[];
+  thumbnail?: string;
 }
 
 export interface SeminarGenerationOptions {
@@ -94,6 +95,12 @@ IDENTITÉ DE MARQUE:
 - Ton général: Mystérieux mais rassurant, professionnel mais accessible
 - Valeurs: Authenticité, bienveillance, expertise, accompagnement personnalisé
 - Positionnement: Praticien expérimenté, approche holistique, ancrage local
+
+LIENS DU SITE (À UTILISER DANS LES POSTS):
+- Page Respiration Holotropique : https://www.psypnos.fr/respiration-holotropique
+- Inscription séminaire : https://www.psypnos.fr/inscription-seminaire
+Ces liens DOIVENT être intégrés dans les posts quand la plateforme le permet (Facebook, LinkedIn, Twitter).
+Pour Instagram et Threads, mentionner "lien en bio" en référençant la page d'inscription.
 
 CONTEXTE DES SÉMINAIRES:
 - Les séminaires sont des expériences immersives de groupe
@@ -266,6 +273,7 @@ Places restantes: ${options.placesRemaining || 'non précisé'}
 Prix: ${formattedPrice}
 Thématiques: ${seminar.tags.join(', ')}
 Jours avant l'événement: ${daysUntil}
+${seminar.thumbnail ? `Image du séminaire: ${seminar.thumbnail}` : ''}
 
 ═══════════════════════════════════════════
 FORMAT DE POST : "${formatSpec.name}"
@@ -330,8 +338,8 @@ OBJECTIFS SPÉCIFIQUES AU SÉMINAIRE
    - La transformation possible (sans promesse thérapeutique)
 
 3. Appel à l'action CLAIR :
-   - Inciter à s'inscrire
-   - "Lien en bio" pour Instagram
+   - Inciter à s'inscrire via "lien en bio" (le lien en bio pointe vers https://www.psypnos.fr/inscription-seminaire)
+   - Mentionner la page https://www.psypnos.fr/respiration-holotropique pour en savoir plus sur la pratique
 
 ═══════════════════════════════════════════
 RÈGLES INSTAGRAM ESSENTIELLES
@@ -431,6 +439,11 @@ Places restantes: ${options.placesRemaining || 'non précisé'}
 Prix: ${formattedPrice}
 Thématiques: ${seminar.tags.join(', ')}
 Jours avant l'événement: ${daysUntil}
+${seminar.thumbnail ? `Image du séminaire: ${seminar.thumbnail}` : ''}
+
+LIENS À UTILISER:
+- Page d'inscription: https://www.psypnos.fr/inscription-seminaire
+- En savoir plus sur la pratique: https://www.psypnos.fr/respiration-holotropique
 
 ═══════════════════════════════════════════
 FORMAT DE POST LINKEDIN : "${formatSpec.name}"
@@ -517,7 +530,7 @@ FORMAT DE RÉPONSE
 Réponds UNIQUEMENT avec ce JSON (sans markdown, sans backticks) :
 
 {
-  "content": "Le contenu du post LinkedIn (avec \\n pour les sauts de ligne). Mentionner que le lien est en commentaire.",
+  "content": "Le contenu du post LinkedIn (avec \\n pour les sauts de ligne). Mentionner le lien https://www.psypnos.fr/inscription-seminaire en commentaire et/ou https://www.psypnos.fr/respiration-holotropique pour en savoir plus.",
   "hashtags": ["${suggestedHashtags[0] || 'seminaire'}", "${suggestedHashtags[1] || 'bienetre'}", "${suggestedHashtags[2] || 'ressourcement'}", "${suggestedHashtags[3] || 'developpementpersonnel'}"],
   "suggestedMediaAlt": "Description alternative pour l'image",
   "formatUsed": "${format}",
@@ -528,7 +541,7 @@ RAPPEL FINAL:
 - Le post doit faire ${formatSpec.optimalLength.min}-${formatSpec.optimalLength.max} mots
 - Paragraphes ULTRA-COURTS (1-3 lignes)
 - Question d'engagement en fin de post
-- Lien mentionné "en commentaire"`;
+- Mentionner les vrais liens (https://www.psypnos.fr/inscription-seminaire et https://www.psypnos.fr/respiration-holotropique) "en commentaire"`;
 }
 
 /**
@@ -589,6 +602,11 @@ Places restantes: ${options.placesRemaining || 'non précisé'}
 Prix: ${formattedPrice}
 Thématiques: ${seminar.tags.join(', ')}
 Jours avant l'événement: ${daysUntil}
+${seminar.thumbnail ? `Image du séminaire: ${seminar.thumbnail}` : ''}
+
+LIENS À UTILISER:
+- Page d'inscription: https://www.psypnos.fr/inscription-seminaire
+- En savoir plus sur la pratique: https://www.psypnos.fr/respiration-holotropique
 
 ═══════════════════════════════════════════
 FORMAT DE POST FACEBOOK : "${formatSpec.name}"
@@ -642,7 +660,8 @@ RÈGLES FACEBOOK ESSENTIELLES
 ✅ À FAIRE :
 • Ton chaleureux et conversationnel
 • Utiliser des sauts de ligne pour aérer
-• Inclure le lien vers l'inscription avec 👉
+• Inclure le VRAI lien vers l'inscription : 👉 https://www.psypnos.fr/inscription-seminaire
+• Référencer la page de la pratique : https://www.psypnos.fr/respiration-holotropique
 • Terminer par une question qui invite aux commentaires
 • Maximum 2-3 hashtags, discrets en fin de post
 
@@ -652,6 +671,7 @@ RÈGLES FACEBOOK ESSENTIELLES
 • Promesses thérapeutiques
 • Trop d'émojis
 • Urgence anxiogène
+• Placeholder [LIEN] au lieu des vrais liens
 
 ═══════════════════════════════════════════
 FORMAT DE RÉPONSE
@@ -660,7 +680,7 @@ FORMAT DE RÉPONSE
 Réponds UNIQUEMENT avec ce JSON (sans markdown, sans backticks) :
 
 {
-  "content": "Le contenu du post Facebook (avec \\n pour les sauts de ligne). Inclure [LIEN] à l'emplacement souhaité.",
+  "content": "Le contenu du post Facebook (avec \\n pour les sauts de ligne). Utiliser les vrais liens https://www.psypnos.fr/inscription-seminaire et https://www.psypnos.fr/respiration-holotropique.",
   "hashtags": ["${suggestedHashtags[0] || 'seminaire'}", "${suggestedHashtags[1] || 'bienetre'}"],
   "suggestedMediaAlt": "Description alternative pour l'image",
   "formatUsed": "${format}",
@@ -696,7 +716,7 @@ RÈGLE CRITIQUE : LIMITE DE CARACTÈRES
 ⚠️ THREADS A UNE LIMITE DE 500 CARACTÈRES MAXIMUM ⚠️
 
 Tu dois générer un post de ${formatSpec.maxLength} CARACTÈRES maximum.
-Le lien sera ajouté automatiquement, ne l'inclus PAS dans le contenu.
+Le lien https://www.psypnos.fr/inscription-seminaire sera ajouté automatiquement, ne l'inclus PAS dans le contenu.
 
 ═══════════════════════════════════════════
 SÉMINAIRE À PROMOUVOIR
@@ -708,6 +728,7 @@ Dates: ${formattedDates}
 Lieu: ${location}
 Capacité: ${seminar.capacity} places
 Jours avant: ${daysUntil}
+${seminar.thumbnail ? `Image du séminaire: ${seminar.thumbnail}` : ''}
 
 ═══════════════════════════════════════════
 FORMAT DE POST THREADS : "${formatSpec.name}"
@@ -822,6 +843,11 @@ Dates: ${formattedDates}
 Capacité: ${seminar.capacity} places (CRÉER UN SENTIMENT D'URGENCE)
 Prix: ${formattedPrice}
 Thématiques: ${seminar.tags.join(', ')}
+${seminar.thumbnail ? `Image du séminaire: ${seminar.thumbnail}` : ''}
+
+LIENS À UTILISER:
+- Page d'inscription: https://www.psypnos.fr/inscription-seminaire
+- En savoir plus: https://www.psypnos.fr/respiration-holotropique
 
 ═══════════════════════════════════════════
 SPÉCIFICATIONS ${spec.name.toUpperCase()}
@@ -867,8 +893,8 @@ OBJECTIFS SPÉCIFIQUES AU SÉMINAIRE
    - La transformation possible
 
 3. Appel à l'action CLAIR :
-   - Inciter à s'inscrire
-   - Mentionner comment réserver
+   - Inciter à s'inscrire via https://www.psypnos.fr/inscription-seminaire
+   - Référencer https://www.psypnos.fr/respiration-holotropique pour en savoir plus
 
 ═══════════════════════════════════════════
 FORMAT DE RÉPONSE ATTENDU
@@ -995,6 +1021,13 @@ Places restantes: ${options.placesRemaining || 'non précisé'}
 Prix: ${formattedPrice}
 Thématiques: ${seminar.tags.join(', ')}
 Jours avant l'événement: ${daysUntil}
+${seminar.thumbnail ? `Image du séminaire: ${seminar.thumbnail}` : ''}
+
+LIENS DU SITE (À UTILISER):
+- Page d'inscription: https://www.psypnos.fr/inscription-seminaire
+- Page Respiration Holotropique: https://www.psypnos.fr/respiration-holotropique
+→ Facebook/LinkedIn/Twitter: inclure les vrais liens dans le post
+→ Instagram/Threads: mentionner "lien en bio" (qui pointe vers la page d'inscription)
 
 ═══════════════════════════════════════════
 NIVEAU D'URGENCE : ${urgencyLevel}/5 - ${urgencySpec.name}
@@ -1024,7 +1057,8 @@ OBJECTIFS POUR TOUS LES POSTS
 
 1. URGENCE POSITIVE (niveau ${urgencyLevel}/5): ${urgencySpec.examplePhrase}
 2. EXPÉRIENCE UNIQUE: Cadre exceptionnel (${location}), accompagnement de qualité
-3. APPEL À L'ACTION: Inciter à s'inscrire
+3. APPEL À L'ACTION: Inciter à s'inscrire via https://www.psypnos.fr/inscription-seminaire
+4. LIENS: Utiliser les vrais liens du site (inscription + page respiration holotropique)
 
 ═══════════════════════════════════════════
 CONTRAINTES DÉONTOLOGIQUES


### PR DESCRIPTION
## Description

This PR enhances the seminar social media generation system by:

1. **Adding thumbnail support**: Seminars can now include a `thumbnail` field that gets passed through to the prompt builders and returned in generated content as `suggestedMediaUrl`
2. **Explicit site URLs in prompts**: Replaces placeholder references with actual URLs for:
   - Inscription page: `https://www.psypnos.fr/inscription-seminaire`
   - Respiration holotropique page: `https://www.psypnos.fr/respiration-holotropique`
3. **Platform-specific link handling**: Clarifies in prompts how links should be handled per platform:
   - Facebook/LinkedIn/Twitter: Include actual URLs inline
   - Instagram/Threads: Reference "lien en bio"
4. **Comprehensive unit tests**: Added 167 lines of test coverage for the seminar prompt builders

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre

## Test Plan

Added comprehensive unit tests in `seminar-prompt-builder.test.ts` covering:
- System prompt contains required site URLs and Psypnos context
- User prompts include URLs and thumbnail handling for all platforms
- Multi-platform prompts contain proper link instructions per platform type
- Seminar essential information is preserved in all prompt variants

All tests pass with Vitest.

https://claude.ai/code/session_014PAGeqjEKfkjMNjsDqSJKR