### PR TITLE
fix(social): corriger échec publication Instagram — API v18.0 dépréciée

### DIFF
--- a/apps/psypnos/__tests__/unit/social-publishers.test.ts
+++ b/apps/psypnos/__tests__/unit/social-publishers.test.ts
@@ -108,7 +108,7 @@ describe('FacebookPublisher', () => {
     expect(result.error).toContain('Page ID missing');
   });
 
-  it('devrait publier un post texte avec succès', async () => {
+  it('devrait publier un post texte avec succès via Graph API v21.0', async () => {
     mockFetch.mockResolvedValueOnce(mockResponse({ id: '123_456' }));
 
     const result = await publisher.publish(
@@ -122,8 +122,8 @@ describe('FacebookPublisher', () => {
     expect(result.platformUrl).toContain('facebook.com');
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Vérifier l'URL d'appel
-    expect(getCallUrl()).toContain('graph.facebook.com');
+    // Vérifier l'URL d'appel et la version API
+    expect(getCallUrl()).toContain('graph.facebook.com/v21.0');
     expect(getCallUrl()).toContain('page123/feed');
   });
 
@@ -251,9 +251,12 @@ describe('InstagramPublisher', () => {
     expect(result.externalPostId).toBe('media_001');
     expect(result.platformUrl).toBe('https://instagram.com/p/abc123');
     expect(mockFetch).toHaveBeenCalledTimes(4);
+
+    // Vérifier que l'API Graph v21.0 est utilisée
+    expect(getCallUrl(0)).toContain('graph.facebook.com/v21.0');
   });
 
-  it('devrait gérer un échec de création de container', async () => {
+  it("devrait propager le message d'erreur API lors d'un échec de création de container", async () => {
     mockFetch.mockResolvedValueOnce(mockResponse({ error: { message: 'Invalid image' } }, 400));
 
     const result = await publisher.publish(
@@ -264,7 +267,21 @@ describe('InstagramPublisher', () => {
     );
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Failed to create media container');
+    expect(result.error).toBe('Invalid image');
+  });
+
+  it("devrait retourner un message HTTP fallback si aucun message d'erreur API", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({}, 500));
+
+    const result = await publisher.publish(
+      baseInput({
+        mediaUrls: ['https://example.com/bad.jpg'],
+        accountMetadata: { igUserId: 'ig123' },
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('HTTP error 500');
   });
 
   it('devrait gérer un timeout de traitement media', async () => {

--- a/packages/social/src/posting/facebook.ts
+++ b/packages/social/src/posting/facebook.ts
@@ -19,7 +19,7 @@ import type {
   ContentValidationResult,
 } from './types';
 
-const GRAPH_API_VERSION = 'v18.0';
+const GRAPH_API_VERSION = 'v21.0';
 const GRAPH_API_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
 export class FacebookPublisher implements SocialPublisher {

--- a/packages/social/src/posting/instagram.ts
+++ b/packages/social/src/posting/instagram.ts
@@ -20,7 +20,7 @@ import type {
   ContentValidationResult,
 } from './types';
 
-const GRAPH_API_VERSION = 'v18.0';
+const GRAPH_API_VERSION = 'v21.0';
 const GRAPH_API_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
 export class InstagramPublisher implements SocialPublisher {
@@ -87,13 +87,6 @@ export class InstagramPublisher implements SocialPublisher {
 
       const containerId = await this.createMediaContainer(igUserId, imageUrl, caption, accessToken);
 
-      if (!containerId) {
-        return {
-          success: false,
-          error: 'Failed to create media container',
-        };
-      }
-
       // Wait for media processing
       await this.waitForMediaProcessing(containerId, accessToken);
 
@@ -107,12 +100,21 @@ export class InstagramPublisher implements SocialPublisher {
     }
   }
 
+  /**
+   * Crée un media container Instagram via le Graph API.
+   *
+   * @param igUserId - Identifiant Instagram Business/Creator
+   * @param imageUrl - URL publique de l'image
+   * @param caption - Légende du post
+   * @param accessToken - Token d'accès déchiffré
+   * @throws Error si l'API retourne une erreur ou si l'ID est absent
+   */
   private async createMediaContainer(
     igUserId: string,
     imageUrl: string,
     caption: string,
     accessToken: string
-  ): Promise<string | null> {
+  ): Promise<string> {
     const url = `${GRAPH_API_BASE}/${igUserId}/media`;
 
     const fullImageUrl = imageUrl.startsWith('http') ? imageUrl : `${this.baseUrl}${imageUrl}`;
@@ -131,10 +133,14 @@ export class InstagramPublisher implements SocialPublisher {
 
     if (!response.ok) {
       console.error('[InstagramPublisher] Container creation error:', data);
-      return null;
+      throw new Error(data.error?.message || `HTTP error ${response.status}`);
     }
 
-    return data.id || null;
+    if (!data.id) {
+      throw new Error('Instagram API returned no container ID');
+    }
+
+    return data.id;
   }
 
   private async waitForMediaProcessing(


### PR DESCRIPTION
## Summary
- Met à jour Graph API de v18.0 à v21.0 dans les publishers Instagram et Facebook (v18.0 dépréciée depuis août 2025)
- Corrige la propagation d'erreur dans `InstagramPublisher.createMediaContainer` : l'erreur API réelle est maintenant remontée au lieu du message générique "Failed to create media container"
- Ajoute des tests pour la propagation d'erreur et la vérification de la version API

## Test plan
- [x] Tests unitaires publishers : 30/30 passent
- [x] Tests couverture globaux : 546/546 passent (89.78%)
- [x] Tests UI : 110/110 passent
- [x] Build complet psypnos : OK
- [x] Type-check : OK

Fixes #240

https://claude.ai/code/session_01WL43AWEmSXFoG7riZmSgH8