### PR TITLE
fix(db): activer RLS sur toutes les tables PostgreSQL

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -28,7 +28,8 @@
     "db:migrate:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
     "db:seed": "tsx src/seed.ts",
-    "db:reset": "prisma migrate reset --force"
+    "db:reset": "prisma migrate reset --force",
+    "db:enable-rls": "prisma db execute --file prisma/sql/enable-rls.sql"
   },
   "dependencies": {
     "@prisma/client": "^6.0.0"

--- a/packages/db/prisma/sql/enable-rls.sql
+++ b/packages/db/prisma/sql/enable-rls.sql
@@ -1,0 +1,88 @@
+-- =============================================================================
+-- ENABLE ROW LEVEL SECURITY (RLS) ON ALL TABLES
+-- =============================================================================
+-- Fixes Supabase alerts: rls_disabled_in_public + sensitive_columns_exposed
+-- See: https://github.com/dduquenne/kairn/issues/252
+--
+-- Context:
+--   Supabase exposes all tables in the `public` schema via PostgREST API.
+--   Without RLS, anyone with the anon key can read/write all data.
+--
+-- Strategy:
+--   - Enable RLS on every table (deny-all by default for non-owner roles)
+--   - No permissive policies created (the app uses Prisma via DATABASE_URL,
+--     which connects as the table owner and bypasses RLS automatically)
+--   - PostgREST roles (anon, authenticated) are effectively blocked
+--
+-- Rollback:
+--   Replace ENABLE with DISABLE in each statement below.
+-- =============================================================================
+
+-- Multi-tenancy
+ALTER TABLE "Site" ENABLE ROW LEVEL SECURITY;
+
+-- Authentication & Sessions
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Session" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "RefreshToken" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "SecretKey" ENABLE ROW LEVEL SECURITY;
+
+-- Blog
+ALTER TABLE "BlogPost" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Tag" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BlogPostTag" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BlogPostExtended" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BlogAnalytics" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BlogFaqClick" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BlogCtaClick" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BlogGenerationJob" ENABLE ROW LEVEL SECURITY;
+
+-- Testimonials & Contact
+ALTER TABLE "Testimonial" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Contact" ENABLE ROW LEVEL SECURITY;
+
+-- Analytics
+ALTER TABLE "AnalyticsEvent" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsDailySummary" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "VisitorGeolocation" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsGoal" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsGoalCompletion" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsAlert" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsAlertHistory" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsAnomaly" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsDashboardConfig" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AnalyticsScheduledReport" ENABLE ROW LEVEL SECURITY;
+
+-- Seminars & Appointments
+ALTER TABLE "Seminar" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Appointment" ENABLE ROW LEVEL SECURITY;
+
+-- Social
+ALTER TABLE "SocialAccount" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "SocialPost" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "SocialPostAnalytics" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "SocialAccountSnapshot" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "SocialTemplate" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "SocialGenerationLog" ENABLE ROW LEVEL SECURITY;
+
+-- Visitors & Bots
+ALTER TABLE "BotVisit" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "NavigationHistory" ENABLE ROW LEVEL SECURITY;
+
+-- Experiments (A/B Testing)
+ALTER TABLE "Experiment" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "ExperimentVariant" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "ExperimentAssignment" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "ExperimentResult" ENABLE ROW LEVEL SECURITY;
+
+-- Chat
+ALTER TABLE "ChatConversation" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "ChatMessage" ENABLE ROW LEVEL SECURITY;
+
+-- Infrastructure
+ALTER TABLE "Deployment" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "MaintenanceMode" ENABLE ROW LEVEL SECURITY;
+
+-- Push Notifications
+ALTER TABLE "PushSubscription" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PushNotificationLog" ENABLE ROW LEVEL SECURITY;

--- a/packages/db/src/__tests__/enable-rls.test.ts
+++ b/packages/db/src/__tests__/enable-rls.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Extracts model names from the Prisma schema file.
+ * Parses lines matching `model <Name> {` and returns the list of names.
+ */
+function extractPrismaModels(schemaPath: string): string[] {
+  const schema = readFileSync(schemaPath, 'utf-8');
+  const modelRegex = /^model\s+(\w+)\s+\{/gm;
+  const models: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = modelRegex.exec(schema)) !== null) {
+    models.push(match[1] as string);
+  }
+  return models.sort();
+}
+
+/**
+ * Extracts table names from the enable-rls.sql migration file.
+ * Parses lines matching `ALTER TABLE "TableName" ENABLE ROW LEVEL SECURITY;`.
+ */
+function extractRlsTables(sqlPath: string): string[] {
+  const sql = readFileSync(sqlPath, 'utf-8');
+  const alterRegex = /ALTER\s+TABLE\s+"(\w+)"\s+ENABLE\s+ROW\s+LEVEL\s+SECURITY/gi;
+  const tables: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = alterRegex.exec(sql)) !== null) {
+    tables.push(match[1] as string);
+  }
+  return tables.sort();
+}
+
+const DB_PACKAGE_ROOT = resolve(__dirname, '../..');
+const SCHEMA_PATH = resolve(DB_PACKAGE_ROOT, 'prisma/schema.prisma');
+const RLS_SQL_PATH = resolve(DB_PACKAGE_ROOT, 'prisma/sql/enable-rls.sql');
+
+describe('enable-rls.sql', () => {
+  const prismaModels = extractPrismaModels(SCHEMA_PATH);
+  const rlsTables = extractRlsTables(RLS_SQL_PATH);
+
+  it('should contain valid ALTER TABLE statements', () => {
+    expect(rlsTables.length).toBeGreaterThan(0);
+  });
+
+  it('should cover every Prisma model with an ENABLE ROW LEVEL SECURITY statement', () => {
+    const missingTables = prismaModels.filter(model => !rlsTables.includes(model));
+    expect(missingTables).toEqual([]);
+  });
+
+  it('should not reference tables that do not exist in the Prisma schema', () => {
+    const extraTables = rlsTables.filter(table => !prismaModels.includes(table));
+    expect(extraTables).toEqual([]);
+  });
+
+  it('should not have duplicate ALTER TABLE statements', () => {
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+    for (const table of rlsTables) {
+      if (seen.has(table)) {
+        duplicates.push(table);
+      }
+      seen.add(table);
+    }
+    expect(duplicates).toEqual([]);
+  });
+
+  it('should use ENABLE (not DISABLE) for all tables', () => {
+    const sql = readFileSync(RLS_SQL_PATH, 'utf-8');
+    const disableMatches = sql.match(/ALTER\s+TABLE\s+"\w+"\s+DISABLE\s+ROW\s+LEVEL\s+SECURITY/gi);
+    expect(disableMatches).toBeNull();
+  });
+});


### PR DESCRIPTION
Corrige les 42 alertes Supabase rls_disabled_in_public et l'alerte sensitive_columns_exposed sur SecretKey.secret.

Ajoute enable-rls.sql qui active ROW LEVEL SECURITY sur les 45 tables du schéma public. Sans politique permissive, les rôles PostgREST (anon, authenticated) sont bloqués par défaut. Le rôle propriétaire utilisé par Prisma via DATABASE_URL bypass RLS automatiquement.

Ajoute un test de cohérence qui vérifie que chaque modèle Prisma est couvert par le SQL RLS et un script npm db:enable-rls pour appliquer.

Fixes #252

https://claude.ai/code/session_01EmLpXyePmT3evi3edwocmt

## Description

<!-- Décrivez les changements apportés -->

## Type de changement

- [ ] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [ ] Mon code suit les conventions du projet
- [ ] J'ai testé mes changements localement
- [ ] J'ai mis à jour la documentation si nécessaire
- [ ] Les types TypeScript sont corrects
- [ ] Pas de nouvelles erreurs ESLint
- [ ] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [ ] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->
