### PR TITLE
fix(db): ajouter --schema au script db:enable-rls

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,7 +29,7 @@
     "db:studio": "prisma studio",
     "db:seed": "tsx src/seed.ts",
     "db:reset": "prisma migrate reset --force",
-    "db:enable-rls": "prisma db execute --file prisma/sql/enable-rls.sql"
+    "db:enable-rls": "prisma db execute --file prisma/sql/enable-rls.sql --schema prisma/schema.prisma"
   },
   "dependencies": {
     "@prisma/client": "^6.0.0"


### PR DESCRIPTION
## Summary
- Adds the required `--schema prisma/schema.prisma` flag to the `db:enable-rls` script so that `prisma db execute` can locate the datasource URL from the schema file.

## Test plan
- [x] Run `pnpm --filter @kairn/db db:enable-rls` — should connect to the database and apply RLS statements without the `Either --url or --schema must be provided` error.

Fixes the post-merge execution error reported on #252.

https://claude.ai/code/session_01EmLpXyePmT3evi3edwocmt