### PR TITLE
fix(db): remplacer npx par prisma dans enable-rls

### DIFF
--- a/packages/db/src/enable-rls.ts
+++ b/packages/db/src/enable-rls.ts
@@ -53,7 +53,7 @@ if (!databaseUrl) {
 }
 
 console.warn('Applying RLS migration...');
-execSync(`npx prisma db execute --file "${SQL_FILE}" --url "${databaseUrl}"`, {
+execSync(`prisma db execute --file "${SQL_FILE}" --url "${databaseUrl}"`, {
   stdio: 'inherit',
   cwd: PACKAGE_ROOT,
 });


### PR DESCRIPTION
Remplace `npx prisma` par `prisma` directement. npx déclenche npm qui bloque sur la résolution de paquets. prisma est déjà installé comme devDependency et disponible via node_modules/.bin quand pnpm exécute le script.

https://claude.ai/code/session_01EmLpXyePmT3evi3edwocmt