### PR TITLE
Fix infinite re-render loop in fetchInsights callback

### DIFF
--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -427,6 +427,7 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const isLoadingInsightsRef = useRef(false);
 
   // Mode simulation
   let simulationContext: ReturnType<typeof useSimulation> | null = null;
@@ -953,9 +954,12 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
   }, [fetchData]);
 
   // Lazy-load insights (Claude API call — 3-15s latency)
-  // Called on demand when the user opens the InsightsDrawer
+  // Called on demand when the user opens the InsightsDrawer.
+  // Uses a ref for the concurrency guard so the callback reference stays stable
+  // and does not cause infinite re-render loops in consumer useEffects.
   const fetchInsights = useCallback(async () => {
-    if (isLoadingInsights) return;
+    if (isLoadingInsightsRef.current) return;
+    isLoadingInsightsRef.current = true;
     setIsLoadingInsights(true);
     try {
       const timeRange = mapPeriodToTimeRange(period);
@@ -983,9 +987,10 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
     } catch (err) {
       console.error('Error fetching insights:', err);
     } finally {
+      isLoadingInsightsRef.current = false;
       setIsLoadingInsights(false);
     }
-  }, [period, customStartDate, customEndDate, isLoadingInsights]);
+  }, [period, customStartDate, customEndDate]);
 
   return {
     data,


### PR DESCRIPTION
## Description

Fixes an infinite re-render loop in the `fetchInsights` callback by using a ref-based concurrency guard instead of relying on the `isLoadingInsights` state variable in the dependency array.

### Problem
The `fetchInsights` callback was including `isLoadingInsights` in its dependency array, which caused the callback reference to change whenever the loading state updated. This triggered infinite re-render loops in consumer components that depend on the callback reference (e.g., in `useEffect` dependencies).

### Solution
- Introduced `isLoadingInsightsRef` to track the loading state without affecting the callback's reference stability
- Removed `isLoadingInsights` from the dependency array of `fetchInsights`
- The callback reference now remains stable across re-renders, preventing cascading re-render loops in consumers
- State updates to `setIsLoadingInsights` continue to work as expected for UI updates

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [ ] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

## Test Plan

The fix prevents re-render loops that would occur when `fetchInsights` is used as a dependency in consumer `useEffect` hooks. Verify that opening the InsightsDrawer and triggering insight fetches no longer causes excessive re-renders or console warnings about dependency arrays.

https://claude.ai/code/session_01CwjfZKcn6ZA9HKn5zs19b3