### PR TITLE
fix(deploy): documenter et diagnostiquer la limite Hobby Vercel

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -11,7 +11,7 @@ Ce guide décrit les étapes pour déployer un site Kairn sur Vercel avec QStash
 
 ## Prérequis
 
-1. Compte Vercel (Pro recommandé)
+1. **Compte Vercel Pro (obligatoire)** — le plan Hobby est limité à 12 Serverless Functions par déploiement, ce qui est insuffisant pour l'application (~200 routes dynamiques + API). Sans le plan Pro, le déploiement échouera avec l'erreur : `No more than 12 Serverless Functions can be added to a Deployment on the Hobby plan.`
 2. Compte Upstash avec QStash activé
 3. Base de données PostgreSQL (Supabase)
 4. Node.js 22+ et pnpm 10+
@@ -203,6 +203,28 @@ Pour déployer un nouveau site (ex: unanima) :
 1. Vérifiez que toutes les variables d'environnement sont définies
 2. Assurez-vous que la base de données est accessible
 3. Vérifiez les logs de build dans Vercel
+
+### Erreur "No more than 12 Serverless Functions"
+
+```
+Error: No more than 12 Serverless Functions can be added to a Deployment on the Hobby plan.
+```
+
+Cette erreur signifie que le projet Vercel est sur le **plan Hobby**, qui limite à 12 Serverless Functions par déploiement. L'application Kairn génère ~200 routes dynamiques (pages + API), chacune compilée en Serverless Function.
+
+**Solution** : Passer le projet au **plan Pro** dans les paramètres Vercel :
+
+1. Aller dans Vercel Dashboard → Settings → Billing
+2. Upgrader vers le plan Pro (ou Team)
+3. Relancer le déploiement
+
+**Vérification locale** : Avant de déployer, vérifiez les limites avec :
+
+```bash
+pnpm check:vercel -- --app psypnos --plan hobby
+# ou pour vérifier les limites Pro :
+pnpm check:vercel -- --app psypnos --plan pro
+```
 
 ## Maintenance
 

--- a/apps/psypnos/package.json
+++ b/apps/psypnos/package.json
@@ -3,6 +3,9 @@
   "version": "1.7.22",
   "private": true,
   "description": "Site PSYPNOS - Psychothérapie, Hypnose & Respiration Holotropique",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,css}\"",
     "audit": "pnpm audit --audit-level=moderate",
     "prepare": "husky || true",
-    "preinstall": "npx only-allow pnpm"
+    "preinstall": "npx only-allow pnpm",
+    "check:vercel": "tsx scripts/check-vercel-limits.ts"
   },
   "devDependencies": {
     "@axe-core/react": "^4.11.1",

--- a/scripts/check-vercel-limits.ts
+++ b/scripts/check-vercel-limits.ts
@@ -1,0 +1,232 @@
+/**
+ * Script de vérification des limites Vercel avant déploiement.
+ *
+ * Vérifie que le build Next.js ne dépasse pas les limites du plan Vercel,
+ * notamment le nombre de Serverless Functions (12 max sur Hobby, illimité sur Pro).
+ *
+ * Usage :
+ *   pnpm tsx scripts/check-vercel-limits.ts --app psypnos [--plan pro]
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const VERCEL_LIMITS = {
+  hobby: {
+    maxServerlessFunctions: 12,
+    maxEdgeFunctions: 1,
+    maxFunctionSizeMB: 50,
+    label: 'Hobby',
+  },
+  pro: {
+    maxServerlessFunctions: Infinity,
+    maxEdgeFunctions: Infinity,
+    maxFunctionSizeMB: 250,
+    label: 'Pro',
+  },
+} as const;
+
+type Plan = keyof typeof VERCEL_LIMITS;
+
+interface CheckResult {
+  ok: boolean;
+  serverlessFunctionCount: number;
+  edgeFunctionCount: number;
+  maxFunctionSizeMB: number;
+  plan: Plan;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Compte les Serverless Functions dans le build Next.js
+ */
+function countFunctions(nextOutputDir: string): {
+  serverless: number;
+  edge: number;
+  maxSizeMB: number;
+} {
+  const serverDir = path.join(nextOutputDir, 'server', 'app');
+  let serverless = 0;
+  let edge = 0;
+  let maxSizeMB = 0;
+
+  if (!fs.existsSync(serverDir)) {
+    console.error(`Répertoire introuvable : ${serverDir}`);
+    console.error("Exécutez d'abord : pnpm turbo run build --filter=@kairn/<app>");
+    process.exit(1);
+  }
+
+  /**
+   * Parcourt récursivement le répertoire pour compter les fichiers route.js et page.js
+   */
+  function walk(dir: string): void {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.name === 'route.js' || entry.name === 'page.js') {
+        // Vérifier si c'est un fichier dynamique (Serverless Function)
+        const nftPath = `${fullPath}.nft.json`;
+        if (fs.existsSync(nftPath)) {
+          serverless++;
+
+          // Estimer la taille via le fichier nft.json
+          try {
+            const nft = JSON.parse(fs.readFileSync(nftPath, 'utf-8'));
+            const files: string[] = nft.files || [];
+            let totalSize = 0;
+            const base = path.dirname(nftPath);
+            for (const f of files) {
+              try {
+                totalSize += fs.statSync(path.join(base, f)).size;
+              } catch {
+                // fichier non trouvé, ignorer
+              }
+            }
+            const sizeMB = totalSize / 1024 / 1024;
+            if (sizeMB > maxSizeMB) {
+              maxSizeMB = sizeMB;
+            }
+          } catch {
+            // Erreur de parsing, ignorer
+          }
+        }
+      }
+    }
+  }
+
+  // Vérifier les Edge Functions
+  const edgeDir = path.join(nextOutputDir, 'server', 'edge');
+  if (fs.existsSync(edgeDir)) {
+    const middlewareManifest = path.join(nextOutputDir, 'server', 'middleware-manifest.json');
+    if (fs.existsSync(middlewareManifest)) {
+      try {
+        const manifest = JSON.parse(fs.readFileSync(middlewareManifest, 'utf-8'));
+        edge = Object.keys(manifest.middleware || {}).length;
+      } catch {
+        // Erreur de parsing
+      }
+    }
+  }
+
+  walk(serverDir);
+  return { serverless, edge, maxSizeMB: Math.round(maxSizeMB * 10) / 10 };
+}
+
+/**
+ * Vérifie les limites Vercel pour le build
+ */
+function checkLimits(appName: string, plan: Plan): CheckResult {
+  const nextOutputDir = path.resolve(`apps/${appName}/.next`);
+  const limits = VERCEL_LIMITS[plan];
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!fs.existsSync(nextOutputDir)) {
+    return {
+      ok: false,
+      serverlessFunctionCount: 0,
+      edgeFunctionCount: 0,
+      maxFunctionSizeMB: 0,
+      plan,
+      errors: [`Build introuvable : ${nextOutputDir}. Exécutez le build d'abord.`],
+      warnings: [],
+    };
+  }
+
+  const { serverless, edge, maxSizeMB } = countFunctions(nextOutputDir);
+
+  if (serverless > limits.maxServerlessFunctions) {
+    errors.push(
+      `Nombre de Serverless Functions (${serverless}) dépasse la limite du plan ${limits.label} (${limits.maxServerlessFunctions}). ` +
+        'Passez au plan Pro ou réduisez le nombre de routes dynamiques.'
+    );
+  }
+
+  if (edge > limits.maxEdgeFunctions) {
+    errors.push(
+      `Nombre d'Edge Functions (${edge}) dépasse la limite du plan ${limits.label} (${limits.maxEdgeFunctions}).`
+    );
+  }
+
+  if (maxSizeMB > limits.maxFunctionSizeMB) {
+    errors.push(
+      `Plus grande fonction (${maxSizeMB} MB) dépasse la limite du plan ${limits.label} (${limits.maxFunctionSizeMB} MB).`
+    );
+  }
+
+  // Warnings pour le plan Pro
+  if (plan === 'pro' && maxSizeMB > 200) {
+    warnings.push(
+      `Plus grande fonction (${maxSizeMB} MB) approche de la limite de 250 MB. Envisagez d'optimiser les imports.`
+    );
+  }
+
+  if (plan === 'hobby' && serverless > 10) {
+    warnings.push(
+      `${serverless} Serverless Functions détectées. Le plan Hobby est limité à 12. Passez au plan Pro.`
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    serverlessFunctionCount: serverless,
+    edgeFunctionCount: edge,
+    maxFunctionSizeMB: maxSizeMB,
+    plan,
+    errors,
+    warnings,
+  };
+}
+
+// --- CLI ---
+const args = process.argv.slice(2);
+let appName = 'psypnos';
+let plan: Plan = 'hobby';
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--app' && args[i + 1]) {
+    appName = args[i + 1];
+    i++;
+  } else if (args[i] === '--plan' && args[i + 1]) {
+    plan = args[i + 1] as Plan;
+    i++;
+  }
+}
+
+if (!(plan in VERCEL_LIMITS)) {
+  console.error(`Plan inconnu : ${plan}. Utilisez 'hobby' ou 'pro'.`);
+  process.exit(1);
+}
+
+console.log(`\n🔍 Vérification des limites Vercel (plan ${VERCEL_LIMITS[plan].label})...\n`);
+console.log(`   Application : @kairn/${appName}`);
+console.log(`   Build : apps/${appName}/.next\n`);
+
+const result = checkLimits(appName, plan);
+
+console.log(`📊 Résultats :`);
+console.log(`   Serverless Functions : ${result.serverlessFunctionCount}`);
+console.log(`   Edge Functions : ${result.edgeFunctionCount}`);
+console.log(`   Plus grande fonction : ${result.maxFunctionSizeMB} MB\n`);
+
+if (result.warnings.length > 0) {
+  console.log('⚠️  Avertissements :');
+  for (const w of result.warnings) {
+    console.log(`   - ${w}`);
+  }
+  console.log();
+}
+
+if (result.errors.length > 0) {
+  console.log('❌ Erreurs :');
+  for (const e of result.errors) {
+    console.log(`   - ${e}`);
+  }
+  console.log();
+  process.exit(1);
+} else {
+  console.log('✅ Toutes les vérifications passent.\n');
+}


### PR DESCRIPTION
## Résumé

- **Cause racine** : Vercel a commencé à appliquer strictement la limite de 12 Serverless Functions du plan Hobby. L'application génère ~196 fonctions (routes dynamiques + API), bien au-delà de cette limite.
- **Preuve** : les builds réussi (`be56cb5`) et échoué (`f7b649b`) sont identiques jusqu'à l'étape « Deploying outputs » — seul le dernier reçoit l'erreur de limite.
- **Résolution définitive** : passer au plan **Vercel Pro** (Settings → Billing).

## Changements

- `DEPLOYMENT.md` : documenter le prérequis Pro comme obligatoire + section troubleshooting dédiée
- `scripts/check-vercel-limits.ts` : script de vérification pré-déploiement (compte les Serverless Functions vs limites du plan)
- `package.json` : ajouter le script `check:vercel`
- `apps/psypnos/package.json` : ajouter `engines.node >= 22` (cohérence avec `.nvmrc`)

## Test plan

- [ ] Exécuter `pnpm check:vercel -- --app psypnos --plan hobby` → doit échouer avec erreur
- [ ] Exécuter `pnpm check:vercel -- --app psypnos --plan pro` → doit passer
- [ ] Upgrader le plan Vercel vers Pro
- [ ] Relancer le déploiement → doit réussir

Fixes #261

https://claude.ai/code/session_01RpU7r1eRh36BjfsJdiiCYc