### PR TITLE
Replace setImmediate with after() for blog job worker execution

### DIFF
--- a/apps/psypnos/__tests__/unit/blog-jobs-route.test.ts
+++ b/apps/psypnos/__tests__/unit/blog-jobs-route.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests unitaires pour la route /api/blog/jobs.
+ *
+ * Vérifie que :
+ * - Le worker de génération est lancé via after() (et non setImmediate)
+ * - maxDuration est correctement exporté à 300
+ * - Les cas d'erreur sont gérés (auth, validation, clé API manquante)
+ * - Le job est créé en base avec le bon statut initial
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks hoistés — vi.hoisted() évite les erreurs de référence ──
+
+const { mockAfter, mockCreate, mockFindMany, mockWithAdminAuth, mockRunWorker } = vi.hoisted(
+  () => ({
+    mockAfter: vi.fn(),
+    mockCreate: vi.fn(),
+    mockFindMany: vi.fn(),
+    mockWithAdminAuth: vi.fn(),
+    mockRunWorker: vi.fn(),
+  })
+);
+
+// ─── Mocks — déclarés AVANT les imports ───────────────────────────
+
+vi.mock('next/server', () => ({
+  after: (...args: unknown[]) => mockAfter(...args),
+  NextRequest: vi.fn(),
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}));
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    blogGenerationJob: {
+      create: mockCreate,
+      findMany: mockFindMany,
+    },
+  },
+}));
+
+vi.mock('../../app/api/auth/middleware', () => ({
+  withAdminAuth: () => mockWithAdminAuth(),
+}));
+
+vi.mock('../../app/api/blog/jobs/worker', () => ({
+  runBlogGenerationWorker: (...args: unknown[]) => mockRunWorker(...args),
+}));
+
+// ─── Imports (après les mocks) ────────────────────────────────────
+
+import { POST, maxDuration } from '../../app/api/blog/jobs/route';
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+/** Crée une fausse NextRequest avec un body JSON */
+function createRequest(body: Record<string, unknown>) {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+    nextUrl: { searchParams: new URLSearchParams() },
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+const VALID_BODY = {
+  topic: 'Les bienfaits de la méditation',
+  category: 'Comprendre',
+  targetLength: 'medium',
+  preferredTones: ['pédagogique'],
+  usePsypnosStyle: true,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+describe('/api/blog/jobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWithAdminAuth.mockResolvedValue({ error: null });
+    process.env.ANTHROPIC_API_KEY = 'test-key-123';
+
+    mockCreate.mockResolvedValue({
+      id: 'job-abc-123',
+      status: 'PENDING',
+      input: VALID_BODY,
+      progress: 0,
+      currentStep: 'En attente de traitement',
+      totalSteps: 9,
+    });
+
+    mockRunWorker.mockResolvedValue(undefined);
+  });
+
+  describe('maxDuration', () => {
+    it('doit être exporté à 300 secondes pour supporter la génération complète', () => {
+      expect(maxDuration).toBe(300);
+    });
+  });
+
+  describe('POST — Cas nominal', () => {
+    it('doit créer un job et lancer le worker via after()', async () => {
+      const request = createRequest(VALID_BODY);
+      const response = await POST(request);
+
+      // Vérifie que le job est créé en BDD
+      expect(mockCreate).toHaveBeenCalledOnce();
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'PENDING',
+            progress: 0,
+            totalSteps: 9,
+          }),
+        })
+      );
+
+      // Vérifie que after() est appelé (et non setImmediate)
+      expect(mockAfter).toHaveBeenCalledOnce();
+      expect(mockAfter).toHaveBeenCalledWith(expect.any(Function));
+
+      // Vérifie la réponse
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          jobId: 'job-abc-123',
+          status: 'PENDING',
+        })
+      );
+    });
+
+    it('doit appeler runBlogGenerationWorker quand le callback after() est exécuté', async () => {
+      const request = createRequest(VALID_BODY);
+      await POST(request);
+
+      // Récupérer et exécuter le callback passé à after()
+      const afterCallback = mockAfter.mock.calls[0]?.[0] as (() => Promise<void>) | undefined;
+      expect(afterCallback).toBeDefined();
+      await afterCallback!();
+
+      expect(mockRunWorker).toHaveBeenCalledOnce();
+      expect(mockRunWorker).toHaveBeenCalledWith('job-abc-123', 'test-key-123');
+    });
+
+    it('doit gérer les erreurs du worker sans les propager', async () => {
+      mockRunWorker.mockRejectedValue(new Error('Worker crash'));
+
+      const request = createRequest(VALID_BODY);
+      await POST(request);
+
+      // Exécuter le callback after() — ne doit pas throw
+      const afterCallback = mockAfter.mock.calls[0]?.[0] as (() => Promise<void>) | undefined;
+      expect(afterCallback).toBeDefined();
+      await expect(afterCallback!()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("POST — Cas d'erreur", () => {
+    it("doit retourner 401 si l'authentification échoue", async () => {
+      const errorResponse = { status: 401, body: { message: 'Non autorisé' } };
+      mockWithAdminAuth.mockResolvedValue({ error: errorResponse });
+
+      const request = createRequest(VALID_BODY);
+      const response = await POST(request);
+
+      expect(response).toBe(errorResponse);
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockAfter).not.toHaveBeenCalled();
+    });
+
+    it('doit retourner 400 si le topic est manquant', async () => {
+      const request = createRequest({ ...VALID_BODY, topic: '' });
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockAfter).not.toHaveBeenCalled();
+    });
+
+    it('doit retourner 400 si la catégorie est invalide', async () => {
+      const request = createRequest({ ...VALID_BODY, category: 'Invalide' });
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('doit retourner 500 si ANTHROPIC_API_KEY est manquante', async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+
+      const request = createRequest(VALID_BODY);
+      const response = await POST(request);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual(
+        expect.objectContaining({ message: "Le service n'est pas configuré." })
+      );
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('doit retourner 500 si la création du job en BDD échoue', async () => {
+      mockCreate.mockRejectedValue(new Error('DB connection error'));
+
+      const request = createRequest(VALID_BODY);
+      const response = await POST(request);
+
+      expect(response.status).toBe(500);
+      expect(mockAfter).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/psypnos/app/api/blog/jobs/route.ts
+++ b/apps/psypnos/app/api/blog/jobs/route.ts
@@ -9,23 +9,29 @@
  * GET - Lister les jobs récents
  */
 
-import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
+import { after, NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
-import { prisma } from "@/lib/db/prisma";
+import { prisma } from '@/lib/db/prisma';
 
-import { withAdminAuth } from "../../auth/middleware";
+import { withAdminAuth } from '../../auth/middleware';
 
-import { runBlogGenerationWorker } from "./worker";
+import { runBlogGenerationWorker } from './worker';
+
+/**
+ * Timeout Vercel — la génération sectionnelle enchaîne 8-12 appels Claude API
+ * séquentiels, chacun pouvant prendre jusqu'à 90 secondes.
+ */
+export const maxDuration = 300;
 
 /**
  * Schéma de validation pour les paramètres de génération
  */
 const createJobSchema = z.object({
-  topic: z.string().trim().min(1, "Le sujet est requis"),
-  category: z.enum(["Comprendre", "Traverser", "Découvrir", "Cheminer"]),
-  targetLength: z.enum(["short", "medium", "long"]).optional().default("medium"),
-  editorialCategory: z.enum(["Comprendre", "Traverser", "Découvrir", "Cheminer"]).optional(),
+  topic: z.string().trim().min(1, 'Le sujet est requis'),
+  category: z.enum(['Comprendre', 'Traverser', 'Découvrir', 'Cheminer']),
+  targetLength: z.enum(['short', 'medium', 'long']).optional().default('medium'),
+  editorialCategory: z.enum(['Comprendre', 'Traverser', 'Découvrir', 'Cheminer']).optional(),
   preferredTones: z.array(z.string()).optional(),
   tones: z.array(z.string()).optional(),
   seoQuery: z.string().trim().optional(),
@@ -61,60 +67,58 @@ export async function POST(request: NextRequest) {
     if (!parsed.success) {
       const firstError = parsed.error.issues[0];
       return NextResponse.json(
-        { message: firstError?.message ?? "Données invalides." },
+        { message: firstError?.message ?? 'Données invalides.' },
         { status: 400 }
       );
     }
 
     input = parsed.data;
   } catch (error) {
-    return NextResponse.json({ message: "Données invalides." }, { status: 400 });
+    return NextResponse.json({ message: 'Données invalides.' }, { status: 400 });
   }
 
   // Vérifier la clé API Anthropic
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     console.error("[BlogJob] ANTHROPIC_API_KEY n'est pas configurée");
-    return NextResponse.json(
-      { message: "Le service n'est pas configuré." },
-      { status: 500 }
-    );
+    return NextResponse.json({ message: "Le service n'est pas configuré." }, { status: 500 });
   }
 
   try {
     // Créer le job en base de données
     const job = await prisma.blogGenerationJob.create({
       data: {
-        status: "PENDING",
+        status: 'PENDING',
         input: input as any, // JSON
         progress: 0,
-        currentStep: "En attente de traitement",
+        currentStep: 'En attente de traitement',
         totalSteps: 9,
       },
     });
 
     console.log(`[BlogJob] Job créé: ${job.id}`);
 
-    // Lancer le worker en arrière-plan (sans attendre)
-    // Utilisation de setImmediate pour ne pas bloquer la réponse HTTP
-    setImmediate(() => {
-      runBlogGenerationWorker(job.id, apiKey).catch((error) => {
+    // Lancer le worker en arrière-plan via after() de Next.js
+    // after() utilise waitUntil() sous le capot sur Vercel, ce qui garantit
+    // que la Serverless Function reste active jusqu'à la fin du worker,
+    // même après l'envoi de la réponse HTTP.
+    after(async () => {
+      try {
+        await runBlogGenerationWorker(job.id, apiKey);
+      } catch (error) {
         console.error(`[BlogJob] Erreur worker pour job ${job.id}:`, error);
-      });
+      }
     });
 
     // Retourner immédiatement l'ID du job
     return NextResponse.json({
       jobId: job.id,
       status: job.status,
-      message: "Job de génération créé avec succès",
+      message: 'Job de génération créé avec succès',
     });
   } catch (error) {
-    console.error("[BlogJob] Erreur création job:", error);
-    return NextResponse.json(
-      { message: "Erreur lors de la création du job" },
-      { status: 500 }
-    );
+    console.error('[BlogJob] Erreur création job:', error);
+    return NextResponse.json({ message: 'Erreur lors de la création du job' }, { status: 500 });
   }
 }
 
@@ -132,16 +136,16 @@ export async function GET(request: NextRequest) {
   if (authResult.error) return authResult.error;
 
   const searchParams = request.nextUrl.searchParams;
-  const limitParam = searchParams.get("limit");
-  const statusParam = searchParams.get("status");
+  const limitParam = searchParams.get('limit');
+  const statusParam = searchParams.get('status');
 
   const limit = limitParam ? Math.min(parseInt(limitParam, 10), 100) : 20;
-  const status = statusParam as "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED" | null;
+  const status = statusParam as 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED' | null;
 
   try {
     const jobs = await prisma.blogGenerationJob.findMany({
       where: status ? { status } : undefined,
-      orderBy: { createdAt: "desc" },
+      orderBy: { createdAt: 'desc' },
       take: limit,
       select: {
         id: true,
@@ -164,7 +168,7 @@ export async function GET(request: NextRequest) {
     // Extraire le topic de l'input pour l'affichage
     const jobsWithTopic = jobs.map((job: (typeof jobs)[number]) => ({
       ...job,
-      topic: (job.input as Record<string, unknown>)?.topic || "Sans titre",
+      topic: (job.input as Record<string, unknown>)?.topic || 'Sans titre',
     }));
 
     return NextResponse.json({
@@ -172,9 +176,9 @@ export async function GET(request: NextRequest) {
       total: jobsWithTopic.length,
     });
   } catch (error) {
-    console.error("[BlogJob] Erreur liste jobs:", error);
+    console.error('[BlogJob] Erreur liste jobs:', error);
     return NextResponse.json(
-      { message: "Erreur lors de la récupération des jobs" },
+      { message: 'Erreur lors de la récupération des jobs' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Description

Replace `setImmediate()` with Next.js's `after()` API for launching the blog generation worker in the background. This ensures the Serverless Function remains active until the worker completes, leveraging Vercel's `waitUntil()` mechanism under the hood.

Additionally:
- Export `maxDuration = 300` to support the full generation pipeline (8-12 sequential Claude API calls)
- Add comprehensive unit tests for the `/api/blog/jobs` route covering nominal cases, error handling, and worker execution
- Normalize string quotes to single quotes throughout the file

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre

## Test Plan

Added 212 lines of comprehensive unit tests covering:
- `maxDuration` export validation
- Nominal case: job creation and worker execution via `after()`
- Worker error handling without propagation
- Authentication failures (401)
- Input validation failures (400)
- Missing API key configuration (500)
- Database creation errors (500)

All tests use Vitest mocks to isolate the route handler and verify correct integration with Next.js's `after()` API.

https://claude.ai/code/session_019JHDgYUHC8wGCnXDiq4TEe