### PR TITLE
fix(blog): corriger la persistance de publishedAt et le cache admin

### DIFF
--- a/apps/psypnos/__tests__/unit/blog-prisma-store.test.ts
+++ b/apps/psypnos/__tests__/unit/blog-prisma-store.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests unitaires pour le store Prisma du blog.
+ *
+ * Vérifie que :
+ * - La date de publication (publishedAt) est toujours persistée, même pour les brouillons
+ * - Les modifications d'un article sont correctement enregistrées
+ * - Le formatage de sortie retourne la bonne date
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks hoistés — vi.hoisted() évite les erreurs de référence ──
+
+const {
+  mockFindUnique,
+  mockCreate,
+  mockUpdate,
+  mockFindMany,
+  mockGetSiteId,
+  mockTagFindUnique,
+  mockTagCreate,
+} = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockCreate: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockFindMany: vi.fn(),
+  mockGetSiteId: vi.fn(),
+  mockTagFindUnique: vi.fn(),
+  mockTagCreate: vi.fn(),
+}));
+
+// ─── Mocks — déclarés AVANT les imports ───────────────────────────
+
+vi.mock('@/lib/db/prisma', () => ({
+  default: {
+    blogPost: {
+      findUnique: mockFindUnique,
+      create: mockCreate,
+      update: mockUpdate,
+      findMany: mockFindMany,
+    },
+    tag: {
+      findUnique: mockTagFindUnique,
+      create: mockTagCreate,
+    },
+  },
+}));
+
+vi.mock('@/lib/db/site', () => ({
+  getSiteId: () => mockGetSiteId(),
+}));
+
+// ─── Imports (après les mocks) ────────────────────────────────────
+
+import { createBlogPost, updateBlogPost, getBlogPostBySlug } from '../../app/api/blog/prisma-store';
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+const SITE_ID = 'site-test-123';
+
+/** Génère un objet post Prisma simulé */
+function makePrismaPost(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'post-1',
+    siteId: SITE_ID,
+    slug: 'test-article',
+    title: 'Article de test',
+    excerpt: 'Description de test',
+    content: 'Contenu de test',
+    coverImage: null,
+    status: 'PUBLISHED',
+    category: 'Comprendre',
+    imagePrompt: null,
+    seoIntent: null,
+    persona: null,
+    tones: [],
+    faq: null,
+    jsonLd: null,
+    featured: false,
+    authorName: 'David Duquenne',
+    publishedAt: new Date('2026-01-15T00:00:00.000Z'),
+    createdAt: new Date('2025-12-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-15T00:00:00.000Z'),
+    tags: [],
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+describe('Blog Prisma Store — publishedAt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSiteId.mockResolvedValue(SITE_ID);
+  });
+
+  describe('updateBlogPost', () => {
+    it('devrait mettre à jour publishedAt quand la date change sur un article publié', async () => {
+      const existingPost = makePrismaPost();
+
+      mockFindUnique.mockResolvedValueOnce(existingPost);
+      mockUpdate.mockResolvedValueOnce(
+        makePrismaPost({
+          publishedAt: new Date('2026-03-04T00:00:00.000Z'),
+          tags: [],
+        })
+      );
+
+      const result = await updateBlogPost('test-article', {
+        date: '2026-03-04',
+        published: true,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.date).toBe('2026-03-04');
+
+      // Vérifier que Prisma reçoit la bonne date
+      const prismaUpdateCall = mockUpdate.mock.calls[0]![1] as {
+        data: Record<string, unknown>;
+      };
+      // L'argument est passé comme { where, data, include }
+      const updateArgs = mockUpdate.mock.calls[0]![0] as {
+        data: { publishedAt: Date };
+      };
+      expect(updateArgs.data.publishedAt).toEqual(new Date('2026-03-04T00:00:00.000Z'));
+    });
+
+    it('devrait conserver publishedAt même pour un brouillon', async () => {
+      const existingPost = makePrismaPost({ status: 'DRAFT', publishedAt: null });
+
+      mockFindUnique.mockResolvedValueOnce(existingPost);
+      mockUpdate.mockResolvedValueOnce(
+        makePrismaPost({
+          status: 'DRAFT',
+          publishedAt: new Date('2026-05-15T00:00:00.000Z'),
+          tags: [],
+        })
+      );
+
+      const result = await updateBlogPost('test-article', {
+        date: '2026-05-15',
+        published: false,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.date).toBe('2026-05-15');
+
+      const updateArgs = mockUpdate.mock.calls[0]![0] as {
+        data: { publishedAt: Date; status: string };
+      };
+      // publishedAt doit être la date choisie, pas null
+      expect(updateArgs.data.publishedAt).toEqual(new Date('2026-05-15T00:00:00.000Z'));
+      expect(updateArgs.data.status).toBe('DRAFT');
+    });
+
+    it('devrait conserver la date existante si aucune date fournie', async () => {
+      const existingDate = new Date('2026-01-15T00:00:00.000Z');
+      const existingPost = makePrismaPost({ publishedAt: existingDate });
+
+      mockFindUnique.mockResolvedValueOnce(existingPost);
+      mockUpdate.mockResolvedValueOnce(makePrismaPost({ publishedAt: existingDate, tags: [] }));
+
+      await updateBlogPost('test-article', {
+        title: 'Nouveau titre',
+      });
+
+      const updateArgs = mockUpdate.mock.calls[0]![0] as {
+        data: { publishedAt: Date };
+      };
+      expect(updateArgs.data.publishedAt).toEqual(existingDate);
+    });
+
+    it("devrait retourner null si le post n'existe pas", async () => {
+      mockFindUnique.mockResolvedValueOnce(null);
+
+      const result = await updateBlogPost('inexistant', {
+        date: '2026-03-04',
+      });
+
+      expect(result).toBeNull();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createBlogPost', () => {
+    it('devrait définir publishedAt même pour un brouillon', async () => {
+      // slugExists check
+      mockFindUnique.mockResolvedValueOnce(null);
+
+      const createdPost = makePrismaPost({
+        status: 'DRAFT',
+        publishedAt: new Date('2026-06-01T00:00:00.000Z'),
+        tags: [],
+      });
+      mockCreate.mockResolvedValueOnce(createdPost);
+
+      const result = await createBlogPost({
+        slug: 'nouveau-brouillon',
+        title: 'Brouillon',
+        content: 'Contenu du brouillon',
+        author: 'David Duquenne',
+        category: 'Comprendre',
+        date: '2026-06-01',
+        published: false,
+      });
+
+      expect(result.date).toBe('2026-06-01');
+
+      const createArgs = mockCreate.mock.calls[0]![0] as {
+        data: { publishedAt: Date; status: string };
+      };
+      // publishedAt doit être la date choisie, pas null
+      expect(createArgs.data.publishedAt).toEqual(new Date('2026-06-01T00:00:00.000Z'));
+      expect(createArgs.data.status).toBe('DRAFT');
+    });
+
+    it('devrait définir publishedAt pour un article publié', async () => {
+      mockFindUnique.mockResolvedValueOnce(null);
+
+      const createdPost = makePrismaPost({
+        status: 'PUBLISHED',
+        publishedAt: new Date('2026-03-04T00:00:00.000Z'),
+        tags: [],
+      });
+      mockCreate.mockResolvedValueOnce(createdPost);
+
+      const result = await createBlogPost({
+        slug: 'article-publie',
+        title: 'Article publié',
+        content: "Contenu de l'article",
+        author: 'David Duquenne',
+        category: 'Comprendre',
+        date: '2026-03-04',
+        published: true,
+      });
+
+      expect(result.date).toBe('2026-03-04');
+      expect(result.published).toBe(true);
+    });
+  });
+
+  describe('getBlogPostBySlug — formatage de la date', () => {
+    it('devrait retourner la date de publishedAt quand elle existe', async () => {
+      const post = makePrismaPost({
+        publishedAt: new Date('2026-03-04T00:00:00.000Z'),
+      });
+      mockFindUnique.mockResolvedValueOnce(post);
+
+      const result = await getBlogPostBySlug('test-article', true);
+
+      expect(result).not.toBeNull();
+      expect(result!.date).toBe('2026-03-04');
+    });
+
+    it('devrait retourner createdAt en fallback quand publishedAt est null', async () => {
+      const post = makePrismaPost({
+        publishedAt: null,
+        createdAt: new Date('2025-12-01T00:00:00.000Z'),
+      });
+      mockFindUnique.mockResolvedValueOnce(post);
+
+      const result = await getBlogPostBySlug('test-article', true);
+
+      expect(result).not.toBeNull();
+      expect(result!.date).toBe('2025-12-01');
+    });
+  });
+});

--- a/apps/psypnos/app/api/blog/posts/[slug]/route.ts
+++ b/apps/psypnos/app/api/blog/posts/[slug]/route.ts
@@ -1,44 +1,40 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-import { revalidatePath } from "next/cache";
-import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { withAdminAuth } from "../../../auth/middleware";
+import { withAdminAuth } from '../../../auth/middleware';
 import {
   getBlogPostBySlug,
   updateBlogPost,
   deleteBlogPost,
   validateSlug,
-} from "../../prisma-store";
+} from '../../prisma-store';
 
 // GET - Retrieve a specific post
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ slug: string }> }
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   try {
     const { slug } = await params;
 
     // Check for admin access (to see unpublished posts)
     const searchParams = request.nextUrl.searchParams;
-    const includeUnpublished = searchParams.get("includeUnpublished") === "true";
+    const includeUnpublished = searchParams.get('includeUnpublished') === 'true';
 
     const post = await getBlogPostBySlug(slug, includeUnpublished);
 
     if (!post) {
-      return NextResponse.json({ error: "Article introuvable" }, { status: 404 });
+      return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
-    // Cache the post for 1 hour
-    return NextResponse.json(post, {
-      headers: {
-        "Cache-Control":
-          "public, s-maxage=3600, max-age=3600, stale-while-revalidate=86400",
-      },
-    });
+    // Disable cache for admin requests to ensure fresh data after edits
+    const cacheHeaders = includeUnpublished
+      ? { 'Cache-Control': 'private, no-store' }
+      : { 'Cache-Control': 'public, s-maxage=3600, max-age=3600, stale-while-revalidate=86400' };
+
+    return NextResponse.json(post, { headers: cacheHeaders });
   } catch (error) {
-    console.error("Error fetching post:", error);
+    console.error('Error fetching post:', error);
     return NextResponse.json(
       { error: "Erreur lors de la récupération de l'article" },
       { status: 500 }
@@ -47,10 +43,7 @@ export async function GET(
 }
 
 // PUT - Update a post (protected by authentication)
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ slug: string }> }
-) {
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   // Verify authentication
   const authResult = await withAdminAuth();
   if (authResult.error) return authResult.error;
@@ -61,10 +54,7 @@ export async function PUT(
     // Validate slug
     const slugValidation = validateSlug(slug);
     if (!slugValidation.valid) {
-      return NextResponse.json(
-        { error: slugValidation.error },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: slugValidation.error }, { status: 400 });
     }
 
     const body = await request.json();
@@ -73,10 +63,7 @@ export async function PUT(
     if (body.slug && body.slug !== slug) {
       const newSlugValidation = validateSlug(body.slug);
       if (!newSlugValidation.valid) {
-        return NextResponse.json(
-          { error: newSlugValidation.error },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: newSlugValidation.error }, { status: 400 });
       }
     }
 
@@ -86,29 +73,25 @@ export async function PUT(
     const updated = await updateBlogPost(actualOldSlug, body);
 
     if (!updated) {
-      return NextResponse.json(
-        { error: "Article introuvable" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
     // Invalidate cache - include homepage for featured articles
-    revalidatePath("/api/blog/posts");
-    revalidatePath("/blog");
+    revalidatePath('/api/blog/posts');
+    revalidatePath('/blog');
     revalidatePath(`/blog/${actualOldSlug}`);
-    revalidatePath("/");
+    revalidatePath('/');
     if (body.slug && body.slug !== actualOldSlug) {
       revalidatePath(`/blog/${body.slug}`);
     }
 
     return NextResponse.json(updated);
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Erreur lors de la mise à jour";
-    console.error("Error updating post:", error);
+    const message = error instanceof Error ? error.message : 'Erreur lors de la mise à jour';
+    console.error('Error updating post:', error);
 
     // Check for duplicate slug error
-    if (message.includes("existe déjà")) {
+    if (message.includes('existe déjà')) {
       return NextResponse.json({ error: message }, { status: 400 });
     }
 
@@ -131,41 +114,35 @@ export async function DELETE(
     // Validate slug
     const slugValidation = validateSlug(slug);
     if (!slugValidation.valid) {
-      return NextResponse.json(
-        { error: slugValidation.error },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: slugValidation.error }, { status: 400 });
     }
 
     const deleted = await deleteBlogPost(slug);
 
     if (!deleted) {
-      return NextResponse.json(
-        { error: "Article introuvable" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
     // Invalidate cache - include homepage for featured articles
-    revalidatePath("/api/blog/posts");
-    revalidatePath("/blog");
+    revalidatePath('/api/blog/posts');
+    revalidatePath('/blog');
     revalidatePath(`/blog/${slug}`);
-    revalidatePath("/admin/blog");
-    revalidatePath("/");
+    revalidatePath('/admin/blog');
+    revalidatePath('/');
 
     return NextResponse.json(
       {
-        message: "Article supprimé avec succès",
+        message: 'Article supprimé avec succès',
         slug: slug,
       },
       {
         headers: {
-          "Cache-Control": "no-cache, no-store, must-revalidate",
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
         },
       }
     );
   } catch (error) {
-    console.error("Error deleting post:", error);
+    console.error('Error deleting post:', error);
     return NextResponse.json(
       { error: "Erreur lors de la suppression de l'article" },
       { status: 500 }
@@ -188,43 +165,37 @@ export async function PATCH(
 
     // Only allow specific fields for PATCH
     const allowedFields: Record<string, boolean> = {};
-    if ("published" in body) {
+    if ('published' in body) {
       allowedFields.published = Boolean(body.published);
     }
-    if ("featured" in body) {
+    if ('featured' in body) {
       allowedFields.featured = Boolean(body.featured);
     }
 
     if (Object.keys(allowedFields).length === 0) {
-      return NextResponse.json(
-        { error: "Aucun champ valide à mettre à jour" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Aucun champ valide à mettre à jour' }, { status: 400 });
     }
 
     const updated = await updateBlogPost(slug, allowedFields);
 
     if (!updated) {
-      return NextResponse.json(
-        { error: "Article introuvable" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
     // Invalidate cache - include homepage for featured changes
-    revalidatePath("/api/blog/posts");
-    revalidatePath("/blog");
+    revalidatePath('/api/blog/posts');
+    revalidatePath('/blog');
     revalidatePath(`/blog/${slug}`);
-    revalidatePath("/");
+    revalidatePath('/');
 
     return NextResponse.json({
-      message: "Article mis à jour avec succès",
+      message: 'Article mis à jour avec succès',
       slug: slug,
       published: updated.published,
       featured: updated.featured,
     });
   } catch (error) {
-    console.error("Error patching post:", error);
+    console.error('Error patching post:', error);
     return NextResponse.json(
       { error: "Erreur lors de la mise à jour de l'article" },
       { status: 500 }

--- a/apps/psypnos/app/api/blog/prisma-store.ts
+++ b/apps/psypnos/app/api/blog/prisma-store.ts
@@ -261,7 +261,7 @@ export async function createBlogPost(data: BlogPostPayload): Promise<BlogPostOut
         jsonLd: data.jsonLd as Prisma.InputJsonValue | undefined,
         featured,
         authorName: data.author,
-        publishedAt: published ? postDate : null,
+        publishedAt: postDate,
         tags: {
           create: tagRecords.map(tag => ({
             tagId: tag.id,
@@ -364,7 +364,7 @@ export async function updateBlogPost(
         }),
         ...(data.featured !== undefined && { featured: data.featured }),
         ...(data.author && { authorName: data.author }),
-        publishedAt: published ? postDate : null,
+        publishedAt: postDate,
         ...tagOperations,
       },
       include: {


### PR DESCRIPTION
## Summary
- **Fix publishedAt persistence**: publishedAt is now always persisted regardless of publish status.
- **Fix stale cache on admin GET**: Admin requests now use no-store cache.
- **Add unit tests**: 8 new tests for date handling.

## Test plan
- [x] lint, type-check, tests, build all pass
- [ ] Manual: verify date persistence on drafts and published posts

Fixes #267

https://claude.ai/code/session_01DBVsb4NqA8fF7HNWWKqD1p