### PR TITLE
Fix image filename handling and add Supabase fallback to API route

### DIFF
--- a/apps/psypnos/__tests__/unit/blog-image-utils.test.ts
+++ b/apps/psypnos/__tests__/unit/blog-image-utils.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests unitaires pour les utilitaires d'URL d'image du blog (BlogImage.tsx).
+ *
+ * Vérifie que :
+ * - getBlogImageUrl gère les URLs Supabase directement
+ * - getBlogImageUrl route les chemins locaux via /api/blog/image
+ * - getCleanImagePath extrait correctement les chemins propres
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { getBlogImageUrl, getCleanImagePath } from '../../app/admin/blog/_components/BlogImage';
+
+describe('getBlogImageUrl', () => {
+  it('retourne une chaîne vide si imagePath est undefined', () => {
+    expect(getBlogImageUrl(undefined)).toBe('');
+  });
+
+  it('retourne une chaîne vide si imagePath est vide', () => {
+    expect(getBlogImageUrl('')).toBe('');
+  });
+
+  it('retourne directement une URL Supabase https', () => {
+    const supabaseUrl = 'https://abc.supabase.co/storage/v1/object/public/blog-images/slug.webp';
+    const result = getBlogImageUrl(supabaseUrl, false);
+
+    expect(result).toBe(supabaseUrl);
+    expect(result).not.toContain('/api/blog/image');
+  });
+
+  it('ajoute un cache-buster aux URLs Supabase', () => {
+    const supabaseUrl = 'https://abc.supabase.co/storage/v1/object/public/blog-images/slug.webp';
+    const result = getBlogImageUrl(supabaseUrl, true);
+
+    expect(result).toContain(supabaseUrl);
+    expect(result).toMatch(/\?t=\d+$/);
+  });
+
+  it("route les chemins locaux /images/blog/ via l'API", () => {
+    const result = getBlogImageUrl('/images/blog/slug.webp', false);
+
+    expect(result).toBe('/api/blog/image?path=slug.webp');
+  });
+
+  it("route les chemins locaux sans slash initial via l'API", () => {
+    const result = getBlogImageUrl('images/blog/slug.webp', false);
+
+    expect(result).toBe('/api/blog/image?path=slug.webp');
+  });
+
+  it('gère les chemins avec des sous-dossiers (temp/)', () => {
+    const result = getBlogImageUrl('/images/blog/temp/file.png', false);
+
+    expect(result).toBe('/api/blog/image?path=temp%2Ffile.png');
+  });
+
+  it('nettoie les paramètres de requête existants', () => {
+    const result = getBlogImageUrl('/images/blog/slug.webp?t=123', false);
+
+    expect(result).toBe('/api/blog/image?path=slug.webp');
+  });
+});
+
+describe('getCleanImagePath', () => {
+  it('retourne une chaîne vide si imagePath est undefined', () => {
+    expect(getCleanImagePath(undefined)).toBe('');
+  });
+
+  it('retourne les URLs Supabase telles quelles', () => {
+    const url = 'https://abc.supabase.co/storage/v1/object/public/blog-images/slug.webp';
+    expect(getCleanImagePath(url)).toBe(url);
+  });
+
+  it('retire les paramètres de requête des URLs Supabase', () => {
+    const url = 'https://abc.supabase.co/storage/v1/object/public/blog-images/slug.webp?t=123';
+    expect(getCleanImagePath(url)).toBe(
+      'https://abc.supabase.co/storage/v1/object/public/blog-images/slug.webp'
+    );
+  });
+
+  it('préfixe les chemins relatifs avec /images/blog/', () => {
+    expect(getCleanImagePath('slug.webp')).toBe('/images/blog/slug.webp');
+  });
+
+  it('conserve les chemins absolus /images/blog/', () => {
+    expect(getCleanImagePath('/images/blog/slug.webp')).toBe('/images/blog/slug.webp');
+  });
+
+  it('extrait le chemin depuis une URL API', () => {
+    expect(getCleanImagePath('/api/blog/image?path=slug.webp')).toBe('/images/blog/slug.webp');
+  });
+});

--- a/apps/psypnos/__tests__/unit/supabase-client.test.ts
+++ b/apps/psypnos/__tests__/unit/supabase-client.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests unitaires pour le client Supabase singleton.
+ *
+ * Vérifie que :
+ * - Le client accepte SUPABASE_SERVICE_KEY (nom principal)
+ * - Le client accepte SUPABASE_SERVICE_ROLE_KEY (nom legacy)
+ * - Le client retourne null si aucune variable n'est définie
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Mocks hoistés ──────────────────────────────────────────────
+
+const { mockCreateClient } = vi.hoisted(() => ({
+  mockCreateClient: vi.fn(),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mockCreateClient,
+  SupabaseClient: class {},
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe('supabase/client', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    // Supprimer le singleton global
+    delete (globalThis as Record<string, unknown>).supabase;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('utilise SUPABASE_SERVICE_KEY en priorité', async () => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key-value';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'role-key-value';
+
+    const fakeClient = { storage: {} };
+    mockCreateClient.mockReturnValue(fakeClient);
+
+    const { supabase } = await import('../../lib/supabase/client');
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      'https://test.supabase.co',
+      'service-key-value',
+      expect.any(Object)
+    );
+    expect(supabase).toBe(fakeClient);
+  });
+
+  it('utilise SUPABASE_SERVICE_ROLE_KEY en fallback', async () => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    delete process.env.SUPABASE_SERVICE_KEY;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'role-key-value';
+
+    const fakeClient = { storage: {} };
+    mockCreateClient.mockReturnValue(fakeClient);
+
+    const { supabase } = await import('../../lib/supabase/client');
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      'https://test.supabase.co',
+      'role-key-value',
+      expect.any(Object)
+    );
+    expect(supabase).toBe(fakeClient);
+  });
+
+  it("retourne null si aucune clé n'est définie", async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_KEY;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const { supabase } = await import('../../lib/supabase/client');
+
+    expect(supabase).toBeNull();
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('isSupabaseStorageConfigured retourne true quand configuré', async () => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'key';
+
+    const fakeClient = { storage: {} };
+    mockCreateClient.mockReturnValue(fakeClient);
+
+    const { isSupabaseStorageConfigured } = await import('../../lib/supabase/client');
+
+    expect(isSupabaseStorageConfigured()).toBe(true);
+  });
+
+  it('isSupabaseStorageConfigured retourne false sans config', async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_KEY;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const { isSupabaseStorageConfigured } = await import('../../lib/supabase/client');
+
+    expect(isSupabaseStorageConfigured()).toBe(false);
+  });
+});

--- a/apps/psypnos/__tests__/unit/supabase-storage.test.ts
+++ b/apps/psypnos/__tests__/unit/supabase-storage.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests unitaires pour le module de stockage Supabase.
+ *
+ * Vérifie que :
+ * - uploadImage utilise le nom de fichier tel quel (pas de normalisation .webp)
+ * - Le fallback local fonctionne quand Supabase n'est pas configuré
+ * - deleteImage, getImageUrl et imageExists fonctionnent correctement
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks hoistés ──────────────────────────────────────────────
+
+const {
+  mockUpload,
+  mockGetPublicUrl,
+  mockRemove,
+  mockList,
+  mockIsConfigured,
+  mockSupabase,
+  mockMkdir,
+  mockWriteFile,
+  mockUnlink,
+  mockAccess,
+} = vi.hoisted(() => ({
+  mockUpload: vi.fn(),
+  mockGetPublicUrl: vi.fn(),
+  mockRemove: vi.fn(),
+  mockList: vi.fn(),
+  mockIsConfigured: vi.fn(),
+  mockSupabase: {
+    storage: {
+      from: vi.fn(),
+    },
+  },
+  mockMkdir: vi.fn(),
+  mockWriteFile: vi.fn(),
+  mockUnlink: vi.fn(),
+  mockAccess: vi.fn(),
+}));
+
+// ─── Mocks — déclarés AVANT les imports ─────────────────────────
+
+vi.mock('../../lib/supabase/client', () => ({
+  supabase: mockSupabase,
+  isSupabaseStorageConfigured: mockIsConfigured,
+}));
+
+vi.mock('fs', () => ({
+  promises: {
+    mkdir: mockMkdir,
+    writeFile: mockWriteFile,
+    unlink: mockUnlink,
+    access: mockAccess,
+  },
+}));
+
+// ─── Import du module sous test ─────────────────────────────────
+
+import {
+  uploadImage,
+  deleteImage,
+  getImageUrl,
+  imageExists,
+  BUCKETS,
+} from '../../lib/supabase/storage';
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe('supabase/storage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Configuration par défaut : Supabase activé
+    mockIsConfigured.mockReturnValue(true);
+
+    mockSupabase.storage.from.mockReturnValue({
+      upload: mockUpload,
+      getPublicUrl: mockGetPublicUrl,
+      remove: mockRemove,
+      list: mockList,
+    });
+  });
+
+  // ── uploadImage ──────────────────────────────────────────────
+
+  describe('uploadImage', () => {
+    it('conserve le nom de fichier tel quel (pas de normalisation .webp)', async () => {
+      mockUpload.mockResolvedValue({ error: null });
+      mockGetPublicUrl.mockReturnValue({
+        data: {
+          publicUrl: 'https://supabase.co/storage/v1/object/public/blog-images/temp/slug-1.png',
+        },
+      });
+
+      const result = await uploadImage(
+        BUCKETS.BLOG_IMAGES,
+        'temp/slug-1.png',
+        Buffer.from('fake-png'),
+        'image/png'
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockUpload).toHaveBeenCalledWith('temp/slug-1.png', expect.any(Buffer), {
+        contentType: 'image/png',
+        upsert: true,
+      });
+      // Vérifie que le nom n'a PAS été modifié en .png.webp
+      expect(mockGetPublicUrl).toHaveBeenCalledWith('temp/slug-1.png');
+    });
+
+    it('conserve les fichiers .jpg sans ajouter .webp', async () => {
+      mockUpload.mockResolvedValue({ error: null });
+      mockGetPublicUrl.mockReturnValue({
+        data: { publicUrl: 'https://supabase.co/storage/v1/object/public/blog-images/article.jpg' },
+      });
+
+      const result = await uploadImage(
+        BUCKETS.BLOG_IMAGES,
+        'article.jpg',
+        Buffer.from('fake-jpg'),
+        'image/jpeg'
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockUpload).toHaveBeenCalledWith('article.jpg', expect.any(Buffer), {
+        contentType: 'image/jpeg',
+        upsert: true,
+      });
+    });
+
+    it('retourne une erreur si Supabase upload échoue', async () => {
+      mockUpload.mockResolvedValue({ error: { message: 'Bucket not found' } });
+
+      const result = await uploadImage(
+        BUCKETS.BLOG_IMAGES,
+        'test.webp',
+        Buffer.from('data'),
+        'image/webp'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Bucket not found');
+    });
+
+    it("utilise le fallback local quand Supabase n'est pas configuré", async () => {
+      mockIsConfigured.mockReturnValue(false);
+      mockMkdir.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const result = await uploadImage(
+        BUCKETS.BLOG_IMAGES,
+        'slug.webp',
+        Buffer.from('data'),
+        'image/webp'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.url).toBe('/images/blog/slug.webp');
+      expect(mockWriteFile).toHaveBeenCalled();
+    });
+  });
+
+  // ── deleteImage ──────────────────────────────────────────────
+
+  describe('deleteImage', () => {
+    it('supprime le fichier avec le nom exact fourni', async () => {
+      mockRemove.mockResolvedValue({ error: null });
+
+      const result = await deleteImage(BUCKETS.BLOG_IMAGES, 'article.png');
+
+      expect(result.success).toBe(true);
+      expect(mockRemove).toHaveBeenCalledWith(['article.png']);
+    });
+  });
+
+  // ── getImageUrl ──────────────────────────────────────────────
+
+  describe('getImageUrl', () => {
+    it("retourne l'URL Supabase avec le nom de fichier exact", () => {
+      mockGetPublicUrl.mockReturnValue({
+        data: { publicUrl: 'https://supabase.co/storage/v1/object/public/blog-images/slug.webp' },
+      });
+
+      const url = getImageUrl(BUCKETS.BLOG_IMAGES, 'slug.webp');
+
+      expect(url).toBe('https://supabase.co/storage/v1/object/public/blog-images/slug.webp');
+      expect(mockGetPublicUrl).toHaveBeenCalledWith('slug.webp');
+    });
+
+    it("retourne un chemin local quand Supabase n'est pas configuré", () => {
+      mockIsConfigured.mockReturnValue(false);
+
+      const url = getImageUrl(BUCKETS.BLOG_IMAGES, 'slug.webp');
+
+      expect(url).toBe('/images/blog/slug.webp');
+    });
+  });
+
+  // ── imageExists ──────────────────────────────────────────────
+
+  describe('imageExists', () => {
+    it("vérifie l'existence avec le nom de fichier exact", async () => {
+      mockList.mockResolvedValue({
+        data: [{ name: 'slug.png' }],
+        error: null,
+      });
+
+      const exists = await imageExists(BUCKETS.BLOG_IMAGES, 'slug.png');
+
+      expect(exists).toBe(true);
+    });
+
+    it("retourne false si le fichier n'existe pas", async () => {
+      mockList.mockResolvedValue({
+        data: [{ name: 'other.png' }],
+        error: null,
+      });
+
+      const exists = await imageExists(BUCKETS.BLOG_IMAGES, 'slug.png');
+
+      expect(exists).toBe(false);
+    });
+  });
+});

--- a/apps/psypnos/app/admin/blog/_components/BlogImage.tsx
+++ b/apps/psypnos/app/admin/blog/_components/BlogImage.tsx
@@ -1,36 +1,44 @@
-"use client";
+'use client';
 
-import { Loader2, ImageOff, RefreshCw } from "lucide-react";
-import { useState, useEffect, useCallback, useRef } from "react";
+import { Loader2, ImageOff, RefreshCw } from 'lucide-react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 /**
- * Convertit un chemin d'image en URL API pour le servir dynamiquement
+ * Convertit un chemin d'image en URL affichable
  *
- * Cela résout le problème du mode standalone de Next.js où les fichiers
- * créés dynamiquement dans /public ne sont pas accessibles directement.
+ * - URLs complètes (Supabase) : retournées directement
+ * - Chemins locaux (/images/blog/...) : routés via /api/blog/image pour
+ *   résoudre le problème du mode standalone de Next.js
  *
- * @param imagePath - Chemin de l'image (ex: /images/blog/slug.webp ou /images/blog/temp/file.webp)
+ * @param imagePath - Chemin ou URL de l'image
  * @param bustCache - Ajouter un timestamp pour forcer le rechargement
- * @returns URL de l'API pour servir l'image
+ * @returns URL affichable pour l'image
  */
 export function getBlogImageUrl(imagePath: string | undefined, bustCache = true): string {
-  if (!imagePath) return "";
+  if (!imagePath) return '';
 
   // Nettoyer le chemin des paramètres existants
-  const cleanPath = imagePath.split("?")[0] ?? imagePath;
+  const cleanPath = imagePath.split('?')[0] ?? imagePath;
 
-  // Extraire le chemin relatif après /images/blog/
-  let relativePath = cleanPath;
-  if (cleanPath.startsWith("/images/blog/")) {
-    relativePath = cleanPath.replace("/images/blog/", "");
-  } else if (cleanPath.startsWith("images/blog/")) {
-    relativePath = cleanPath.replace("images/blog/", "");
+  // URLs complètes (Supabase ou autre CDN) : utiliser directement
+  if (cleanPath.startsWith('http://') || cleanPath.startsWith('https://')) {
+    if (bustCache) {
+      const separator = cleanPath.includes('?') ? '&' : '?';
+      return `${cleanPath}${separator}t=${Date.now()}`;
+    }
+    return cleanPath;
   }
 
-  // Construire l'URL de l'API
+  // Chemins locaux : router via l'API
+  let relativePath = cleanPath;
+  if (cleanPath.startsWith('/images/blog/')) {
+    relativePath = cleanPath.replace('/images/blog/', '');
+  } else if (cleanPath.startsWith('images/blog/')) {
+    relativePath = cleanPath.replace('images/blog/', '');
+  }
+
   const apiUrl = `/api/blog/image?path=${encodeURIComponent(relativePath)}`;
 
-  // Ajouter un timestamp pour le cache-busting si demandé
   if (bustCache) {
     return `${apiUrl}&t=${Date.now()}`;
   }
@@ -43,21 +51,26 @@ export function getBlogImageUrl(imagePath: string | undefined, bustCache = true)
  * Utilisé pour stocker le chemin dans la base de données sans le timestamp
  */
 export function getCleanImagePath(imagePath: string | undefined): string {
-  if (!imagePath) return "";
+  if (!imagePath) return '';
 
-  // Retirer les paramètres de requête
-  const cleanPath = imagePath.split("?")[0] ?? imagePath;
-
-  // Si c'est déjà un chemin relatif au dossier blog, le garder
-  if (!cleanPath.startsWith("/") && !cleanPath.startsWith("http")) {
-    return `/images/blog/${cleanPath}`;
+  // Si c'est une URL API, extraire le chemin AVANT de supprimer les query params
+  if (imagePath.includes('/api/blog/image')) {
+    const url = new URL(imagePath, 'http://localhost');
+    const path = url.searchParams.get('path');
+    return path ? `/images/blog/${path}` : '';
   }
 
-  // Si c'est une URL API, extraire le chemin
-  if (cleanPath.includes("/api/blog/image")) {
-    const url = new URL(cleanPath, "http://localhost");
-    const path = url.searchParams.get("path");
-    return path ? `/images/blog/${path}` : "";
+  // Retirer les paramètres de requête
+  const cleanPath = imagePath.split('?')[0] ?? imagePath;
+
+  // URLs Supabase : retourner telles quelles (ce sont les URLs de stockage)
+  if (cleanPath.startsWith('http://') || cleanPath.startsWith('https://')) {
+    return cleanPath;
+  }
+
+  // Si c'est déjà un chemin relatif au dossier blog, le garder
+  if (!cleanPath.startsWith('/')) {
+    return `/images/blog/${cleanPath}`;
   }
 
   // Sinon retourner tel quel (devrait être /images/blog/...)
@@ -99,7 +112,7 @@ interface BlogImageProps {
   reloadKey?: string | number;
 }
 
-type LoadingState = "loading" | "loaded" | "error";
+type LoadingState = 'loading' | 'loaded' | 'error';
 
 /**
  * Composant d'image robuste pour le blog avec:
@@ -111,14 +124,14 @@ type LoadingState = "loading" | "loaded" | "error";
 export function BlogImage({
   src,
   alt,
-  className = "",
-  containerClassName = "",
+  className = '',
+  containerClassName = '',
   showRetryButton = true,
   onLoad,
   onError,
   reloadKey,
 }: BlogImageProps) {
-  const [loadingState, setLoadingState] = useState<LoadingState>("loading");
+  const [loadingState, setLoadingState] = useState<LoadingState>('loading');
   const [retryCount, setRetryCount] = useState(0);
   const imgRef = useRef<HTMLImageElement>(null);
 
@@ -126,40 +139,38 @@ export function BlogImage({
   const imageUrl = getBlogImageUrl(src, true);
 
   // Clé unique pour forcer le rechargement quand src ou reloadKey change
-  const uniqueKey = `${imageUrl}-${reloadKey || ""}-${retryCount}`;
+  const uniqueKey = `${imageUrl}-${reloadKey || ''}-${retryCount}`;
 
   // Reset l'état quand l'image change
   useEffect(() => {
     if (src) {
-      setLoadingState("loading");
+      setLoadingState('loading');
       setRetryCount(0);
     } else {
-      setLoadingState("error");
+      setLoadingState('error');
     }
   }, [src, reloadKey]);
 
   const handleLoad = useCallback(() => {
-    setLoadingState("loaded");
+    setLoadingState('loaded');
     onLoad?.();
   }, [onLoad]);
 
   const handleError = useCallback(() => {
-    setLoadingState("error");
+    setLoadingState('error');
     onError?.();
   }, [onError]);
 
   const handleRetry = useCallback(() => {
-    setLoadingState("loading");
-    setRetryCount((prev) => prev + 1);
+    setLoadingState('loading');
+    setRetryCount(prev => prev + 1);
   }, []);
 
   // Si pas d'image source, afficher directement le placeholder
   if (!src) {
     return (
-      <div
-        className={`flex items-center justify-center bg-night/40 ${containerClassName}`}
-      >
-        <div className="flex flex-col items-center gap-2 text-ivory/40">
+      <div className={`bg-night/40 flex items-center justify-center ${containerClassName}`}>
+        <div className="text-ivory/40 flex flex-col items-center gap-2">
           <ImageOff className="h-8 w-8" />
           <span className="text-sm">Aucune image</span>
         </div>
@@ -170,22 +181,22 @@ export function BlogImage({
   return (
     <div className={`relative ${containerClassName}`}>
       {/* Spinner de chargement */}
-      {loadingState === "loading" && (
-        <div className="absolute inset-0 flex items-center justify-center bg-night/60 backdrop-blur-sm z-10">
-          <Loader2 className="h-8 w-8 animate-spin text-gold" />
+      {loadingState === 'loading' && (
+        <div className="bg-night/60 absolute inset-0 z-10 flex items-center justify-center backdrop-blur-sm">
+          <Loader2 className="text-gold h-8 w-8 animate-spin" />
         </div>
       )}
 
       {/* État d'erreur */}
-      {loadingState === "error" && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center bg-night/60 backdrop-blur-sm z-10 gap-3">
+      {loadingState === 'error' && (
+        <div className="bg-night/60 absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 backdrop-blur-sm">
           <ImageOff className="h-8 w-8 text-red-400" />
-          <span className="text-sm text-ivory/60">Impossible de charger l&apos;image</span>
+          <span className="text-ivory/60 text-sm">Impossible de charger l&apos;image</span>
           {showRetryButton && (
             <button
               type="button"
               onClick={handleRetry}
-              className="flex items-center gap-2 rounded-lg bg-gold/20 px-3 py-1.5 text-sm font-medium text-gold transition hover:bg-gold/30"
+              className="bg-gold/20 text-gold hover:bg-gold/30 flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition"
             >
               <RefreshCw className="h-4 w-4" />
               Réessayer
@@ -200,7 +211,7 @@ export function BlogImage({
         key={uniqueKey}
         src={imageUrl}
         alt={alt}
-        className={`${className} ${loadingState === "loading" ? "opacity-0" : "opacity-100"} transition-opacity duration-300`}
+        className={`${className} ${loadingState === 'loading' ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
         onLoad={handleLoad}
         onError={handleError}
         // Désactiver le lazy loading pour les images du formulaire
@@ -231,12 +242,12 @@ export function BlogImageProposal({
   onClick,
   index,
 }: BlogImageProposalProps) {
-  const [loadingState, setLoadingState] = useState<LoadingState>("loading");
+  const [loadingState, setLoadingState] = useState<LoadingState>('loading');
 
   const imageUrl = getBlogImageUrl(src, true);
 
   useEffect(() => {
-    setLoadingState("loading");
+    setLoadingState('loading');
   }, [src]);
 
   return (
@@ -244,23 +255,21 @@ export function BlogImageProposal({
       type="button"
       onClick={onClick}
       className={`group relative aspect-video overflow-hidden rounded-lg border-2 transition ${
-        isSelected
-          ? "border-gold ring-2 ring-gold/30"
-          : "border-gold/20 hover:border-gold/50"
+        isSelected ? 'border-gold ring-gold/30 ring-2' : 'border-gold/20 hover:border-gold/50'
       }`}
     >
       {/* Spinner de chargement */}
-      {loadingState === "loading" && (
-        <div className="absolute inset-0 flex items-center justify-center bg-night/60 z-10">
-          <Loader2 className="h-6 w-6 animate-spin text-gold" />
+      {loadingState === 'loading' && (
+        <div className="bg-night/60 absolute inset-0 z-10 flex items-center justify-center">
+          <Loader2 className="text-gold h-6 w-6 animate-spin" />
         </div>
       )}
 
       {/* État d'erreur */}
-      {loadingState === "error" && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center bg-night/60 z-10">
+      {loadingState === 'error' && (
+        <div className="bg-night/60 absolute inset-0 z-10 flex flex-col items-center justify-center">
           <ImageOff className="h-6 w-6 text-red-400" />
-          <span className="text-xs text-ivory/50 mt-1">Erreur</span>
+          <span className="text-ivory/50 mt-1 text-xs">Erreur</span>
         </div>
       )}
 
@@ -269,20 +278,20 @@ export function BlogImageProposal({
         src={imageUrl}
         alt={alt}
         className={`h-full w-full object-cover transition group-hover:scale-105 ${
-          loadingState === "loading" ? "opacity-0" : "opacity-100"
+          loadingState === 'loading' ? 'opacity-0' : 'opacity-100'
         }`}
-        onLoad={() => setLoadingState("loaded")}
-        onError={() => setLoadingState("error")}
+        onLoad={() => setLoadingState('loaded')}
+        onError={() => setLoadingState('error')}
         loading="eager"
         decoding="sync"
       />
 
       {/* Overlay de sélection */}
-      {isSelected && loadingState === "loaded" && (
-        <div className="absolute inset-0 flex items-center justify-center bg-gold/20">
-          <div className="rounded-full bg-gold p-2">
+      {isSelected && loadingState === 'loaded' && (
+        <div className="bg-gold/20 absolute inset-0 flex items-center justify-center">
+          <div className="bg-gold rounded-full p-2">
             <svg
-              className="h-5 w-5 text-night"
+              className="text-night h-5 w-5"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -295,8 +304,8 @@ export function BlogImageProposal({
       )}
 
       {/* Label en bas */}
-      <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-night/80 to-transparent p-3">
-        <p className="text-sm font-medium text-ivory">Option {index + 1}</p>
+      <div className="from-night/80 absolute inset-x-0 bottom-0 bg-gradient-to-t to-transparent p-3">
+        <p className="text-ivory text-sm font-medium">Option {index + 1}</p>
       </div>
     </button>
   );

--- a/apps/psypnos/app/api/blog/confirm-image-selection/route.ts
+++ b/apps/psypnos/app/api/blog/confirm-image-selection/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      finalPath: `/images/blog/${slug}.webp`,
+      finalPath: result.url,
     });
   } catch (error) {
     console.error('Erreur lors de la confirmation de la sélection:', error);

--- a/apps/psypnos/app/api/blog/image/route.ts
+++ b/apps/psypnos/app/api/blog/image/route.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-import { readFile, stat } from "fs/promises";
-import { join } from "path";
+import { readFile, stat } from 'fs/promises';
+import { join } from 'path';
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from 'next/server';
 
 /**
  * API pour servir les images du blog dynamiquement
@@ -12,91 +12,82 @@ import { NextRequest, NextResponse } from "next/server";
  * Résout le problème du mode standalone de Next.js où les fichiers
  * créés dynamiquement dans /public ne sont pas accessibles.
  *
- * Usage:
- * - /api/blog/image?path=slug.webp          → /public/images/blog/slug.webp
- * - /api/blog/image?path=temp/file.webp     → /public/images/blog/temp/file.webp
+ * Essaie d'abord le filesystem local, puis Supabase Storage en fallback.
  *
- * Headers de cache:
- * - Pas de cache pour permettre les mises à jour immédiates
- * - ETag pour optimiser les requêtes conditionnelles
+ * Usage:
+ * - /api/blog/image?path=slug.webp          → local ou Supabase
+ * - /api/blog/image?path=temp/file.webp     → local ou Supabase
  */
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const imagePath = searchParams.get("path");
+    const imagePath = searchParams.get('path');
 
     if (!imagePath) {
-      return NextResponse.json(
-        { error: "Le paramètre 'path' est requis" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Le paramètre 'path' est requis" }, { status: 400 });
     }
 
     // Validation de sécurité: empêcher la traversée de répertoire
-    const normalizedPath = imagePath.replace(/\\/g, "/");
-    if (normalizedPath.includes("..") || normalizedPath.startsWith("/")) {
-      return NextResponse.json(
-        { error: "Chemin invalide" },
-        { status: 400 }
-      );
+    const normalizedPath = imagePath.replace(/\\/g, '/');
+    if (normalizedPath.includes('..') || normalizedPath.startsWith('/')) {
+      return NextResponse.json({ error: 'Chemin invalide' }, { status: 400 });
     }
 
     // Construire le chemin absolu vers l'image
-    const publicDir = join(process.cwd(), "public", "images", "blog");
+    const publicDir = join(process.cwd(), 'public', 'images', 'blog');
     const fullPath = join(publicDir, normalizedPath);
 
-    // Vérifier que le fichier existe et obtenir ses métadonnées
-    let fileStats;
+    // Essayer le filesystem local d'abord
     try {
-      fileStats = await stat(fullPath);
+      const fileStats = await stat(fullPath);
+      const fileBuffer = await readFile(fullPath);
+
+      // Déterminer le type MIME
+      const extension = normalizedPath.split('.').pop()?.toLowerCase();
+      const mimeTypes: Record<string, string> = {
+        webp: 'image/webp',
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        png: 'image/png',
+        gif: 'image/gif',
+        svg: 'image/svg+xml',
+      };
+      const contentType = mimeTypes[extension || ''] || 'application/octet-stream';
+
+      // Générer un ETag basé sur la taille et la date de modification
+      const etag = `"${fileStats.size}-${fileStats.mtime.getTime()}"`;
+
+      // Vérifier si le client a une version en cache valide
+      const ifNoneMatch = request.headers.get('if-none-match');
+      if (ifNoneMatch === etag) {
+        return new NextResponse(null, { status: 304 });
+      }
+
+      return new NextResponse(fileBuffer, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Content-Length': fileStats.size.toString(),
+          'Cache-Control': 'no-cache, must-revalidate',
+          ETag: etag,
+          'Last-Modified': fileStats.mtime.toUTCString(),
+        },
+      });
     } catch {
-      return NextResponse.json(
-        { error: "Image non trouvée" },
-        { status: 404 }
-      );
+      // Fichier non trouvé localement — tenter Supabase
     }
 
-    // Lire le fichier
-    const fileBuffer = await readFile(fullPath);
-
-    // Déterminer le type MIME
-    const extension = normalizedPath.split(".").pop()?.toLowerCase();
-    const mimeTypes: Record<string, string> = {
-      webp: "image/webp",
-      jpg: "image/jpeg",
-      jpeg: "image/jpeg",
-      png: "image/png",
-      gif: "image/gif",
-      svg: "image/svg+xml",
-    };
-    const contentType = mimeTypes[extension || ""] || "application/octet-stream";
-
-    // Générer un ETag basé sur la taille et la date de modification
-    const etag = `"${fileStats.size}-${fileStats.mtime.getTime()}"`;
-
-    // Vérifier si le client a une version en cache valide
-    const ifNoneMatch = request.headers.get("if-none-match");
-    if (ifNoneMatch === etag) {
-      return new NextResponse(null, { status: 304 });
+    // Fallback Supabase : import dynamique pour éviter l'erreur au build SSG
+    const { isSupabaseStorageConfigured } = await import('@/lib/supabase/client');
+    if (isSupabaseStorageConfigured()) {
+      const { getImageUrl, BUCKETS } = await import('@/lib/supabase/storage');
+      const supabaseUrl = getImageUrl(BUCKETS.BLOG_IMAGES, normalizedPath);
+      return NextResponse.redirect(supabaseUrl, { status: 302 });
     }
 
-    // Retourner l'image avec les headers appropriés
-    return new NextResponse(fileBuffer, {
-      status: 200,
-      headers: {
-        "Content-Type": contentType,
-        "Content-Length": fileStats.size.toString(),
-        "Cache-Control": "no-cache, must-revalidate",
-        "ETag": etag,
-        // Permettre la mise en cache conditionnelle mais forcer la revalidation
-        "Last-Modified": fileStats.mtime.toUTCString(),
-      },
-    });
+    return NextResponse.json({ error: 'Image non trouvée' }, { status: 404 });
   } catch (error) {
     console.error("Erreur lors de la lecture de l'image:", error);
-    return NextResponse.json(
-      { error: "Erreur lors de la lecture de l'image" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Erreur lors de la lecture de l'image" }, { status: 500 });
   }
 }

--- a/apps/psypnos/lib/supabase/client.ts
+++ b/apps/psypnos/lib/supabase/client.ts
@@ -6,7 +6,7 @@
  * Used for Supabase Storage (images)
  */
 
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
 // Declare global type for the Supabase client in development
 declare global {
@@ -16,28 +16,36 @@ declare global {
 
 function createSupabaseClient(): SupabaseClient | null {
   const supabaseUrl = process.env.SUPABASE_URL;
-  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabaseServiceKey =
+    process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !supabaseServiceKey) {
     console.warn(
-      "Supabase credentials not configured. Image storage will fall back to local filesystem."
+      'Supabase credentials not configured. Image storage will fall back to local filesystem.'
     );
     return null;
   }
 
-  return createClient(supabaseUrl, supabaseServiceKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  });
+  try {
+    return createClient(supabaseUrl, supabaseServiceKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+  } catch (error) {
+    console.warn(
+      'Failed to create Supabase client:',
+      error instanceof Error ? error.message : error
+    );
+    return null;
+  }
 }
 
 // Use global instance in development to prevent too many connections during hot reloading
-const supabase =
-  globalThis.supabase ?? createSupabaseClient();
+const supabase = globalThis.supabase ?? createSupabaseClient();
 
-if (process.env.NODE_ENV !== "production" && supabase) {
+if (process.env.NODE_ENV !== 'production' && supabase) {
   globalThis.supabase = supabase;
 }
 

--- a/apps/psypnos/lib/supabase/storage.ts
+++ b/apps/psypnos/lib/supabase/storage.ts
@@ -5,31 +5,34 @@
  * Supabase Storage Module
  * Handles image upload/delete for blog articles and seminars
  * Falls back to local filesystem if Supabase is not configured
+ *
+ * Les noms de fichier sont utilisés tels quels (pas de normalisation d'extension).
+ * Les appelants sont responsables de fournir l'extension correcte.
  */
 
-import { promises as fs } from "fs";
-import path from "path";
+import { promises as fs } from 'fs';
+import path from 'path';
 
-import { supabase, isSupabaseStorageConfigured } from "./client";
+import { supabase, isSupabaseStorageConfigured } from './client';
 
 // Storage bucket names
 export const BUCKETS = {
-  BLOG_IMAGES: "blog-images",
-  SEMINAR_IMAGES: "seminar-images",
+  BLOG_IMAGES: 'blog-images',
+  SEMINAR_IMAGES: 'seminar-images',
 } as const;
 
 export type BucketName = (typeof BUCKETS)[keyof typeof BUCKETS];
 
 // Local fallback paths
 const LOCAL_PATHS: Record<BucketName, string> = {
-  [BUCKETS.BLOG_IMAGES]: "public/images/blog",
-  [BUCKETS.SEMINAR_IMAGES]: "public/images/seminars",
+  [BUCKETS.BLOG_IMAGES]: 'public/images/blog',
+  [BUCKETS.SEMINAR_IMAGES]: 'public/images/seminars',
 };
 
 // Public URL paths for local storage
 const PUBLIC_URL_PATHS: Record<BucketName, string> = {
-  [BUCKETS.BLOG_IMAGES]: "/images/blog",
-  [BUCKETS.SEMINAR_IMAGES]: "/images/seminars",
+  [BUCKETS.BLOG_IMAGES]: '/images/blog',
+  [BUCKETS.SEMINAR_IMAGES]: '/images/seminars',
 };
 
 interface UploadResult {
@@ -50,22 +53,15 @@ export async function uploadImage(
   bucket: BucketName,
   filename: string,
   buffer: Buffer,
-  contentType: string = "image/webp"
+  contentType: string = 'image/webp'
 ): Promise<UploadResult> {
-  // Ensure filename has .webp extension
-  const normalizedFilename = filename.endsWith(".webp")
-    ? filename
-    : `${filename}.webp`;
-
   if (isSupabaseStorageConfigured() && supabase) {
     try {
       // Upload to Supabase Storage
-      const { error } = await supabase.storage
-        .from(bucket)
-        .upload(normalizedFilename, buffer, {
-          contentType,
-          upsert: true, // Overwrite if exists
-        });
+      const { error } = await supabase.storage.from(bucket).upload(filename, buffer, {
+        contentType,
+        upsert: true, // Overwrite if exists
+      });
 
       if (error) {
         console.error(`Supabase upload error: ${error.message}`);
@@ -75,19 +71,18 @@ export async function uploadImage(
       // Get public URL
       const {
         data: { publicUrl },
-      } = supabase.storage.from(bucket).getPublicUrl(normalizedFilename);
+      } = supabase.storage.from(bucket).getPublicUrl(filename);
 
       return { success: true, url: publicUrl };
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Unknown upload error";
+      const message = error instanceof Error ? error.message : 'Unknown upload error';
       console.error(`Supabase upload exception: ${message}`);
       return { success: false, error: message };
     }
   }
 
   // Fallback to local filesystem
-  return uploadImageLocal(bucket, normalizedFilename, buffer);
+  return uploadImageLocal(bucket, filename, buffer);
 }
 
 /**
@@ -113,8 +108,7 @@ async function uploadImageLocal(
 
     return { success: true, url };
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Unknown local upload error";
+    const message = error instanceof Error ? error.message : 'Unknown local upload error';
     console.error(`Local upload error: ${message}`);
     return { success: false, error: message };
   }
@@ -123,19 +117,10 @@ async function uploadImageLocal(
 /**
  * Delete an image from Supabase Storage or local filesystem
  */
-export async function deleteImage(
-  bucket: BucketName,
-  filename: string
-): Promise<DeleteResult> {
-  const normalizedFilename = filename.endsWith(".webp")
-    ? filename
-    : `${filename}.webp`;
-
+export async function deleteImage(bucket: BucketName, filename: string): Promise<DeleteResult> {
   if (isSupabaseStorageConfigured() && supabase) {
     try {
-      const { error } = await supabase.storage
-        .from(bucket)
-        .remove([normalizedFilename]);
+      const { error } = await supabase.storage.from(bucket).remove([filename]);
 
       if (error) {
         console.error(`Supabase delete error: ${error.message}`);
@@ -144,24 +129,20 @@ export async function deleteImage(
 
       return { success: true };
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Unknown delete error";
+      const message = error instanceof Error ? error.message : 'Unknown delete error';
       console.error(`Supabase delete exception: ${message}`);
       return { success: false, error: message };
     }
   }
 
   // Fallback to local filesystem
-  return deleteImageLocal(bucket, normalizedFilename);
+  return deleteImageLocal(bucket, filename);
 }
 
 /**
  * Delete image from local filesystem (fallback)
  */
-async function deleteImageLocal(
-  bucket: BucketName,
-  filename: string
-): Promise<DeleteResult> {
+async function deleteImageLocal(bucket: BucketName, filename: string): Promise<DeleteResult> {
   try {
     const localPath = LOCAL_PATHS[bucket];
     const fullPath = path.join(process.cwd(), localPath, filename);
@@ -171,12 +152,11 @@ async function deleteImageLocal(
     return { success: true };
   } catch (error) {
     // File might not exist, which is OK
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return { success: true };
     }
 
-    const message =
-      error instanceof Error ? error.message : "Unknown local delete error";
+    const message = error instanceof Error ? error.message : 'Unknown local delete error';
     console.error(`Local delete error: ${message}`);
     return { success: false, error: message };
   }
@@ -186,40 +166,27 @@ async function deleteImageLocal(
  * Get the public URL for an image
  */
 export function getImageUrl(bucket: BucketName, filename: string): string {
-  const normalizedFilename = filename.endsWith(".webp")
-    ? filename
-    : `${filename}.webp`;
-
   if (isSupabaseStorageConfigured() && supabase) {
     const {
       data: { publicUrl },
-    } = supabase.storage.from(bucket).getPublicUrl(normalizedFilename);
+    } = supabase.storage.from(bucket).getPublicUrl(filename);
     return publicUrl;
   }
 
   // Local URL
-  return `${PUBLIC_URL_PATHS[bucket]}/${normalizedFilename}`;
+  return `${PUBLIC_URL_PATHS[bucket]}/${filename}`;
 }
 
 /**
  * Check if an image exists
  */
-export async function imageExists(
-  bucket: BucketName,
-  filename: string
-): Promise<boolean> {
-  const normalizedFilename = filename.endsWith(".webp")
-    ? filename
-    : `${filename}.webp`;
-
+export async function imageExists(bucket: BucketName, filename: string): Promise<boolean> {
   if (isSupabaseStorageConfigured() && supabase) {
     try {
-      const { data, error } = await supabase.storage
-        .from(bucket)
-        .list("", { search: normalizedFilename });
+      const { data, error } = await supabase.storage.from(bucket).list('', { search: filename });
 
       if (error) return false;
-      return data?.some((file) => file.name === normalizedFilename) ?? false;
+      return data?.some(file => file.name === filename) ?? false;
     } catch {
       return false;
     }
@@ -228,7 +195,7 @@ export async function imageExists(
   // Check local filesystem
   try {
     const localPath = LOCAL_PATHS[bucket];
-    const fullPath = path.join(process.cwd(), localPath, normalizedFilename);
+    const fullPath = path.join(process.cwd(), localPath, filename);
     await fs.access(fullPath);
     return true;
   } catch {
@@ -245,7 +212,7 @@ export async function migrateImageToSupabase(
   filename: string
 ): Promise<UploadResult> {
   if (!isSupabaseStorageConfigured()) {
-    return { success: false, error: "Supabase Storage not configured" };
+    return { success: false, error: 'Supabase Storage not configured' };
   }
 
   try {
@@ -258,8 +225,7 @@ export async function migrateImageToSupabase(
     // Upload to Supabase
     return uploadImage(bucket, filename, buffer);
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Unknown migration error";
+    const message = error instanceof Error ? error.message : 'Unknown migration error';
     return { success: false, error: message };
   }
 }


### PR DESCRIPTION
## Description

This PR fixes image filename handling in the Supabase storage module and improves the blog image API route with proper fallback support.

### Key Changes

1. **Remove automatic `.webp` extension normalization** in `uploadImage`, `deleteImage`, and `getImageUrl`
   - Filenames are now used as-is, without forcing `.webp` extension
   - Callers are responsible for providing the correct extension
   - Fixes issues where files like `slug.png` were being renamed to `slug.png.webp`

2. **Add Supabase fallback to `/api/blog/image` route**
   - Route now tries local filesystem first, then falls back to Supabase Storage
   - Enables serving images from Supabase when local files don't exist
   - Properly handles redirects with 302 status code

3. **Improve Supabase client initialization**
   - Support both `SUPABASE_SERVICE_KEY` (primary) and `SUPABASE_SERVICE_ROLE_KEY` (legacy) environment variables
   - Add error handling for client creation failures
   - Better logging for configuration issues

4. **Update BlogImage utilities**
   - `getBlogImageUrl` now handles full Supabase URLs directly without routing through API
   - `getCleanImagePath` properly extracts paths from API URLs and preserves Supabase URLs
   - Add cache-busting support for Supabase URLs

5. **Update image confirmation endpoint**
   - Return actual upload result URL instead of hardcoded path
   - Respects the storage backend's returned URL (local or Supabase)

### Testing

- Added comprehensive unit tests for Supabase storage module (`supabase-storage.test.ts`)
- Added unit tests for Supabase client initialization (`supabase-client.test.ts`)
- Added unit tests for BlogImage URL utilities (`blog-image-utils.test.ts`)
- All tests verify filename handling without extension normalization
- Tests cover both Supabase and local filesystem fallback paths

## Type de changement

- [x] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles
- [x] Tests unitaires ajoutés et passants

## Sites impactés

- [x] PSYPNOS uniquement

https://claude.ai/code/session_01VBw2PmqbU9YC87CHhW34iG