### PR TITLE
refactor: standardize quote style to single quotes across codebase

### DIFF
--- a/apps/psypnos/app/admin/blog/_components/BlogPostForm.tsx
+++ b/apps/psypnos/app/admin/blog/_components/BlogPostForm.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
+import { motion } from 'framer-motion';
 import {
   FileText,
   Image as ImageIcon,
@@ -9,28 +9,28 @@ import {
   Save,
   ChevronLeft,
   Loader2,
-} from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
-import { Tabs } from "@/components/ui/Tabs";
-import { BlogPost } from "@/lib/blog";
-import { useToast } from "@/lib/toast-context";
+import { Tabs } from '@/components/ui/Tabs';
+import { BlogPost } from '@/lib/blog';
+import { useToast } from '@/lib/toast-context';
 
-import { useArticleGeneration } from "../_hooks/useArticleGeneration";
-import { useFormData } from "../_hooks/useFormData";
-import { useFormSave } from "../_hooks/useFormSave";
-import { useFormValidation } from "../_hooks/useFormValidation";
-import { useImageUpload } from "../_hooks/useImageUpload";
-import { useJsonLdGeneration } from "../_hooks/useJsonLdGeneration";
-import { useOneClickImageGeneration } from "../_hooks/useOneClickImageGeneration";
-import { useTagManagement } from "../_hooks/useTagManagement";
-import { useTextImprovement } from "../_hooks/useTextImprovement";
-import { generateSlugFromTitleAndCategory } from "../_utils/generateSlug";
+import { useArticleGeneration } from '../_hooks/useArticleGeneration';
+import { useFormData } from '../_hooks/useFormData';
+import { useFormSave } from '../_hooks/useFormSave';
+import { useFormValidation } from '../_hooks/useFormValidation';
+import { useImageUpload } from '../_hooks/useImageUpload';
+import { useJsonLdGeneration } from '../_hooks/useJsonLdGeneration';
+import { useOneClickImageGeneration } from '../_hooks/useOneClickImageGeneration';
+import { useTagManagement } from '../_hooks/useTagManagement';
+import { useTextImprovement } from '../_hooks/useTextImprovement';
+import { generateSlugFromTitleAndCategory } from '../_utils/generateSlug';
 
-import { ModalContainer } from "./ModalContainer";
-import { SocialDiffusionSection } from "./SocialDiffusionSection";
-import { EssentialsTab, ContentTab, MediaTab, AdvancedOptionsTab } from "./tabs";
+import { ModalContainer } from './ModalContainer';
+import { SocialDiffusionSection } from './SocialDiffusionSection';
+import { EssentialsTab, ContentTab, MediaTab, AdvancedOptionsTab } from './tabs';
 
 interface BlogPostFormProps {
   post?: BlogPost;
@@ -40,7 +40,7 @@ interface BlogPostFormProps {
 export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
   const router = useRouter();
   const isEditing = !!post;
-  const [activeTab, setActiveTab] = useState("essentials");
+  const [activeTab, setActiveTab] = useState('essentials');
   const [isLoadingJob, setIsLoadingJob] = useState(!!jobId);
 
   const { addToast } = useToast();
@@ -78,11 +78,8 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
   } = useOneClickImageGeneration(formData, updateFormData);
 
   // AI Feature Hooks
-  const {
-    isGeneratorModalOpen,
-    setIsGeneratorModalOpen,
-    handleGenerateArticleData,
-  } = useArticleGeneration(updateFormData, formData.image, generateImageFromArticleData);
+  const { isGeneratorModalOpen, setIsGeneratorModalOpen, handleGenerateArticleData } =
+    useArticleGeneration(updateFormData, formData.image, generateImageFromArticleData);
 
   const {
     isImproverOpen,
@@ -96,9 +93,8 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
   } = useTextImprovement(formData, updateFormData);
 
   // Manual image upload
-  const { isUploadingImage, handleUploadImage } = useImageUpload(
-    formData.slug,
-    (imagePath) => updateFormData({ image: imagePath })
+  const { isUploadingImage, handleUploadImage } = useImageUpload(formData.slug, imagePath =>
+    updateFormData({ image: imagePath })
   );
 
   // Initialize form with post data when editing
@@ -136,16 +132,16 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
         const response = await fetch(`/api/blog/jobs/${jobId}`);
 
         if (!response.ok) {
-          throw new Error("Erreur lors du chargement du job");
+          throw new Error('Erreur lors du chargement du job');
         }
 
         const job = await response.json();
 
-        if (job.status !== "COMPLETED" || !job.result?.article) {
+        if (job.status !== 'COMPLETED' || !job.result?.article) {
           addToast({
-            title: "Job non disponible",
+            title: 'Job non disponible',
             description: "Ce job n'est pas terminé ou ne contient pas de résultat",
-            variant: "error",
+            variant: 'error',
           });
           setIsLoadingJob(false);
           return;
@@ -154,9 +150,9 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
         // Check if job has already been used to create an article
         if (job.usedAt && job.articleSlug) {
           addToast({
-            title: "Job déjà utilisé",
+            title: 'Job déjà utilisé',
             description: `Ce job a déjà été utilisé pour créer un article. Redirection vers l'édition...`,
-            variant: "info",
+            variant: 'info',
           });
           router.push(`/admin/blog/edit/${job.articleSlug}`);
           return;
@@ -166,8 +162,8 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
 
         // Generate slug from title and category
         const baseSlug = generateSlugFromTitleAndCategory(
-          article.title || "",
-          article.category || "Comprendre"
+          article.title || '',
+          article.category || 'Comprendre'
         );
 
         // Check if slug already exists and get a unique one if needed
@@ -181,14 +177,14 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
             if (exists) {
               finalSlug = suggestedSlug;
               addToast({
-                title: "Slug modifié",
+                title: 'Slug modifié',
                 description: `Un article avec le slug "${baseSlug}" existe déjà. Nouveau slug : "${finalSlug}"`,
-                variant: "info",
+                variant: 'info',
               });
             }
           }
         } catch (slugCheckError) {
-          console.warn("Erreur vérification slug, utilisation du slug généré:", slugCheckError);
+          console.warn('Erreur vérification slug, utilisation du slug généré:', slugCheckError);
         }
 
         // Ensure FAQ items have unique IDs
@@ -201,29 +197,29 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
 
         // Update form with job data
         setFormData({
-          title: article.title || "",
+          title: article.title || '',
           slug: finalSlug,
-          description: article.description || "",
-          category: article.category || "Comprendre",
-          content: article.content || "",
+          description: article.description || '',
+          category: article.category || 'Comprendre',
+          content: article.content || '',
           tags: article.tags || [],
           faq: faqWithIds,
-          image: "",
-          imagePrompt: article.imagePrompt || "",
+          image: '',
+          imagePrompt: article.imagePrompt || '',
           published: false,
           featured: false,
-          date: new Date().toISOString().split("T")[0] ?? "",
-          author: "David Duquenne",
-          seoIntent: "",
-          persona: "",
+          date: new Date().toISOString().split('T')[0] ?? '',
+          author: 'David Duquenne',
+          seoIntent: '',
+          persona: '',
           tones: [],
           jsonLd: undefined,
         });
 
         addToast({
-          title: "Article chargé",
-          description: "Les données du job ont été appliquées au formulaire",
-          variant: "success",
+          title: 'Article chargé',
+          description: 'Les données du job ont été appliquées au formulaire',
+          variant: 'success',
         });
 
         // Trigger automatic image generation if imagePrompt exists
@@ -232,24 +228,24 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
             addToast({
               title: "Génération de l'image...",
               description: "L'image va être générée automatiquement",
-              variant: "info",
+              variant: 'info',
             });
             generateImageFromArticleData({
-              title: article.title || "",
-              content: article.content || "",
+              title: article.title || '',
+              content: article.content || '',
               slug: finalSlug,
-              category: article.category || "Comprendre",
+              category: article.category || 'Comprendre',
               tags: article.tags || [],
               imagePrompt: article.imagePrompt,
             });
           }, 500);
         }
       } catch (error) {
-        console.error("Erreur chargement job:", error);
+        console.error('Erreur chargement job:', error);
         addToast({
-          title: "Erreur",
-          description: "Impossible de charger les données du job",
-          variant: "error",
+          title: 'Erreur',
+          description: 'Impossible de charger les données du job',
+          variant: 'error',
         });
       } finally {
         setIsLoadingJob(false);
@@ -262,8 +258,8 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
   // Tab configuration
   const tabs = [
     {
-      id: "essentials",
-      label: "Essentiel",
+      id: 'essentials',
+      label: 'Essentiel',
       icon: FileText,
       children: (
         <EssentialsTab
@@ -276,25 +272,25 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
       ),
     },
     {
-      id: "content",
-      label: "Contenu",
+      id: 'content',
+      label: 'Contenu',
       icon: FileText,
       children: (
         <ContentTab
           content={formData.content}
           faqs={formData.faq}
           error={errors.content}
-          onContentChange={(content) => updateFormData({ content })}
-          onFAQChange={(faq) => updateFormData({ faq })}
+          onContentChange={content => updateFormData({ content })}
+          onFAQChange={faq => updateFormData({ faq })}
           onImproveClick={() => setIsImproverOpen(true)}
           onImproveSelection={handleImproveSelection}
-          onClearError={() => clearError("content")}
+          onClearError={() => clearError('content')}
         />
       ),
     },
     {
-      id: "media",
-      label: "Média",
+      id: 'media',
+      label: 'Média',
       icon: ImageIcon,
       children: (
         <MediaTab
@@ -308,8 +304,8 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
           isUploadingImage={isUploadingImage}
           isRegeneratingPrompt={isRegeneratingPrompt}
           imageProposals={imageProposals}
-          onImageChange={(image) => updateFormData({ image })}
-          onImagePromptChange={(imagePrompt) => updateFormData({ imagePrompt })}
+          onImageChange={image => updateFormData({ image })}
+          onImagePromptChange={imagePrompt => updateFormData({ imagePrompt })}
           onGenerateImage={generateImage}
           onUploadImage={handleUploadImage}
           onSelectProposal={selectProposal}
@@ -319,8 +315,8 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
       ),
     },
     {
-      id: "advanced",
-      label: "Options",
+      id: 'advanced',
+      label: 'Options',
       icon: Settings,
       children: (
         <AdvancedOptionsTab
@@ -343,7 +339,7 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
     return (
       <div className="flex min-h-[400px] items-center justify-center">
         <div className="flex flex-col items-center gap-4">
-          <Loader2 className="h-8 w-8 animate-spin text-gold" />
+          <Loader2 className="text-gold h-8 w-8 animate-spin" />
           <p className="text-ivory/70">Chargement des données de l'article...</p>
         </div>
       </div>
@@ -361,17 +357,17 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
       >
         <div className="flex items-center gap-4">
           <button
-            onClick={() => router.push("/admin/blog")}
-            className="rounded-lg p-2 text-ivory/70 transition hover:bg-gold/10 hover:text-ivory"
+            onClick={() => router.push('/admin/blog')}
+            className="text-ivory/70 hover:bg-gold/10 hover:text-ivory rounded-lg p-2 transition"
           >
             <ChevronLeft className="h-5 w-5" />
           </button>
           <div>
-            <p className="text-sm uppercase tracking-[0.3em] text-gold">
-              {isEditing ? "Modifier" : "Nouvel article"}
+            <p className="text-gold text-sm uppercase tracking-[0.3em]">
+              {isEditing ? 'Modifier' : 'Nouvel article'}
             </p>
-            <h1 className="mt-1 text-2xl font-semibold text-ivory truncate max-w-md">
-              {formData.title || "Sans titre"}
+            <h1 className="text-ivory mt-1 max-w-md truncate text-2xl font-semibold">
+              {formData.title || 'Sans titre'}
             </h1>
           </div>
         </div>
@@ -380,7 +376,7 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
           <button
             onClick={handleSave}
             disabled={isSaving}
-            className="flex items-center gap-2 rounded-lg bg-gold px-6 py-2.5 font-medium text-night transition hover:bg-gold/90 disabled:opacity-50"
+            className="bg-gold text-night hover:bg-gold/90 flex items-center gap-2 rounded-lg px-6 py-2.5 font-medium transition disabled:opacity-50"
           >
             {isSaving ? (
               <>
@@ -403,11 +399,7 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, delay: 0.1 }}
       >
-        <Tabs
-          items={tabs}
-          defaultTab="essentials"
-          onChange={setActiveTab}
-        />
+        <Tabs items={tabs} defaultTab="essentials" onChange={setActiveTab} />
       </motion.div>
 
       {/* Social Diffusion Section */}
@@ -416,12 +408,7 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, delay: 0.2 }}
       >
-        <SocialDiffusionSection
-          blogSlug={formData.slug}
-          blogTitle={formData.title}
-          blogImage={formData.image}
-          isNewPost={!isEditing}
-        />
+        <SocialDiffusionSection blogSlug={formData.slug} isNewPost={!isEditing} />
       </motion.div>
 
       {/* Action Footer */}
@@ -432,15 +419,15 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
         className="flex flex-col gap-3 sm:flex-row sm:justify-end"
       >
         <button
-          onClick={() => router.push("/admin/blog")}
-          className="rounded-lg border border-gold/20 px-6 py-3 font-medium text-ivory/70 transition hover:border-gold/40 hover:text-ivory"
+          onClick={() => router.push('/admin/blog')}
+          className="border-gold/20 text-ivory/70 hover:border-gold/40 hover:text-ivory rounded-lg border px-6 py-3 font-medium transition"
         >
           Annuler
         </button>
         <button
           onClick={handleSave}
           disabled={isSaving}
-          className="flex items-center justify-center gap-2 rounded-lg bg-gold px-8 py-3 font-medium text-night transition hover:bg-gold/90 disabled:opacity-50"
+          className="bg-gold text-night hover:bg-gold/90 flex items-center justify-center gap-2 rounded-lg px-8 py-3 font-medium transition disabled:opacity-50"
         >
           {isSaving ? (
             <>
@@ -450,7 +437,7 @@ export function BlogPostForm({ post, jobId }: BlogPostFormProps) {
           ) : formData.published ? (
             <>
               <Save className="h-5 w-5" />
-              {isEditing ? "Mettre à jour" : "Publier l'article"}
+              {isEditing ? 'Mettre à jour' : "Publier l'article"}
             </>
           ) : (
             <>

--- a/apps/psypnos/app/admin/blog/_components/SocialDiffusionSection.tsx
+++ b/apps/psypnos/app/admin/blog/_components/SocialDiffusionSection.tsx
@@ -1,153 +1,97 @@
-"use client";
+'use client';
 
-import {
-  Share2,
-  Sparkles,
-  Loader2,
-  Check,
-  ChevronDown,
-  Copy,
-  ExternalLink,
-  AlertCircle,
-} from "lucide-react";
-import { useState, useEffect, useCallback } from "react";
+import { Share2, Sparkles, Check, ChevronDown } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
 
-import { CONTENT_TONES, CONTENT_ANGLES } from "@/lib/social/prompts";
-import type { SocialPlatform, ContentTone, ContentAngle } from "@/lib/social/types";
+import type { SocialPlatform } from '@/lib/social/types';
 
-import { SocialPlatformIcon } from "../../social/accounts/_components/SocialPlatformIcon";
-
-
-interface GeneratedContent {
-  platform: SocialPlatform;
-  content: string;
-  hashtags: string[];
-  characterCount: number;
-}
+import { SocialPlatformIcon } from '../../social/accounts/_components/SocialPlatformIcon';
 
 interface SocialDiffusionSectionProps {
   blogSlug?: string;
-  blogTitle: string;
-  blogImage?: string;
   isNewPost: boolean;
 }
 
 const PLATFORMS: Array<{ id: SocialPlatform; name: string }> = [
-  { id: "FACEBOOK", name: "Facebook" },
-  { id: "LINKEDIN", name: "LinkedIn" },
-  { id: "INSTAGRAM", name: "Instagram" },
-  { id: "TWITTER", name: "Twitter/X" },
-  { id: "THREADS", name: "Threads" },
+  { id: 'FACEBOOK', name: 'Facebook' },
+  { id: 'LINKEDIN', name: 'LinkedIn' },
+  { id: 'INSTAGRAM', name: 'Instagram' },
+  { id: 'TWITTER', name: 'Twitter/X' },
+  { id: 'THREADS', name: 'Threads' },
 ];
 
-export function SocialDiffusionSection({
-  blogSlug,
-  blogTitle,
-  blogImage,
-  isNewPost,
-}: SocialDiffusionSectionProps) {
+/**
+ * Section de diffusion réseaux sociaux dans la page d'édition d'article.
+ * Permet de sélectionner les plateformes cibles et redirige vers le module
+ * de génération IA dédié (/admin/social/posts/new).
+ */
+export function SocialDiffusionSection({ blogSlug, isNewPost }: SocialDiffusionSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [selectedPlatforms, setSelectedPlatforms] = useState<SocialPlatform[]>([
-    "FACEBOOK",
-    "LINKEDIN",
-    "INSTAGRAM",
+    'FACEBOOK',
+    'LINKEDIN',
+    'INSTAGRAM',
   ]);
-  const [selectedTone, setSelectedTone] = useState<ContentTone>("inspirant");
-  const [selectedAngle, setSelectedAngle] = useState<ContentAngle>("benefices");
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [generations, setGenerations] = useState<GeneratedContent[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [copiedPlatform, setCopiedPlatform] = useState<SocialPlatform | null>(null);
 
   const togglePlatform = (platform: SocialPlatform) => {
-    setSelectedPlatforms((prev) =>
-      prev.includes(platform)
-        ? prev.filter((p) => p !== platform)
-        : [...prev, platform]
+    setSelectedPlatforms(prev =>
+      prev.includes(platform) ? prev.filter(p => p !== platform) : [...prev, platform]
     );
   };
 
-  const handleGenerate = useCallback(async () => {
-    if (!blogSlug || selectedPlatforms.length === 0) return;
-
-    setIsGenerating(true);
-    setError(null);
-
-    try {
-      const response = await fetch("/api/social/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          blogSlug,
-          platforms: selectedPlatforms,
-          tone: selectedTone,
-          angle: selectedAngle,
-        }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || "Erreur lors de la génération");
-      }
-
-      setGenerations(data.generations);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Erreur inconnue");
-    } finally {
-      setIsGenerating(false);
+  /**
+   * Construit l'URL de redirection vers le module de génération IA
+   * avec l'article et les plateformes pré-sélectionnés.
+   */
+  const buildGenerateUrl = () => {
+    const params = new URLSearchParams();
+    if (blogSlug) params.set('blogSlug', blogSlug);
+    if (selectedPlatforms.length > 0) {
+      params.set('platforms', selectedPlatforms.join(','));
     }
-  }, [blogSlug, selectedPlatforms, selectedTone, selectedAngle]);
-
-  const handleCopy = async (content: string, hashtags: string[], platform: SocialPlatform) => {
-    const fullContent = `${content}\n\n${hashtags.map((h) => `#${h}`).join(" ")}`;
-    await navigator.clipboard.writeText(fullContent);
-    setCopiedPlatform(platform);
-    setTimeout(() => setCopiedPlatform(null), 2000);
+    return `/admin/social/posts/new?${params.toString()}`;
   };
 
   // If new post without slug, show disabled state
   if (isNewPost && !blogSlug) {
     return (
-      <div className="rounded-xl border border-gold/10 bg-night/30 p-4">
-        <div className="flex items-center gap-3 text-ivory/40">
+      <div className="border-gold/10 bg-night/30 rounded-xl border p-4">
+        <div className="text-ivory/40 flex items-center gap-3">
           <Share2 className="h-5 w-5" />
-          <span>Sauvegardez l'article pour activer la diffusion sociale</span>
+          <span>Sauvegardez l&apos;article pour activer la diffusion sociale</span>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="rounded-xl border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 backdrop-blur-sm overflow-hidden">
+    <div className="border-gold/20 from-night/60 to-night/40 overflow-hidden rounded-xl border bg-gradient-to-br backdrop-blur-sm">
       {/* Header */}
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="flex w-full items-center justify-between px-6 py-4 hover:bg-gold/5 transition"
+        className="hover:bg-gold/5 flex w-full items-center justify-between px-6 py-4 transition"
       >
         <div className="flex items-center gap-3">
-          <Share2 className="h-5 w-5 text-gold" />
-          <span className="font-semibold text-ivory">Diffusion réseaux sociaux</span>
-          {generations.length > 0 && (
-            <span className="rounded-full bg-green-500/20 px-2 py-0.5 text-xs text-green-400">
-              {generations.length} posts générés
-            </span>
-          )}
+          <Share2 className="text-gold h-5 w-5" />
+          <span className="text-ivory font-semibold">Diffusion réseaux sociaux</span>
         </div>
         <ChevronDown
-          className={`h-5 w-5 text-gold transition-transform ${isExpanded ? "rotate-180" : ""}`}
+          className={`text-gold h-5 w-5 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
         />
       </button>
 
       {/* Content */}
       {isExpanded && (
-        <div className="border-t border-gold/10 px-6 py-4 space-y-5">
+        <div className="border-gold/10 space-y-5 border-t px-6 py-4">
           {/* Platform Selection */}
           <div>
-            <p className="mb-3 text-sm font-medium text-ivory">Plateformes</p>
+            <p className="text-ivory mb-3 text-sm font-medium">
+              Sélectionnez les plateformes cibles
+            </p>
             <div className="flex flex-wrap gap-2">
-              {PLATFORMS.map((platform) => {
+              {PLATFORMS.map(platform => {
                 const isSelected = selectedPlatforms.includes(platform.id);
                 return (
                   <button
@@ -156,136 +100,35 @@ export function SocialDiffusionSection({
                     onClick={() => togglePlatform(platform.id)}
                     className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition ${
                       isSelected
-                        ? "bg-gold/20 text-gold ring-1 ring-gold/30"
-                        : "bg-night/60 text-ivory/60 hover:bg-gold/10 hover:text-ivory"
+                        ? 'bg-gold/20 text-gold ring-gold/30 ring-1'
+                        : 'bg-night/60 text-ivory/60 hover:bg-gold/10 hover:text-ivory'
                     }`}
                   >
                     <SocialPlatformIcon platform={platform.id} className="h-4 w-4" />
                     {platform.name}
+                    {isSelected && <Check className="h-3.5 w-3.5" />}
                   </button>
                 );
               })}
             </div>
           </div>
 
-          {/* Tone & Angle */}
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div>
-              <label className="mb-2 block text-sm font-medium text-ivory">Ton</label>
-              <select
-                value={selectedTone}
-                onChange={(e) => setSelectedTone(e.target.value as ContentTone)}
-                className="w-full rounded-lg border border-gold/20 bg-night/50 px-3 py-2 text-sm text-ivory transition focus:border-gold focus:outline-none"
-              >
-                {Object.values(CONTENT_TONES).map((tone) => (
-                  <option key={tone.id} value={tone.id}>
-                    {tone.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="mb-2 block text-sm font-medium text-ivory">Angle</label>
-              <select
-                value={selectedAngle}
-                onChange={(e) => setSelectedAngle(e.target.value as ContentAngle)}
-                className="w-full rounded-lg border border-gold/20 bg-night/50 px-3 py-2 text-sm text-ivory transition focus:border-gold focus:outline-none"
-              >
-                {Object.values(CONTENT_ANGLES).map((angle) => (
-                  <option key={angle.id} value={angle.id}>
-                    {angle.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          {/* Generate Button */}
-          <button
-            type="button"
-            onClick={handleGenerate}
-            disabled={isGenerating || selectedPlatforms.length === 0}
-            className="flex w-full items-center justify-center gap-2 rounded-lg bg-gold/20 px-4 py-3 font-medium text-gold transition hover:bg-gold/30 disabled:opacity-50"
+          {/* Generate Button — redirects to /admin/social/posts/new */}
+          <Link
+            href={buildGenerateUrl()}
+            className={`bg-gold/20 text-gold hover:bg-gold/30 flex w-full items-center justify-center gap-2 rounded-lg px-4 py-3 font-medium transition ${
+              selectedPlatforms.length === 0 ? 'pointer-events-none opacity-50' : ''
+            }`}
+            aria-disabled={selectedPlatforms.length === 0}
           >
-            {isGenerating ? (
-              <>
-                <Loader2 className="h-5 w-5 animate-spin" />
-                Génération en cours...
-              </>
-            ) : (
-              <>
-                <Sparkles className="h-5 w-5" />
-                Générer les posts
-              </>
-            )}
-          </button>
+            <Sparkles className="h-5 w-5" />
+            Générer les posts IA
+          </Link>
 
-          {/* Error */}
-          {error && (
-            <div className="flex items-start gap-2 rounded-lg bg-red-500/10 p-3">
-              <AlertCircle className="h-5 w-5 flex-shrink-0 text-red-400" />
-              <p className="text-sm text-red-400">{error}</p>
-            </div>
-          )}
-
-          {/* Generated Content */}
-          {generations.length > 0 && (
-            <div className="space-y-4">
-              <p className="text-sm font-medium text-ivory">Contenu généré</p>
-
-              {generations.map((gen) => (
-                <div
-                  key={gen.platform}
-                  className="rounded-lg border border-gold/10 bg-night/40 overflow-hidden"
-                >
-                  <div className="flex items-center justify-between border-b border-gold/10 px-4 py-2">
-                    <div className="flex items-center gap-2">
-                      <SocialPlatformIcon platform={gen.platform} className="h-4 w-4" />
-                      <span className="font-medium text-ivory">
-                        {PLATFORMS.find((p) => p.id === gen.platform)?.name}
-                      </span>
-                      <span className="text-xs text-ivory/40">
-                        {gen.characterCount} caractères
-                      </span>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handleCopy(gen.content, gen.hashtags, gen.platform)}
-                      className="flex items-center gap-1.5 rounded px-2 py-1 text-xs text-gold hover:bg-gold/10 transition"
-                    >
-                      {copiedPlatform === gen.platform ? (
-                        <>
-                          <Check className="h-3.5 w-3.5" />
-                          Copié !
-                        </>
-                      ) : (
-                        <>
-                          <Copy className="h-3.5 w-3.5" />
-                          Copier
-                        </>
-                      )}
-                    </button>
-                  </div>
-                  <div className="p-4">
-                    <p className="whitespace-pre-wrap text-sm text-ivory/80">{gen.content}</p>
-                    {gen.hashtags.length > 0 && (
-                      <p className="mt-3 text-sm text-gold/70">
-                        {gen.hashtags.map((h) => `#${h}`).join(" ")}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              ))}
-
-              {/* Link to full social page */}
-              <a
-                href={`/admin/social/posts/new?blogSlug=${blogSlug}`}
-                className="flex items-center justify-center gap-2 rounded-lg border border-gold/20 px-4 py-2.5 text-sm text-ivory/70 transition hover:border-gold/40 hover:text-ivory"
-              >
-                <ExternalLink className="h-4 w-4" />
-                Ouvrir dans l'éditeur complet
-              </a>
-            </div>
+          {selectedPlatforms.length === 0 && (
+            <p className="text-ivory/40 text-center text-xs">
+              Sélectionnez au moins une plateforme pour continuer
+            </p>
           )}
         </div>
       )}

--- a/apps/psypnos/app/admin/social/posts/new/page.tsx
+++ b/apps/psypnos/app/admin/social/posts/new/page.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
-import { motion } from "framer-motion";
+import { motion } from 'framer-motion';
 import {
   Sparkles,
   ChevronLeft,
@@ -13,15 +13,15 @@ import {
   RotateCcw,
   Save,
   FileText,
-} from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState, useRef } from "react";
+} from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useState, useRef } from 'react';
 
-import { CONTENT_TONES, CONTENT_ANGLES } from "@/lib/social/prompts";
-import { FACEBOOK_FORMATS, FACEBOOK_TONE_LEVELS } from "@/lib/social/prompts/facebook-specs";
-import { INSTAGRAM_FORMATS, AUTHENTICITY_LEVELS } from "@/lib/social/prompts/instagram-specs";
-import { LINKEDIN_FORMATS, LINKEDIN_EXPERTISE_LEVELS } from "@/lib/social/prompts/linkedin-specs";
-import { THREADS_FORMATS, THREADS_AUTHENTICITY_LEVELS } from "@/lib/social/prompts/threads-specs";
+import { CONTENT_TONES, CONTENT_ANGLES } from '@/lib/social/prompts';
+import { FACEBOOK_FORMATS, FACEBOOK_TONE_LEVELS } from '@/lib/social/prompts/facebook-specs';
+import { INSTAGRAM_FORMATS, AUTHENTICITY_LEVELS } from '@/lib/social/prompts/instagram-specs';
+import { LINKEDIN_FORMATS, LINKEDIN_EXPERTISE_LEVELS } from '@/lib/social/prompts/linkedin-specs';
+import { THREADS_FORMATS, THREADS_AUTHENTICITY_LEVELS } from '@/lib/social/prompts/threads-specs';
 import type {
   SocialPlatform,
   ContentTone,
@@ -35,14 +35,14 @@ import type {
   FacebookToneLevel,
   LinkedInPostFormat,
   LinkedInExpertiseLevel,
-} from "@/lib/social/types";
-import { useToast } from "@/lib/toast-context";
+} from '@/lib/social/types';
+import { useToast } from '@/lib/toast-context';
 
-import { SocialPlatformIcon } from "../../accounts/_components/SocialPlatformIcon";
+import { SocialPlatformIcon } from '../../accounts/_components/SocialPlatformIcon';
 
-import { ArticleSelector } from "./_components/ArticleSelector";
-import { GeneratedContentPreview } from "./_components/GeneratedContentPreview";
-import { SavePostModal } from "./_components/SavePostModal";
+import { ArticleSelector } from './_components/ArticleSelector';
+import { GeneratedContentPreview } from './_components/GeneratedContentPreview';
+import { SavePostModal } from './_components/SavePostModal';
 
 // ===========================================
 // Types
@@ -75,29 +75,29 @@ const AVAILABLE_PLATFORMS: Array<{
   description: string;
 }> = [
   {
-    id: "FACEBOOK",
-    name: "Facebook",
-    description: "Posts pour Pages Facebook",
+    id: 'FACEBOOK',
+    name: 'Facebook',
+    description: 'Posts pour Pages Facebook',
   },
   {
-    id: "LINKEDIN",
-    name: "LinkedIn",
-    description: "Posts professionnels",
+    id: 'LINKEDIN',
+    name: 'LinkedIn',
+    description: 'Posts professionnels',
   },
   {
-    id: "INSTAGRAM",
-    name: "Instagram",
-    description: "Captions Instagram",
+    id: 'INSTAGRAM',
+    name: 'Instagram',
+    description: 'Captions Instagram',
   },
   {
-    id: "TWITTER",
-    name: "Twitter/X",
-    description: "Tweets courts et percutants",
+    id: 'TWITTER',
+    name: 'Twitter/X',
+    description: 'Tweets courts et percutants',
   },
   {
-    id: "THREADS",
-    name: "Threads",
-    description: "Posts conversationnels",
+    id: 'THREADS',
+    name: 'Threads',
+    description: 'Posts conversationnels',
   },
 ];
 
@@ -110,41 +110,59 @@ export default function NewSocialPostPage() {
   const searchParams = useSearchParams();
   const { addToast } = useToast();
 
-  // Récupérer le blogSlug depuis l'URL pour pré-sélectionner l'article
-  const blogSlugFromUrl = searchParams?.get("blogSlug") ?? null;
+  // Récupérer le blogSlug et les plateformes depuis l'URL pour pré-sélection
+  const blogSlugFromUrl = searchParams?.get('blogSlug') ?? null;
+  const platformsFromUrl = searchParams?.get('platforms') ?? null;
+
+  /**
+   * Parse les plateformes depuis le paramètre URL.
+   * Retourne les plateformes par défaut si le paramètre est absent ou invalide.
+   */
+  const parsePlatformsFromUrl = (): SocialPlatform[] => {
+    if (!platformsFromUrl) return ['FACEBOOK', 'LINKEDIN', 'INSTAGRAM'];
+    const validPlatforms: SocialPlatform[] = [
+      'FACEBOOK',
+      'LINKEDIN',
+      'INSTAGRAM',
+      'TWITTER',
+      'THREADS',
+    ];
+    const parsed = platformsFromUrl
+      .split(',')
+      .filter((p): p is SocialPlatform => validPlatforms.includes(p as SocialPlatform));
+    return parsed.length > 0 ? parsed : ['FACEBOOK', 'LINKEDIN', 'INSTAGRAM'];
+  };
 
   // Form state
   const [selectedArticle, setSelectedArticle] = useState<BlogPost | null>(null);
-  const [selectedPlatforms, setSelectedPlatforms] = useState<SocialPlatform[]>([
-    "FACEBOOK",
-    "LINKEDIN",
-    "INSTAGRAM",
-  ]);
-  const [selectedTone, setSelectedTone] = useState<ContentTone>("inspirant");
-  const [selectedAngle, setSelectedAngle] = useState<ContentAngle>("benefices");
-  const [customInstructions, setCustomInstructions] = useState("");
+  const [selectedPlatforms, setSelectedPlatforms] =
+    useState<SocialPlatform[]>(parsePlatformsFromUrl());
+  const [selectedTone, setSelectedTone] = useState<ContentTone>('inspirant');
+  const [selectedAngle, setSelectedAngle] = useState<ContentAngle>('benefices');
+  const [customInstructions, setCustomInstructions] = useState('');
 
   // Options spécifiques Instagram
-  const [instagramFormat, setInstagramFormat] = useState<InstagramPostFormat>("hook_reveal");
+  const [instagramFormat, setInstagramFormat] = useState<InstagramPostFormat>('hook_reveal');
   const [authenticityLevel, setAuthenticityLevel] = useState<AuthenticityLevel>(3);
 
   // Options spécifiques Threads
-  const [threadsFormat, setThreadsFormat] = useState<ThreadsPostFormat>("pensee_brute");
-  const [threadsAuthenticityLevel, setThreadsAuthenticityLevel] = useState<ThreadsAuthenticityLevel>(3);
+  const [threadsFormat, setThreadsFormat] = useState<ThreadsPostFormat>('pensee_brute');
+  const [threadsAuthenticityLevel, setThreadsAuthenticityLevel] =
+    useState<ThreadsAuthenticityLevel>(3);
 
   // Options spécifiques Facebook
-  const [facebookFormat, setFacebookFormat] = useState<FacebookPostFormat>("confession");
+  const [facebookFormat, setFacebookFormat] = useState<FacebookPostFormat>('confession');
   const [facebookToneLevel, setFacebookToneLevel] = useState<FacebookToneLevel>(2);
 
   // Options spécifiques LinkedIn
-  const [linkedinFormat, setLinkedinFormat] = useState<LinkedInPostFormat>("observation_pro");
+  const [linkedinFormat, setLinkedinFormat] = useState<LinkedInPostFormat>('observation_pro');
   const [linkedinExpertiseLevel, setLinkedinExpertiseLevel] = useState<LinkedInExpertiseLevel>(3);
 
   // Vérifier si Instagram, Threads, Facebook ou LinkedIn est sélectionné
-  const isInstagramSelected = selectedPlatforms.includes("INSTAGRAM");
-  const isThreadsSelected = selectedPlatforms.includes("THREADS");
-  const isFacebookSelected = selectedPlatforms.includes("FACEBOOK");
-  const isLinkedInSelected = selectedPlatforms.includes("LINKEDIN");
+  const isInstagramSelected = selectedPlatforms.includes('INSTAGRAM');
+  const isThreadsSelected = selectedPlatforms.includes('THREADS');
+  const isFacebookSelected = selectedPlatforms.includes('FACEBOOK');
+  const isLinkedInSelected = selectedPlatforms.includes('LINKEDIN');
 
   // Generation state
   const [generation, setGeneration] = useState<GenerationState>({
@@ -168,20 +186,19 @@ export default function NewSocialPostPage() {
   useEffect(() => {
     async function loadArticles() {
       try {
-        const response = await fetch(
-          "/api/blog/posts?includeUnpublished=false&t=" + Date.now(),
-          { cache: "no-store" }
-        );
+        const response = await fetch('/api/blog/posts?includeUnpublished=false&t=' + Date.now(), {
+          cache: 'no-store',
+        });
 
-        if (!response.ok) throw new Error("Failed to fetch articles");
+        if (!response.ok) throw new Error('Failed to fetch articles');
 
         const data = await response.json();
         setArticles(data);
       } catch (error) {
-        console.error("Error loading articles:", error);
+        console.error('Error loading articles:', error);
         addToast({
-          title: "Impossible de charger les articles",
-          variant: "error",
+          title: 'Impossible de charger les articles',
+          variant: 'error',
         });
       } finally {
         setIsLoadingArticles(false);
@@ -194,15 +211,19 @@ export default function NewSocialPostPage() {
   // Pré-sélectionner l'article si un blogSlug est fourni dans l'URL
   useEffect(() => {
     // Ne traiter que si on a un nouveau slug différent du dernier traité
-    if (blogSlugFromUrl && articles.length > 0 && blogSlugFromUrl !== lastProcessedSlugRef.current) {
-      const article = articles.find((a) => a.slug === blogSlugFromUrl);
+    if (
+      blogSlugFromUrl &&
+      articles.length > 0 &&
+      blogSlugFromUrl !== lastProcessedSlugRef.current
+    ) {
+      const article = articles.find(a => a.slug === blogSlugFromUrl);
       if (article) {
         lastProcessedSlugRef.current = blogSlugFromUrl;
         setSelectedArticle(article);
         addToast({
-          title: "Article pré-sélectionné",
+          title: 'Article pré-sélectionné',
           description: article.title,
-          variant: "info",
+          variant: 'info',
         });
       }
     }
@@ -210,10 +231,8 @@ export default function NewSocialPostPage() {
 
   // Toggle platform selection
   const togglePlatform = useCallback((platform: SocialPlatform) => {
-    setSelectedPlatforms((prev) =>
-      prev.includes(platform)
-        ? prev.filter((p) => p !== platform)
-        : [...prev, platform]
+    setSelectedPlatforms(prev =>
+      prev.includes(platform) ? prev.filter(p => p !== platform) : [...prev, platform]
     );
   }, []);
 
@@ -221,16 +240,16 @@ export default function NewSocialPostPage() {
   const handleGenerate = useCallback(async () => {
     if (!selectedArticle) {
       addToast({
-        title: "Veuillez sélectionner un article",
-        variant: "error",
+        title: 'Veuillez sélectionner un article',
+        variant: 'error',
       });
       return;
     }
 
     if (selectedPlatforms.length === 0) {
       addToast({
-        title: "Veuillez sélectionner au moins une plateforme",
-        variant: "error",
+        title: 'Veuillez sélectionner au moins une plateforme',
+        variant: 'error',
       });
       return;
     }
@@ -243,9 +262,9 @@ export default function NewSocialPostPage() {
     });
 
     try {
-      const response = await fetch("/api/social/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const response = await fetch('/api/social/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           blogSlug: selectedArticle.slug,
           platforms: selectedPlatforms,
@@ -270,7 +289,7 @@ export default function NewSocialPostPage() {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || "Erreur lors de la génération");
+        throw new Error(data.error || 'Erreur lors de la génération');
       }
 
       setGeneration({
@@ -281,22 +300,22 @@ export default function NewSocialPostPage() {
       });
 
       addToast({
-        title: "Contenu généré avec succès",
+        title: 'Contenu généré avec succès',
         description: `${data.generations.length} post(s) créé(s)`,
-        variant: "success",
+        variant: 'success',
       });
     } catch (error) {
-      console.error("Generation error:", error);
-      setGeneration((prev) => ({
+      console.error('Generation error:', error);
+      setGeneration(prev => ({
         ...prev,
         isGenerating: false,
-        error: error instanceof Error ? error.message : "Erreur inconnue",
+        error: error instanceof Error ? error.message : 'Erreur inconnue',
       }));
 
       addToast({
-        title: "Erreur de génération",
-        description: error instanceof Error ? error.message : "Erreur inconnue",
-        variant: "error",
+        title: 'Erreur de génération',
+        description: error instanceof Error ? error.message : 'Erreur inconnue',
+        variant: 'error',
       });
     }
   }, [
@@ -321,17 +340,14 @@ export default function NewSocialPostPage() {
   ]);
 
   // Update generated content
-  const handleUpdateContent = useCallback(
-    (platform: SocialPlatform, newContent: string) => {
-      setGeneration((prev) => ({
-        ...prev,
-        generations: prev.generations.map((g) =>
-          g.platform === platform ? { ...g, content: newContent } : g
-        ),
-      }));
-    },
-    []
-  );
+  const handleUpdateContent = useCallback((platform: SocialPlatform, newContent: string) => {
+    setGeneration(prev => ({
+      ...prev,
+      generations: prev.generations.map(g =>
+        g.platform === platform ? { ...g, content: newContent } : g
+      ),
+    }));
+  }, []);
 
   // Copy content to clipboard
   const handleCopyContent = useCallback(
@@ -339,13 +355,13 @@ export default function NewSocialPostPage() {
       try {
         await navigator.clipboard.writeText(content);
         addToast({
-          title: "Contenu copié",
-          variant: "success",
+          title: 'Contenu copié',
+          variant: 'success',
         });
       } catch {
         addToast({
-          title: "Erreur lors de la copie",
-          variant: "error",
+          title: 'Erreur lors de la copie',
+          variant: 'error',
         });
       }
     },
@@ -355,9 +371,9 @@ export default function NewSocialPostPage() {
   // Handle save success
   const handleSaveSuccess = useCallback(() => {
     addToast({
-      title: "Posts sauvegardés",
-      description: "Les posts ont été ajoutés au calendrier de publication",
-      variant: "success",
+      title: 'Posts sauvegardés',
+      description: 'Les posts ont été ajoutés au calendrier de publication',
+      variant: 'success',
     });
     // Reset generation state
     setGeneration({
@@ -367,7 +383,7 @@ export default function NewSocialPostPage() {
       tokensUsed: 0,
     });
     // Redirect to calendar
-    router.push("/admin/social/calendar");
+    router.push('/admin/social/calendar');
   }, [addToast, router]);
 
   return (
@@ -381,17 +397,13 @@ export default function NewSocialPostPage() {
         <div className="flex items-center gap-4">
           <button
             onClick={() => router.back()}
-            className="rounded-lg p-2 text-ivory/70 transition hover:bg-gold/10 hover:text-ivory"
+            className="text-ivory/70 hover:bg-gold/10 hover:text-ivory rounded-lg p-2 transition"
           >
             <ChevronLeft className="h-5 w-5" />
           </button>
           <div>
-            <p className="text-sm uppercase tracking-[0.3em] text-gold">
-              Réseaux sociaux
-            </p>
-            <h1 className="mt-2 text-3xl font-semibold text-ivory">
-              Générer du contenu
-            </h1>
+            <p className="text-gold text-sm uppercase tracking-[0.3em]">Réseaux sociaux</p>
+            <h1 className="text-ivory mt-2 text-3xl font-semibold">Générer du contenu</h1>
           </div>
         </div>
       </motion.div>
@@ -406,9 +418,9 @@ export default function NewSocialPostPage() {
           className="space-y-6"
         >
           {/* Article Selection - z-index élevé pour que le dropdown passe au-dessus des autres panneaux */}
-          <div className="relative z-50 rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
-            <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-ivory">
-              <FileText className="h-5 w-5 text-gold" />
+          <div className="border-gold/20 from-night/60 to-night/40 relative z-50 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
+            <h2 className="text-ivory mb-4 flex items-center gap-2 text-lg font-semibold">
+              <FileText className="text-gold h-5 w-5" />
               Article source
             </h2>
 
@@ -421,19 +433,17 @@ export default function NewSocialPostPage() {
           </div>
 
           {/* Platform Selection - z-index plus bas pour rester en dessous du dropdown d'article */}
-          <div className="relative z-10 rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
-            <h2 className="mb-4 text-lg font-semibold text-ivory">
-              Plateformes cibles
-            </h2>
+          <div className="border-gold/20 from-night/60 to-night/40 relative z-10 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
+            <h2 className="text-ivory mb-4 text-lg font-semibold">Plateformes cibles</h2>
 
             <div className="space-y-3">
-              {AVAILABLE_PLATFORMS.map((platform) => (
+              {AVAILABLE_PLATFORMS.map(platform => (
                 <label
                   key={platform.id}
                   className={`flex cursor-pointer items-center gap-4 rounded-lg border p-4 transition ${
                     selectedPlatforms.includes(platform.id)
-                      ? "border-gold/40 bg-gold/10"
-                      : "border-gold/10 bg-night/30 hover:border-gold/20"
+                      ? 'border-gold/40 bg-gold/10'
+                      : 'border-gold/10 bg-night/30 hover:border-gold/20'
                   }`}
                 >
                   <input
@@ -442,26 +452,19 @@ export default function NewSocialPostPage() {
                     onChange={() => togglePlatform(platform.id)}
                     className="sr-only"
                   />
-                  <SocialPlatformIcon
-                    platform={platform.id}
-                    className="h-8 w-8"
-                  />
+                  <SocialPlatformIcon platform={platform.id} className="h-8 w-8" />
                   <div className="flex-1">
-                    <p className="font-medium text-ivory">{platform.name}</p>
-                    <p className="text-sm text-ivory/60">
-                      {platform.description}
-                    </p>
+                    <p className="text-ivory font-medium">{platform.name}</p>
+                    <p className="text-ivory/60 text-sm">{platform.description}</p>
                   </div>
                   <div
                     className={`flex h-6 w-6 items-center justify-center rounded border transition ${
                       selectedPlatforms.includes(platform.id)
-                        ? "border-gold bg-gold text-night"
-                        : "border-ivory/30"
+                        ? 'border-gold bg-gold text-night'
+                        : 'border-ivory/30'
                     }`}
                   >
-                    {selectedPlatforms.includes(platform.id) && (
-                      <Check className="h-4 w-4" />
-                    )}
+                    {selectedPlatforms.includes(platform.id) && <Check className="h-4 w-4" />}
                   </div>
                 </label>
               ))}
@@ -469,25 +472,19 @@ export default function NewSocialPostPage() {
           </div>
 
           {/* Tone & Angle */}
-          <div className="rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
-            <h2 className="mb-4 text-lg font-semibold text-ivory">
-              Ton et angle
-            </h2>
+          <div className="border-gold/20 from-night/60 to-night/40 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
+            <h2 className="text-ivory mb-4 text-lg font-semibold">Ton et angle</h2>
 
             <div className="space-y-4">
               {/* Tone Selection */}
               <div>
-                <label className="mb-2 block text-sm font-medium text-ivory/80">
-                  Ton
-                </label>
+                <label className="text-ivory/80 mb-2 block text-sm font-medium">Ton</label>
                 <select
                   value={selectedTone}
-                  onChange={(e) =>
-                    setSelectedTone(e.target.value as ContentTone)
-                  }
-                  className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory transition focus:border-gold focus:outline-none"
+                  onChange={e => setSelectedTone(e.target.value as ContentTone)}
+                  className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none"
                 >
-                  {Object.values(CONTENT_TONES).map((tone) => (
+                  {Object.values(CONTENT_TONES).map(tone => (
                     <option key={tone.id} value={tone.id}>
                       {tone.name} - {tone.description}
                     </option>
@@ -497,17 +494,13 @@ export default function NewSocialPostPage() {
 
               {/* Angle Selection */}
               <div>
-                <label className="mb-2 block text-sm font-medium text-ivory/80">
-                  Angle
-                </label>
+                <label className="text-ivory/80 mb-2 block text-sm font-medium">Angle</label>
                 <select
                   value={selectedAngle}
-                  onChange={(e) =>
-                    setSelectedAngle(e.target.value as ContentAngle)
-                  }
-                  className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory transition focus:border-gold focus:outline-none"
+                  onChange={e => setSelectedAngle(e.target.value as ContentAngle)}
+                  className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none"
                 >
-                  {Object.values(CONTENT_ANGLES).map((angle) => (
+                  {Object.values(CONTENT_ANGLES).map(angle => (
                     <option key={angle.id} value={angle.id}>
                       {angle.name} - {angle.description}
                     </option>
@@ -517,16 +510,15 @@ export default function NewSocialPostPage() {
 
               {/* Custom Instructions */}
               <div>
-                <label className="mb-2 block text-sm font-medium text-ivory/80">
-                  Instructions personnalisées{" "}
-                  <span className="text-ivory/50">(optionnel)</span>
+                <label className="text-ivory/80 mb-2 block text-sm font-medium">
+                  Instructions personnalisées <span className="text-ivory/50">(optionnel)</span>
                 </label>
                 <textarea
                   value={customInstructions}
-                  onChange={(e) => setCustomInstructions(e.target.value)}
+                  onChange={e => setCustomInstructions(e.target.value)}
                   placeholder="Ex: Mettre l'accent sur l'aspect pratique, mentionner une promotion en cours..."
                   rows={3}
-                  className="w-full resize-none rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory placeholder-ivory/40 transition focus:border-gold focus:outline-none"
+                  className="border-gold/20 bg-night/50 text-ivory placeholder-ivory/40 focus:border-gold w-full resize-none rounded-lg border px-4 py-3 transition focus:outline-none"
                 />
               </div>
             </div>
@@ -534,8 +526,8 @@ export default function NewSocialPostPage() {
 
           {/* Instagram Options - Affiché uniquement si Instagram est sélectionné */}
           {isInstagramSelected && (
-            <div className="rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
-              <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-ivory">
+            <div className="border-gold/20 from-night/60 to-night/40 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
+              <h2 className="text-ivory mb-4 flex items-center gap-2 text-lg font-semibold">
                 <SocialPlatformIcon platform="INSTAGRAM" className="h-5 w-5" />
                 Options Instagram
               </h2>
@@ -543,60 +535,56 @@ export default function NewSocialPostPage() {
               <div className="space-y-4">
                 {/* Format Selection */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
                     Format de post
                   </label>
                   <select
                     value={instagramFormat}
-                    onChange={(e) =>
-                      setInstagramFormat(e.target.value as InstagramPostFormat)
-                    }
-                    className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory transition focus:border-gold focus:outline-none"
+                    onChange={e => setInstagramFormat(e.target.value as InstagramPostFormat)}
+                    className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none"
                   >
-                    {Object.values(INSTAGRAM_FORMATS).map((format) => (
+                    {Object.values(INSTAGRAM_FORMATS).map(format => (
                       <option key={format.id} value={format.id}>
                         {format.name} - {format.description}
                       </option>
                     ))}
                   </select>
-                  <p className="mt-2 text-xs text-ivory/50">
-                    {INSTAGRAM_FORMATS[instagramFormat].bestFor.join(" • ")}
+                  <p className="text-ivory/50 mt-2 text-xs">
+                    {INSTAGRAM_FORMATS[instagramFormat].bestFor.join(' • ')}
                   </p>
                 </div>
 
                 {/* Authenticity Level */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
-                    Niveau d&apos;authenticité:{" "}
-                    <span className="text-gold">
-                      {AUTHENTICITY_LEVELS[authenticityLevel].name}
-                    </span>
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
+                    Niveau d&apos;authenticité:{' '}
+                    <span className="text-gold">{AUTHENTICITY_LEVELS[authenticityLevel].name}</span>
                   </label>
                   <input
                     type="range"
                     min="1"
                     max="5"
                     value={authenticityLevel}
-                    onChange={(e) =>
+                    onChange={e =>
                       setAuthenticityLevel(Number(e.target.value) as AuthenticityLevel)
                     }
-                    className="w-full accent-gold"
+                    className="accent-gold w-full"
                   />
-                  <div className="mt-1 flex justify-between text-xs text-ivory/50">
+                  <div className="text-ivory/50 mt-1 flex justify-between text-xs">
                     <span>Professionnel</span>
                     <span>Vulnérable</span>
                   </div>
-                  <p className="mt-2 text-xs text-ivory/50">
+                  <p className="text-ivory/50 mt-2 text-xs">
                     {AUTHENTICITY_LEVELS[authenticityLevel].description}
                   </p>
                 </div>
 
                 {/* Format Preview */}
-                <div className="rounded-lg bg-night/30 p-4">
-                  <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gold/70">
+                <div className="bg-night/30 rounded-lg p-4">
+                  <p className="text-gold/70 mb-2 text-xs font-medium uppercase tracking-wider">
                     Exemple de structure
                   </p>
-                  <pre className="whitespace-pre-wrap text-xs text-ivory/70">
+                  <pre className="text-ivory/70 whitespace-pre-wrap text-xs">
                     {INSTAGRAM_FORMATS[instagramFormat].example.slice(0, 300)}...
                   </pre>
                 </div>
@@ -606,8 +594,8 @@ export default function NewSocialPostPage() {
 
           {/* Threads Options - Affiché uniquement si Threads est sélectionné */}
           {isThreadsSelected && (
-            <div className="rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
-              <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-ivory">
+            <div className="border-gold/20 from-night/60 to-night/40 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
+              <h2 className="text-ivory mb-4 flex items-center gap-2 text-lg font-semibold">
                 <SocialPlatformIcon platform="THREADS" className="h-5 w-5" />
                 Options Threads
               </h2>
@@ -615,31 +603,29 @@ export default function NewSocialPostPage() {
               <div className="space-y-4">
                 {/* Format Selection */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
                     Format de post
                   </label>
                   <select
                     value={threadsFormat}
-                    onChange={(e) =>
-                      setThreadsFormat(e.target.value as ThreadsPostFormat)
-                    }
-                    className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory transition focus:border-gold focus:outline-none"
+                    onChange={e => setThreadsFormat(e.target.value as ThreadsPostFormat)}
+                    className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none"
                   >
-                    {Object.values(THREADS_FORMATS).map((format) => (
+                    {Object.values(THREADS_FORMATS).map(format => (
                       <option key={format.id} value={format.id}>
                         {format.name} - {format.description.slice(0, 50)}...
                       </option>
                     ))}
                   </select>
-                  <p className="mt-2 text-xs text-ivory/50">
-                    Idéal pour : {THREADS_FORMATS[threadsFormat].bestFor.join(" • ")}
+                  <p className="text-ivory/50 mt-2 text-xs">
+                    Idéal pour : {THREADS_FORMATS[threadsFormat].bestFor.join(' • ')}
                   </p>
                 </div>
 
                 {/* Authenticity Level */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
-                    Niveau d&apos;authenticité:{" "}
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
+                    Niveau d&apos;authenticité:{' '}
                     <span className="text-gold">
                       {THREADS_AUTHENTICITY_LEVELS[threadsAuthenticityLevel].name}
                     </span>
@@ -649,28 +635,30 @@ export default function NewSocialPostPage() {
                     min="1"
                     max="5"
                     value={threadsAuthenticityLevel}
-                    onChange={(e) =>
-                      setThreadsAuthenticityLevel(Number(e.target.value) as ThreadsAuthenticityLevel)
+                    onChange={e =>
+                      setThreadsAuthenticityLevel(
+                        Number(e.target.value) as ThreadsAuthenticityLevel
+                      )
                     }
-                    className="w-full accent-gold"
+                    className="accent-gold w-full"
                   />
-                  <div className="mt-1 flex justify-between text-xs text-ivory/50">
+                  <div className="text-ivory/50 mt-1 flex justify-between text-xs">
                     <span>Informatif</span>
                     <span>Brut</span>
                   </div>
-                  <p className="mt-2 text-xs text-ivory/50">
+                  <p className="text-ivory/50 mt-2 text-xs">
                     {THREADS_AUTHENTICITY_LEVELS[threadsAuthenticityLevel].description}
                   </p>
                 </div>
 
                 {/* Format Preview */}
-                <div className="rounded-lg bg-night/30 p-4">
-                  <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gold/70">
+                <div className="bg-night/30 rounded-lg p-4">
+                  <p className="text-gold/70 mb-2 text-xs font-medium uppercase tracking-wider">
                     Exemples de ce format
                   </p>
                   <div className="space-y-2">
                     {THREADS_FORMATS[threadsFormat].examples.slice(0, 2).map((example, idx) => (
-                      <p key={idx} className="text-xs text-ivory/70 italic">
+                      <p key={idx} className="text-ivory/70 text-xs italic">
                         &ldquo;{example}&rdquo;
                       </p>
                     ))}
@@ -678,10 +666,10 @@ export default function NewSocialPostPage() {
                 </div>
 
                 {/* Threads Tips */}
-                <div className="rounded-lg bg-gold/5 p-3">
-                  <p className="text-xs text-gold/80">
-                    💡 Threads privilégie l&apos;authenticité. Pas de hashtags, pas de CTA.
-                    Écrivez comme vous pensez.
+                <div className="bg-gold/5 rounded-lg p-3">
+                  <p className="text-gold/80 text-xs">
+                    💡 Threads privilégie l&apos;authenticité. Pas de hashtags, pas de CTA. Écrivez
+                    comme vous pensez.
                   </p>
                 </div>
               </div>
@@ -690,8 +678,8 @@ export default function NewSocialPostPage() {
 
           {/* Facebook Options - Affiché uniquement si Facebook est sélectionné */}
           {isFacebookSelected && (
-            <div className="rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
-              <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-ivory">
+            <div className="border-gold/20 from-night/60 to-night/40 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
+              <h2 className="text-ivory mb-4 flex items-center gap-2 text-lg font-semibold">
                 <SocialPlatformIcon platform="FACEBOOK" className="h-5 w-5" />
                 Options Facebook
               </h2>
@@ -699,34 +687,32 @@ export default function NewSocialPostPage() {
               <div className="space-y-4">
                 {/* Format Selection */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
                     Format de post
                   </label>
                   <select
                     value={facebookFormat}
-                    onChange={(e) =>
-                      setFacebookFormat(e.target.value as FacebookPostFormat)
-                    }
-                    className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory transition focus:border-gold focus:outline-none"
+                    onChange={e => setFacebookFormat(e.target.value as FacebookPostFormat)}
+                    className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none"
                   >
-                    {Object.values(FACEBOOK_FORMATS).map((format) => (
+                    {Object.values(FACEBOOK_FORMATS).map(format => (
                       <option key={format.id} value={format.id}>
                         {format.name}
                       </option>
                     ))}
                   </select>
-                  <p className="mt-2 text-xs text-ivory/50">
+                  <p className="text-ivory/50 mt-2 text-xs">
                     {FACEBOOK_FORMATS[facebookFormat].description.slice(0, 80)}...
                   </p>
-                  <p className="mt-1 text-xs text-ivory/50">
-                    Idéal pour : {FACEBOOK_FORMATS[facebookFormat].bestFor.join(" • ")}
+                  <p className="text-ivory/50 mt-1 text-xs">
+                    Idéal pour : {FACEBOOK_FORMATS[facebookFormat].bestFor.join(' • ')}
                   </p>
                 </div>
 
                 {/* Tone Level */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
-                    Niveau de ton:{" "}
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
+                    Niveau de ton:{' '}
                     <span className="text-gold">
                       {FACEBOOK_TONE_LEVELS[facebookToneLevel].name}
                     </span>
@@ -736,35 +722,35 @@ export default function NewSocialPostPage() {
                     min="1"
                     max="4"
                     value={facebookToneLevel}
-                    onChange={(e) =>
+                    onChange={e =>
                       setFacebookToneLevel(Number(e.target.value) as FacebookToneLevel)
                     }
-                    className="w-full accent-gold"
+                    className="accent-gold w-full"
                   />
-                  <div className="mt-1 flex justify-between text-xs text-ivory/50">
+                  <div className="text-ivory/50 mt-1 flex justify-between text-xs">
                     <span>Informatif</span>
                     <span>Expert</span>
                   </div>
-                  <p className="mt-2 text-xs text-ivory/50">
+                  <p className="text-ivory/50 mt-2 text-xs">
                     {FACEBOOK_TONE_LEVELS[facebookToneLevel].description}
                   </p>
                 </div>
 
                 {/* Format Preview */}
-                <div className="rounded-lg bg-night/30 p-4">
-                  <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gold/70">
+                <div className="bg-night/30 rounded-lg p-4">
+                  <p className="text-gold/70 mb-2 text-xs font-medium uppercase tracking-wider">
                     Exemple de structure
                   </p>
-                  <pre className="whitespace-pre-wrap text-xs text-ivory/70">
+                  <pre className="text-ivory/70 whitespace-pre-wrap text-xs">
                     {FACEBOOK_FORMATS[facebookFormat].example.slice(0, 400)}...
                   </pre>
                 </div>
 
                 {/* Facebook Tips */}
-                <div className="rounded-lg bg-gold/5 p-3">
-                  <p className="text-xs text-gold/80">
-                    💡 Facebook privilégie le storytelling et les émotions.
-                    Terminez par une question pour susciter les commentaires.
+                <div className="bg-gold/5 rounded-lg p-3">
+                  <p className="text-gold/80 text-xs">
+                    💡 Facebook privilégie le storytelling et les émotions. Terminez par une
+                    question pour susciter les commentaires.
                   </p>
                 </div>
               </div>
@@ -773,8 +759,8 @@ export default function NewSocialPostPage() {
 
           {/* LinkedIn Options - Affiché uniquement si LinkedIn est sélectionné */}
           {isLinkedInSelected && (
-            <div className="rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
-              <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold text-ivory">
+            <div className="border-gold/20 from-night/60 to-night/40 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
+              <h2 className="text-ivory mb-4 flex items-center gap-2 text-lg font-semibold">
                 <SocialPlatformIcon platform="LINKEDIN" className="h-5 w-5" />
                 Options LinkedIn
               </h2>
@@ -782,34 +768,32 @@ export default function NewSocialPostPage() {
               <div className="space-y-4">
                 {/* Format Selection */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
                     Format de post
                   </label>
                   <select
                     value={linkedinFormat}
-                    onChange={(e) =>
-                      setLinkedinFormat(e.target.value as LinkedInPostFormat)
-                    }
-                    className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory transition focus:border-gold focus:outline-none"
+                    onChange={e => setLinkedinFormat(e.target.value as LinkedInPostFormat)}
+                    className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none"
                   >
-                    {Object.values(LINKEDIN_FORMATS).map((format) => (
+                    {Object.values(LINKEDIN_FORMATS).map(format => (
                       <option key={format.id} value={format.id}>
                         {format.name}
                       </option>
                     ))}
                   </select>
-                  <p className="mt-2 text-xs text-ivory/50">
+                  <p className="text-ivory/50 mt-2 text-xs">
                     {LINKEDIN_FORMATS[linkedinFormat].description.slice(0, 80)}...
                   </p>
-                  <p className="mt-1 text-xs text-ivory/50">
-                    Idéal pour : {LINKEDIN_FORMATS[linkedinFormat].bestFor.join(" • ")}
+                  <p className="text-ivory/50 mt-1 text-xs">
+                    Idéal pour : {LINKEDIN_FORMATS[linkedinFormat].bestFor.join(' • ')}
                   </p>
                 </div>
 
                 {/* Expertise Level */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-ivory/80">
-                    Niveau d&apos;expertise:{" "}
+                  <label className="text-ivory/80 mb-2 block text-sm font-medium">
+                    Niveau d&apos;expertise:{' '}
                     <span className="text-gold">
                       {LINKEDIN_EXPERTISE_LEVELS[linkedinExpertiseLevel].name}
                     </span>
@@ -819,35 +803,36 @@ export default function NewSocialPostPage() {
                     min="1"
                     max="5"
                     value={linkedinExpertiseLevel}
-                    onChange={(e) =>
+                    onChange={e =>
                       setLinkedinExpertiseLevel(Number(e.target.value) as LinkedInExpertiseLevel)
                     }
-                    className="w-full accent-gold"
+                    className="accent-gold w-full"
                   />
-                  <div className="mt-1 flex justify-between text-xs text-ivory/50">
+                  <div className="text-ivory/50 mt-1 flex justify-between text-xs">
                     <span>Informatif</span>
                     <span>Personnel</span>
                   </div>
-                  <p className="mt-2 text-xs text-ivory/50">
+                  <p className="text-ivory/50 mt-2 text-xs">
                     {LINKEDIN_EXPERTISE_LEVELS[linkedinExpertiseLevel].description}
                   </p>
                 </div>
 
                 {/* Format Preview */}
-                <div className="rounded-lg bg-night/30 p-4">
-                  <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gold/70">
+                <div className="bg-night/30 rounded-lg p-4">
+                  <p className="text-gold/70 mb-2 text-xs font-medium uppercase tracking-wider">
                     Exemple de structure
                   </p>
-                  <pre className="whitespace-pre-wrap text-xs text-ivory/70">
+                  <pre className="text-ivory/70 whitespace-pre-wrap text-xs">
                     {LINKEDIN_FORMATS[linkedinFormat].example.slice(0, 400)}...
                   </pre>
                 </div>
 
                 {/* LinkedIn Tips */}
-                <div className="rounded-lg bg-gold/5 p-3">
-                  <p className="text-xs text-gold/80">
+                <div className="bg-gold/5 rounded-lg p-3">
+                  <p className="text-gold/80 text-xs">
                     💡 LinkedIn favorise les posts avec commentaires dans les 90 premières minutes.
-                    Terminez toujours par une question ouverte. Lien en commentaire = meilleur reach.
+                    Terminez toujours par une question ouverte. Lien en commentaire = meilleur
+                    reach.
                   </p>
                 </div>
               </div>
@@ -857,12 +842,8 @@ export default function NewSocialPostPage() {
           {/* Generate Button */}
           <button
             onClick={handleGenerate}
-            disabled={
-              !selectedArticle ||
-              selectedPlatforms.length === 0 ||
-              generation.isGenerating
-            }
-            className="flex w-full items-center justify-center gap-3 rounded-lg bg-gradient-to-r from-gold/20 to-gold/30 px-6 py-4 font-medium text-gold transition hover:from-gold/30 hover:to-gold/40 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!selectedArticle || selectedPlatforms.length === 0 || generation.isGenerating}
+            className="from-gold/20 to-gold/30 text-gold hover:from-gold/30 hover:to-gold/40 flex w-full items-center justify-center gap-3 rounded-lg bg-gradient-to-r px-6 py-4 font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
           >
             {generation.isGenerating ? (
               <>
@@ -884,13 +865,11 @@ export default function NewSocialPostPage() {
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.5, delay: 0.2 }}
         >
-          <div className="rounded-lg border border-gold/20 bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm">
+          <div className="border-gold/20 from-night/60 to-night/40 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm">
             <div className="mb-4 flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-ivory">
-                Contenu généré
-              </h2>
+              <h2 className="text-ivory text-lg font-semibold">Contenu généré</h2>
               {generation.tokensUsed > 0 && (
-                <span className="text-sm text-ivory/50">
+                <span className="text-ivory/50 text-sm">
                   {generation.tokensUsed.toLocaleString()} tokens utilisés
                 </span>
               )}
@@ -902,12 +881,8 @@ export default function NewSocialPostPage() {
                 <div className="flex items-start gap-3">
                   <AlertCircle className="h-5 w-5 flex-shrink-0 text-red-400" />
                   <div>
-                    <p className="font-medium text-red-400">
-                      Erreur de génération
-                    </p>
-                    <p className="mt-1 text-sm text-red-400/80">
-                      {generation.error}
-                    </p>
+                    <p className="font-medium text-red-400">Erreur de génération</p>
+                    <p className="mt-1 text-sm text-red-400/80">{generation.error}</p>
                   </div>
                 </div>
               </div>
@@ -916,10 +891,9 @@ export default function NewSocialPostPage() {
             {/* Empty State */}
             {!generation.isGenerating && generation.generations.length === 0 && (
               <div className="py-16 text-center">
-                <Sparkles className="mx-auto h-12 w-12 text-gold/30" />
-                <p className="mt-4 text-ivory/50">
-                  Sélectionnez un article et les plateformes, puis cliquez sur
-                  "Générer le contenu"
+                <Sparkles className="text-gold/30 mx-auto h-12 w-12" />
+                <p className="text-ivory/50 mt-4">
+                  Sélectionnez un article et les plateformes, puis cliquez sur "Générer le contenu"
                 </p>
               </div>
             )}
@@ -927,47 +901,41 @@ export default function NewSocialPostPage() {
             {/* Loading State */}
             {generation.isGenerating && (
               <div className="py-16 text-center">
-                <Loader2 className="mx-auto h-12 w-12 animate-spin text-gold" />
-                <p className="mt-4 text-ivory/70">
-                  Génération du contenu en cours...
-                </p>
-                <p className="mt-2 text-sm text-ivory/50">
-                  Cela peut prendre quelques secondes
-                </p>
+                <Loader2 className="text-gold mx-auto h-12 w-12 animate-spin" />
+                <p className="text-ivory/70 mt-4">Génération du contenu en cours...</p>
+                <p className="text-ivory/50 mt-2 text-sm">Cela peut prendre quelques secondes</p>
               </div>
             )}
 
             {/* Generated Content */}
             {!generation.isGenerating && generation.generations.length > 0 && (
               <div className="space-y-6">
-                {generation.generations.map((gen) => (
+                {generation.generations.map(gen => (
                   <GeneratedContentPreview
                     key={gen.platform}
                     generation={gen}
                     articleImage={selectedArticle?.image}
-                    onContentChange={(content) =>
-                      handleUpdateContent(gen.platform, content)
-                    }
+                    onContentChange={content => handleUpdateContent(gen.platform, content)}
                     onCopy={() =>
                       handleCopyContent(
-                        `${gen.content}\n\n${gen.hashtags.map((h) => `#${h}`).join(" ")}`
+                        `${gen.content}\n\n${gen.hashtags.map(h => `#${h}`).join(' ')}`
                       )
                     }
                   />
                 ))}
 
                 {/* Actions */}
-                <div className="flex gap-3 border-t border-gold/10 pt-6">
+                <div className="border-gold/10 flex gap-3 border-t pt-6">
                   <button
                     onClick={handleGenerate}
-                    className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-gold/20 px-4 py-3 font-medium text-ivory/70 transition hover:border-gold/40 hover:text-ivory"
+                    className="border-gold/20 text-ivory/70 hover:border-gold/40 hover:text-ivory flex flex-1 items-center justify-center gap-2 rounded-lg border px-4 py-3 font-medium transition"
                   >
                     <RotateCcw className="h-4 w-4" />
                     Régénérer
                   </button>
                   <button
                     onClick={() => setIsSaveModalOpen(true)}
-                    className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-gold/20 px-4 py-3 font-medium text-gold transition hover:bg-gold/30"
+                    className="bg-gold/20 text-gold hover:bg-gold/30 flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-3 font-medium transition"
                   >
                     <Save className="h-4 w-4" />
                     Sauvegarder
@@ -984,8 +952,8 @@ export default function NewSocialPostPage() {
         isOpen={isSaveModalOpen}
         onClose={() => setIsSaveModalOpen(false)}
         generations={generation.generations}
-        blogSlug={selectedArticle?.slug || ""}
-        blogTitle={selectedArticle?.title || ""}
+        blogSlug={selectedArticle?.slug || ''}
+        blogTitle={selectedArticle?.title || ''}
         articleImage={selectedArticle?.image}
         tone={selectedTone}
         angle={selectedAngle}

--- a/apps/psypnos/app/api/social/generate/route.ts
+++ b/apps/psypnos/app/api/social/generate/route.ts
@@ -13,7 +13,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { withAdminAuth } from '@/app/api/auth/middleware';
-import { getPostBySlug } from '@/lib/blog';
+import { getPostBySlugAsync } from '@/lib/blog';
 import {
   generateForMultiplePlatforms,
   checkGenerationConfig,
@@ -82,7 +82,13 @@ function validateRequestBody(body: unknown): {
     return { valid: false, error: 'platforms doit être un tableau non vide' };
   }
 
-  const validPlatforms: SocialPlatform[] = ['FACEBOOK', 'LINKEDIN', 'INSTAGRAM', 'TWITTER', 'THREADS'];
+  const validPlatforms: SocialPlatform[] = [
+    'FACEBOOK',
+    'LINKEDIN',
+    'INSTAGRAM',
+    'TWITTER',
+    'THREADS',
+  ];
   for (const p of b.platforms) {
     if (!validPlatforms.includes(p as SocialPlatform)) {
       return { valid: false, error: `Plateforme invalide: ${p}` };
@@ -90,7 +96,13 @@ function validateRequestBody(body: unknown): {
   }
 
   // tone requis
-  const validTones: ContentTone[] = ['informatif', 'inspirant', 'promotionnel', 'educatif', 'personnel'];
+  const validTones: ContentTone[] = [
+    'informatif',
+    'inspirant',
+    'promotionnel',
+    'educatif',
+    'personnel',
+  ];
   if (!b.tone || !validTones.includes(b.tone as ContentTone)) {
     return { valid: false, error: 'tone invalide ou manquant' };
   }
@@ -103,10 +115,17 @@ function validateRequestBody(body: unknown): {
 
   // instagramFormat optionnel mais doit être valide si fourni
   const validInstagramFormats: InstagramPostFormat[] = [
-    'hook_reveal', 'liste_visuelle', 'micro_storytelling',
-    'question_rhethorique', 'citation_reflexion', 'mythe_realite'
+    'hook_reveal',
+    'liste_visuelle',
+    'micro_storytelling',
+    'question_rhethorique',
+    'citation_reflexion',
+    'mythe_realite',
   ];
-  if (b.instagramFormat && !validInstagramFormats.includes(b.instagramFormat as InstagramPostFormat)) {
+  if (
+    b.instagramFormat &&
+    !validInstagramFormats.includes(b.instagramFormat as InstagramPostFormat)
+  ) {
     return { valid: false, error: 'instagramFormat invalide' };
   }
 
@@ -120,8 +139,12 @@ function validateRequestBody(body: unknown): {
 
   // threadsFormat optionnel mais doit être valide si fourni
   const validThreadsFormats: ThreadsPostFormat[] = [
-    'pensee_brute', 'observation_cabinet', 'question_ouverte',
-    'micro_confession', 'fragment_poetique', 'contre_intuitif'
+    'pensee_brute',
+    'observation_cabinet',
+    'question_ouverte',
+    'micro_confession',
+    'fragment_poetique',
+    'contre_intuitif',
   ];
   if (b.threadsFormat && !validThreadsFormats.includes(b.threadsFormat as ThreadsPostFormat)) {
     return { valid: false, error: 'threadsFormat invalide' };
@@ -137,8 +160,12 @@ function validateRequestBody(body: unknown): {
 
   // linkedinFormat optionnel mais doit être valide si fourni
   const validLinkedInFormats: LinkedInPostFormat[] = [
-    'observation_pro', 'contre_intuition', 'liste_puces',
-    'storytelling_court', 'question_provocante', 'temoignage_terrain'
+    'observation_pro',
+    'contre_intuition',
+    'liste_puces',
+    'storytelling_court',
+    'question_provocante',
+    'temoignage_terrain',
   ];
   if (b.linkedinFormat && !validLinkedInFormats.includes(b.linkedinFormat as LinkedInPostFormat)) {
     return { valid: false, error: 'linkedinFormat invalide' };
@@ -187,10 +214,7 @@ export async function POST(request: NextRequest) {
   // Vérifier la configuration
   const configCheck = checkGenerationConfig();
   if (!configCheck.valid) {
-    return NextResponse.json(
-      { error: configCheck.error },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: configCheck.error }, { status: 500 });
   }
 
   try {
@@ -199,10 +223,7 @@ export async function POST(request: NextRequest) {
     const validation = validateRequestBody(body);
 
     if (!validation.valid || !validation.data) {
-      return NextResponse.json(
-        { error: validation.error },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: validation.error }, { status: 400 });
     }
 
     const {
@@ -220,12 +241,9 @@ export async function POST(request: NextRequest) {
     } = validation.data;
 
     // Récupérer l'article
-    const article = await getPostBySlug(blogSlug);
+    const article = await getPostBySlugAsync(blogSlug);
     if (!article) {
-      return NextResponse.json(
-        { error: `Article non trouvé: ${blogSlug}` },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: `Article non trouvé: ${blogSlug}` }, { status: 404 });
     }
 
     // Préparer l'input pour la génération
@@ -312,23 +330,17 @@ export async function GET(request: NextRequest) {
     const platformsParam = searchParams.get('platforms');
 
     if (!blogSlug) {
-      return NextResponse.json(
-        { error: 'blogSlug requis' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'blogSlug requis' }, { status: 400 });
     }
 
     const platforms = platformsParam
       ? (platformsParam.split(',') as SocialPlatform[])
-      : ['FACEBOOK', 'LINKEDIN', 'INSTAGRAM'] as SocialPlatform[];
+      : (['FACEBOOK', 'LINKEDIN', 'INSTAGRAM'] as SocialPlatform[]);
 
     // Récupérer l'article
-    const article = await getPostBySlug(blogSlug);
+    const article = await getPostBySlugAsync(blogSlug);
     if (!article) {
-      return NextResponse.json(
-        { error: `Article non trouvé: ${blogSlug}` },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: `Article non trouvé: ${blogSlug}` }, { status: 404 });
     }
 
     const articleInput: BlogArticleInput = {


### PR DESCRIPTION
## Description

This PR standardizes quote style across the codebase by converting all double quotes to single quotes in JavaScript/TypeScript files. This includes:

- **apps/psypnos/app/admin/social/posts/new/page.tsx**: Converted all string literals, imports, and template strings from double to single quotes
- **apps/psypnos/app/admin/blog/_components/SocialDiffusionSection.tsx**: Simplified component by removing unused imports and state management, converting to single quotes, and refactoring to use URL parameters for platform pre-selection instead of inline generation
- **apps/psypnos/app/admin/blog/_components/BlogPostForm.tsx**: Converted imports and string literals to single quotes
- **apps/psypnos/app/api/social/generate/route.ts**: Converted to single quotes and improved code formatting with better line breaks for readability

Additionally, the `SocialDiffusionSection` component was refactored to:
- Remove local generation logic and state management (tone, angle, generations, error handling)
- Simplify to a platform selector that redirects to `/admin/social/posts/new` with pre-selected platforms and article slug as URL parameters
- Remove unused imports (`CONTENT_TONES`, `CONTENT_ANGLES`, `useCallback`, `useEffect`, etc.)
- Improve accessibility and styling consistency

The API route was updated to use `getPostBySlugAsync` instead of `getPostBySlug` for consistency.

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre

## Notes

The refactoring of `SocialDiffusionSection` improves separation of concerns by moving the complex generation logic to the dedicated `/admin/social/posts/new` page, while the blog editor section now focuses solely on platform selection and navigation.

https://claude.ai/code/session_013Y7DF5Q6RF4vEpWGh95FWg