### PR TITLE
Refactor calendar selection state to use Date instead of CalendarDay

### DIFF
--- a/apps/psypnos/app/admin/social/calendar/page.tsx
+++ b/apps/psypnos/app/admin/social/calendar/page.tsx
@@ -169,7 +169,7 @@ export default function SocialCalendarPage() {
   const [posts, setPosts] = useState<SocialPostCalendar[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [selectedDay, setSelectedDay] = useState<CalendarDay | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
   // Edit modal state
   const [editingPost, setEditingPost] = useState<SocialPostCalendar | null>(null);
@@ -219,19 +219,29 @@ export default function SocialCalendarPage() {
     [year, month, posts]
   );
 
+  /** Jour sélectionné dérivé de calendarDays — se met à jour automatiquement quand posts change */
+  const selectedDay = useMemo(() => {
+    if (!selectedDate) return null;
+    return (
+      calendarDays.find(
+        day => day.date.getTime() === selectedDate.getTime() && day.posts.length > 0
+      ) ?? null
+    );
+  }, [calendarDays, selectedDate]);
+
   const goToPreviousMonth = () => {
     setCurrentDate(new Date(year, month - 1, 1));
-    setSelectedDay(null);
+    setSelectedDate(null);
   };
 
   const goToNextMonth = () => {
     setCurrentDate(new Date(year, month + 1, 1));
-    setSelectedDay(null);
+    setSelectedDate(null);
   };
 
   const goToToday = () => {
     setCurrentDate(new Date());
-    setSelectedDay(null);
+    setSelectedDate(null);
   };
 
   const handlePublishNow = async (postId: string) => {
@@ -311,7 +321,7 @@ export default function SocialCalendarPage() {
           variant: 'success',
         });
         setDeletingPostId(null);
-        setSelectedDay(null);
+        setSelectedDate(null);
         loadPosts();
       } else {
         const data = await response.json();
@@ -418,7 +428,7 @@ export default function SocialCalendarPage() {
               {calendarDays.map((day, index) => (
                 <button
                   key={index}
-                  onClick={() => setSelectedDay(day.posts.length > 0 ? day : null)}
+                  onClick={() => setSelectedDate(day.posts.length > 0 ? day.date : null)}
                   className={`
                     min-h-[100px] rounded-lg border p-2 text-left transition
                     ${
@@ -428,7 +438,7 @@ export default function SocialCalendarPage() {
                     }
                     ${day.isToday ? 'border-gold/40 ring-gold/30 ring-1' : ''}
                     ${day.posts.length > 0 ? 'hover:border-gold/30 cursor-pointer' : 'cursor-default'}
-                    ${selectedDay?.date.getTime() === day.date.getTime() ? 'border-gold/50 bg-gold/10' : ''}
+                    ${selectedDate?.getTime() === day.date.getTime() ? 'border-gold/50 bg-gold/10' : ''}
                   `}
                 >
                   <span
@@ -483,7 +493,7 @@ export default function SocialCalendarPage() {
               })}
             </h2>
             <button
-              onClick={() => setSelectedDay(null)}
+              onClick={() => setSelectedDate(null)}
               className="text-ivory/50 hover:text-ivory text-sm"
             >
               Fermer


### PR DESCRIPTION
## Description

Refactored the social calendar page to separate concerns between the selected date state and the derived calendar day data. Changed `selectedDay` from a state variable holding a `CalendarDay` object to `selectedDate` holding a `Date` object, with `selectedDay` now computed as a memoized derived value.

This improves state management by:
- Storing only the minimal required state (the selected date)
- Deriving the calendar day information from `calendarDays` and `selectedDate` using `useMemo`
- Automatically keeping `selectedDay` in sync when posts change
- Simplifying state updates throughout the component

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Configuration
- [x] ♻️ Refactoring

## Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai testé mes changements localement
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Les types TypeScript sont corrects
- [x] Pas de nouvelles erreurs ESLint
- [x] Pas de secrets ou données sensibles

## Sites impactés

- [ ] Tous les sites (packages/)
- [x] PSYPNOS uniquement
- [ ] Autre : <!-- préciser -->

## Test Plan

The refactoring maintains existing functionality while improving state management. Calendar selection, month navigation, and post deletion all continue to work as before. The memoized `selectedDay` computation ensures the UI stays in sync with the underlying data.

https://claude.ai/code/session_016JKN2LWsefSDQhrtEC9L13