### PR TITLE
feat(social): suggérer les horaires de publication basés sur la date de l'article

### DIFF
--- a/apps/psypnos/__tests__/unit/suggested-time-slots.test.ts
+++ b/apps/psypnos/__tests__/unit/suggested-time-slots.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { computeSuggestedTimes } from '../../lib/social/suggested-times';
+
+describe('computeSuggestedTimes', () => {
+  beforeEach(() => {
+    // Fixer la date courante au mercredi 11 mars 2026 a 10h00
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 11, 10, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retourne des suggestions basees sur la date article quand fournie dans le futur', () => {
+    // Article publie le lundi 16 mars 2026
+    const articleDate = '2026-03-16';
+    const suggestions = computeSuggestedTimes('FACEBOOK', articleDate, 5);
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    // Tous les creneaux doivent etre >= a la date article
+    for (const s of suggestions) {
+      expect(s.date.getTime()).toBeGreaterThanOrEqual(new Date(articleDate).getTime());
+    }
+  });
+
+  it('utilise la date du jour comme fallback quand articleDate est null', () => {
+    const now = new Date();
+    const suggestions = computeSuggestedTimes('FACEBOOK', null, 5);
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    // Tous les creneaux doivent etre apres maintenant
+    for (const s of suggestions) {
+      expect(s.date.getTime()).toBeGreaterThan(now.getTime());
+    }
+  });
+
+  it('utilise la date du jour comme fallback quand articleDate est undefined', () => {
+    const now = new Date();
+    const suggestions = computeSuggestedTimes('FACEBOOK', undefined, 5);
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    for (const s of suggestions) {
+      expect(s.date.getTime()).toBeGreaterThan(now.getTime());
+    }
+  });
+
+  it('utilise maintenant comme plancher quand la date article est passee', () => {
+    const now = new Date();
+    // Article publie il y a une semaine
+    const pastArticleDate = '2026-03-04';
+    const suggestions = computeSuggestedTimes('FACEBOOK', pastArticleDate, 5);
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    // Tous les creneaux doivent etre apres maintenant (pas apres la date passee)
+    for (const s of suggestions) {
+      expect(s.date.getTime()).toBeGreaterThan(now.getTime());
+    }
+  });
+
+  it('marque le premier creneau primary comme ideal', () => {
+    const suggestions = computeSuggestedTimes('FACEBOOK', '2026-03-16', 8);
+    const idealSlots = suggestions.filter(s => s.isIdeal);
+
+    expect(idealSlots).toHaveLength(1);
+    expect(idealSlots[0]!.isPrimary).toBe(true);
+  });
+
+  it('retourne des creneaux tries par date croissante', () => {
+    const suggestions = computeSuggestedTimes('FACEBOOK', '2026-03-16', 8);
+
+    for (let i = 1; i < suggestions.length; i++) {
+      expect(suggestions[i]!.date.getTime()).toBeGreaterThanOrEqual(
+        suggestions[i - 1]!.date.getTime()
+      );
+    }
+  });
+
+  it('respecte la limite maxCount', () => {
+    const suggestions = computeSuggestedTimes('FACEBOOK', null, 3);
+    expect(suggestions.length).toBeLessThanOrEqual(3);
+  });
+
+  it('retourne des creneaux specifiques a la plateforme LINKEDIN', () => {
+    // LinkedIn a des creneaux a 7h et 12h
+    const suggestions = computeSuggestedTimes('LINKEDIN', '2026-03-16', 8);
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    const hours = suggestions.map(s => s.date.getHours());
+    // LinkedIn utilise 7h, 12h, 17h
+    for (const hour of hours) {
+      expect([7, 12, 17]).toContain(hour);
+    }
+  });
+
+  it('retourne des creneaux specifiques a la plateforme TWITTER', () => {
+    const suggestions = computeSuggestedTimes('TWITTER', '2026-03-16', 5);
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    // Twitter n'a que des creneaux a 8h
+    const hours = suggestions.map(s => s.date.getHours());
+    for (const hour of hours) {
+      expect(hour).toBe(8);
+    }
+  });
+
+  it('distingue creneaux primary et secondary pour Facebook', () => {
+    const suggestions = computeSuggestedTimes('FACEBOOK', '2026-03-16', 8);
+
+    const primaries = suggestions.filter(s => s.isPrimary);
+    const secondaries = suggestions.filter(s => !s.isPrimary);
+
+    // Facebook a des creneaux primary (9h) et secondary (13h, 10h weekend)
+    expect(primaries.length).toBeGreaterThan(0);
+    expect(secondaries.length).toBeGreaterThan(0);
+  });
+
+  it('genere des labels lisibles', () => {
+    const suggestions = computeSuggestedTimes('FACEBOOK', '2026-03-16', 3);
+
+    for (const s of suggestions) {
+      // Le label doit contenir une heure au format HH:MM
+      expect(s.label).toMatch(/\d{2}:\d{2}/);
+      // Le label ne doit pas etre vide
+      expect(s.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('retourne un tableau vide si la plateforme n a pas de creneaux definis', () => {
+    // Simuler une plateforme inconnue en castant
+    const suggestions = computeSuggestedTimes('UNKNOWN' as never, null, 5);
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('ne filtre jamais les creneaux futurs meme proches de maintenant', () => {
+    // Fixer a mercredi 11 mars 2026 a 8h59 — le creneau Facebook 9h doit passer
+    vi.setSystemTime(new Date(2026, 2, 11, 8, 59, 0));
+
+    const suggestions = computeSuggestedTimes('FACEBOOK', null, 5);
+
+    // Le creneau 9h du jour doit etre dans les suggestions
+    const todayNine = suggestions.find(s => s.date.getDate() === 11 && s.date.getHours() === 9);
+    expect(todayNine).toBeDefined();
+  });
+});

--- a/apps/psypnos/app/admin/social/_components/EditPostModal.tsx
+++ b/apps/psypnos/app/admin/social/_components/EditPostModal.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Calendar, Clock, Save, Loader2, AlertCircle } from 'lucide-react';
+import { X, Calendar, Save, Loader2, AlertCircle } from 'lucide-react';
 import { useState, useEffect, useCallback } from 'react';
 
 import type { SocialPlatform } from '@/lib/social/types';
 
 import { SocialPlatformIcon } from '../accounts/_components/SocialPlatformIcon';
+
+import { SuggestedTimeSlots } from './SuggestedTimeSlots';
 
 // ===========================================
 // Types
@@ -25,6 +27,7 @@ interface EditPostModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (postId: string, data: { scheduledAt: string | null; content?: string }) => Promise<void>;
+  articleDate?: string | null;
 }
 
 // ===========================================
@@ -36,45 +39,11 @@ function formatDateTimeLocal(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
-function getOptimalTimes() {
-  const now = new Date();
-  const times = [];
-
-  // Add some optimal posting times
-  const optimalHours = [9, 12, 14, 17, 19];
-
-  for (let dayOffset = 0; dayOffset <= 7; dayOffset++) {
-    for (const hour of optimalHours) {
-      const date = new Date(now);
-      date.setDate(now.getDate() + dayOffset);
-      date.setHours(hour, 0, 0, 0);
-
-      if (date > now) {
-        times.push({
-          date,
-          label: date.toLocaleDateString('fr-FR', {
-            weekday: 'short',
-            day: 'numeric',
-            month: 'short',
-          }),
-          time: `${hour}:00`,
-          isPrimary: [9, 12, 17].includes(hour),
-        });
-      }
-
-      if (times.length >= 15) break;
-    }
-    if (times.length >= 15) break;
-  }
-
-  return times;
-}
-
 // ===========================================
 // Main Component
 // ===========================================
 
-export function EditPostModal({ post, isOpen, onClose, onSave }: EditPostModalProps) {
+export function EditPostModal({ post, isOpen, onClose, onSave, articleDate }: EditPostModalProps) {
   const [scheduledDate, setScheduledDate] = useState<string>('');
   const [content, setContent] = useState<string>('');
   const [isContentEdited, setIsContentEdited] = useState(false);
@@ -123,8 +92,6 @@ export function EditPostModal({ post, isOpen, onClose, onSave }: EditPostModalPr
     setContent(value);
     setIsContentEdited(true);
   }, []);
-
-  const optimalTimes = getOptimalTimes();
 
   // Character count
   const maxLength: Record<SocialPlatform, number> = {
@@ -205,31 +172,15 @@ export function EditPostModal({ post, isOpen, onClose, onSave }: EditPostModalPr
                     : 'Laissez vide pour convertir en brouillon'}
                 </p>
 
-                {/* Quick Time Suggestions */}
-                <div className="space-y-2">
-                  <span className="text-ivory/50 flex items-center gap-1 text-xs">
-                    <Clock className="h-3 w-3" />
-                    Créneaux suggérés
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    {optimalTimes.slice(0, 8).map((slot, index) => (
-                      <button
-                        key={index}
-                        onClick={() => handleQuickTime(slot.date)}
-                        className={`
-                          rounded-lg border px-3 py-1.5 text-xs transition
-                          ${
-                            slot.isPrimary
-                              ? 'border-gold/40 bg-gold/10 text-gold hover:bg-gold/20'
-                              : 'border-gold/20 bg-night/30 text-ivory/70 hover:border-gold/40 hover:text-ivory'
-                          }
-                        `}
-                      >
-                        {slot.label} {slot.time}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+                {/* Suggested Time Slots */}
+                {post && (
+                  <SuggestedTimeSlots
+                    platform={post.platform}
+                    articleDate={articleDate}
+                    selectedDate={scheduledDate ? new Date(scheduledDate) : null}
+                    onSelect={handleQuickTime}
+                  />
+                )}
               </div>
 
               {/* Content Editor */}

--- a/apps/psypnos/app/admin/social/_components/SuggestedTimeSlots.tsx
+++ b/apps/psypnos/app/admin/social/_components/SuggestedTimeSlots.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Clock, Sparkles, Star, Trophy } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { computeSuggestedTimes } from '@/lib/social/suggested-times';
+import type { SocialPlatform } from '@/lib/social/types';
+
+// ===========================================
+// Types
+// ===========================================
+
+interface SuggestedTimeSlotsProps {
+  platform: SocialPlatform;
+  articleDate?: string | null;
+  selectedDate?: Date | null;
+  onSelect: (date: Date) => void;
+  maxSuggestions?: number;
+}
+
+// ===========================================
+// Component
+// ===========================================
+
+/**
+ * Affiche les creneaux de publication suggeres pour une plateforme,
+ * en mettant en avant le creneau ideal et les creneaux recommandes.
+ */
+export function SuggestedTimeSlots({
+  platform,
+  articleDate,
+  selectedDate,
+  onSelect,
+  maxSuggestions = 8,
+}: SuggestedTimeSlotsProps) {
+  const suggestions = useMemo(
+    () => computeSuggestedTimes(platform, articleDate, maxSuggestions),
+    [platform, articleDate, maxSuggestions]
+  );
+
+  const idealSlot = suggestions.find(s => s.isIdeal);
+  const primarySlots = suggestions.filter(s => s.isPrimary && !s.isIdeal);
+  const secondarySlots = suggestions.filter(s => !s.isPrimary);
+
+  const isArticleDateInFuture = articleDate ? new Date(articleDate) > new Date() : false;
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-ivory/50 flex items-center gap-1.5 text-xs">
+          <Sparkles className="h-3 w-3" />
+          Creneaux recommandes
+        </p>
+        {articleDate && isArticleDateInFuture && (
+          <p className="text-ivory/40 text-xs">
+            Ref. article :{' '}
+            {new Date(articleDate).toLocaleDateString('fr-FR', {
+              day: 'numeric',
+              month: 'short',
+            })}
+          </p>
+        )}
+      </div>
+
+      {/* Ideal slot — highlighted card */}
+      {idealSlot && (
+        <motion.button
+          initial={{ opacity: 0, scale: 0.98 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.2 }}
+          onClick={() => onSelect(idealSlot.date)}
+          className={`group flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-all hover:scale-[1.01] ${
+            selectedDate?.getTime() === idealSlot.date.getTime()
+              ? 'border-gold bg-gold/15 ring-gold/40 ring-2'
+              : 'border-gold/40 bg-gold/10 hover:border-gold/60 hover:bg-gold/15'
+          }`}
+        >
+          <div className="bg-gold/20 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full">
+            <Trophy className="text-gold h-4 w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-ivory text-sm font-medium">{idealSlot.label}</p>
+            <p className="text-ivory/50 text-xs">
+              {isArticleDateInFuture
+                ? "Pic d'audience proche de la publication"
+                : "Prochain pic d'audience"}
+            </p>
+          </div>
+          <span className="bg-gold/20 text-gold flex-shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium">
+            Ideal
+          </span>
+        </motion.button>
+      )}
+
+      {/* Primary slots */}
+      {primarySlots.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-ivory/40 text-xs uppercase tracking-wider">Recommandes</p>
+          <div className="flex flex-wrap gap-2">
+            {primarySlots.map((slot, idx) => (
+              <motion.button
+                key={slot.date.getTime()}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.15, delay: idx * 0.03 }}
+                onClick={() => onSelect(slot.date)}
+                className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs transition-all hover:scale-105 ${
+                  selectedDate?.getTime() === slot.date.getTime()
+                    ? 'bg-gold/25 text-gold ring-gold/40 ring-2'
+                    : 'bg-gold/15 text-gold hover:bg-gold/25'
+                }`}
+              >
+                <Star className="h-3 w-3" />
+                {slot.label}
+              </motion.button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Secondary slots */}
+      {secondarySlots.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-ivory/40 text-xs uppercase tracking-wider">Autres creneaux</p>
+          <div className="flex flex-wrap gap-2">
+            {secondarySlots.map((slot, idx) => (
+              <motion.button
+                key={slot.date.getTime()}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.15, delay: idx * 0.03 }}
+                onClick={() => onSelect(slot.date)}
+                className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs transition-all hover:scale-105 ${
+                  selectedDate?.getTime() === slot.date.getTime()
+                    ? 'bg-ivory/20 text-ivory ring-gold/40 ring-2'
+                    : 'bg-ivory/10 text-ivory/60 hover:bg-ivory/20 hover:text-ivory/80'
+                }`}
+              >
+                <Clock className="h-3 w-3" />
+                {slot.label}
+              </motion.button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/psypnos/app/admin/social/posts/new/_components/SavePostModal.tsx
+++ b/apps/psypnos/app/admin/social/posts/new/_components/SavePostModal.tsx
@@ -5,16 +5,14 @@ import {
   X,
   Save,
   Calendar,
-  Clock,
   Send,
   FileText,
   Loader2,
   AlertCircle,
   CheckCircle,
-  Sparkles,
   ChevronDown,
 } from 'lucide-react';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 import type {
   SocialPlatform,
@@ -23,8 +21,9 @@ import type {
   ContentTone,
   ContentAngle,
 } from '@/lib/social/types';
-import { OPTIMAL_POSTING_TIMES, PLATFORM_SPECS } from '@/lib/social/types';
+import { PLATFORM_SPECS } from '@/lib/social/types';
 
+import { SuggestedTimeSlots } from '../../../_components/SuggestedTimeSlots';
 import { SocialPlatformIcon } from '../../../accounts/_components/SocialPlatformIcon';
 
 // ===========================================
@@ -37,6 +36,7 @@ interface SavePostModalProps {
   generations: GeneratedContent[];
   blogSlug: string;
   blogTitle: string;
+  articleDate?: string;
   articleImage?: string;
   tone: ContentTone;
   angle: ContentAngle;
@@ -54,71 +54,9 @@ interface PostConfig {
 
 type SaveMode = 'draft' | 'schedule' | 'now';
 
-interface SuggestedTime {
-  date: Date;
-  label: string;
-  isPrimary: boolean;
-}
-
 // ===========================================
 // Helpers
 // ===========================================
-
-function getNextOptimalTimes(platform: SocialPlatform, count: number = 5): SuggestedTime[] {
-  const now = new Date();
-  const slots = OPTIMAL_POSTING_TIMES[platform] || [];
-  const suggestions: SuggestedTime[] = [];
-
-  // Générer les 14 prochains jours de créneaux
-  for (let dayOffset = 0; dayOffset < 14 && suggestions.length < count; dayOffset++) {
-    const date = new Date(now);
-    date.setDate(date.getDate() + dayOffset);
-    const dayOfWeek = date.getDay();
-
-    for (const slot of slots) {
-      if (slot.dayOfWeek === dayOfWeek) {
-        const slotDate = new Date(date);
-        slotDate.setHours(slot.hour, 0, 0, 0);
-
-        // Ne pas inclure les créneaux passés
-        if (slotDate > now) {
-          const label = formatSuggestedTime(slotDate);
-          suggestions.push({
-            date: slotDate,
-            label,
-            isPrimary: slot.priority === 'primary',
-          });
-        }
-      }
-    }
-  }
-
-  // Trier par date et retourner les premiers
-  return suggestions.sort((a, b) => a.date.getTime() - b.date.getTime()).slice(0, count);
-}
-
-function formatSuggestedTime(date: Date): string {
-  const now = new Date();
-  const tomorrow = new Date(now);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-
-  const isToday = date.toDateString() === now.toDateString();
-  const isTomorrow = date.toDateString() === tomorrow.toDateString();
-
-  const time = date.toLocaleTimeString('fr-FR', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-
-  if (isToday) return `Aujourd'hui à ${time}`;
-  if (isTomorrow) return `Demain à ${time}`;
-
-  const day = date.toLocaleDateString('fr-FR', { weekday: 'long' });
-  const dayNum = date.getDate();
-  const month = date.toLocaleDateString('fr-FR', { month: 'short' });
-
-  return `${day.charAt(0).toUpperCase() + day.slice(1)} ${dayNum} ${month} à ${time}`;
-}
 
 function formatDateTimeLocal(date: Date): string {
   const pad = (n: number) => n.toString().padStart(2, '0');
@@ -135,6 +73,7 @@ export function SavePostModal({
   generations,
   blogSlug,
   blogTitle,
+  articleDate,
   articleImage,
   tone,
   angle,
@@ -195,23 +134,6 @@ export function SavePostModal({
       );
     }
   }, [generations, accounts]);
-
-  // Calculer les suggestions d'horaires optimaux pour chaque plateforme
-  const suggestedTimes = useMemo(() => {
-    const times: Record<SocialPlatform, SuggestedTime[]> = {
-      FACEBOOK: [],
-      LINKEDIN: [],
-      INSTAGRAM: [],
-      TWITTER: [],
-      THREADS: [],
-    };
-
-    for (const platform of Object.keys(times) as SocialPlatform[]) {
-      times[platform] = getNextOptimalTimes(platform, 5);
-    }
-
-    return times;
-  }, []);
 
   // Handlers
   const updatePostConfig = useCallback((platform: SocialPlatform, updates: Partial<PostConfig>) => {
@@ -473,39 +395,29 @@ export function SavePostModal({
                         <p className="text-ivory/60 mb-3 text-sm">
                           Date et heure de publication pour tous les posts :
                         </p>
-                        <div className="grid gap-4 sm:grid-cols-2">
-                          <input
-                            type="datetime-local"
-                            value={
-                              globalScheduleDate ? formatDateTimeLocal(globalScheduleDate) : ''
-                            }
-                            onChange={e => {
-                              const date = e.target.value ? new Date(e.target.value) : null;
-                              setGlobalScheduleDate(date);
-                            }}
-                            min={formatDateTimeLocal(new Date())}
-                            className="border-gold/20 bg-night/50 text-ivory focus:border-gold rounded-lg border px-4 py-2 focus:outline-none"
+                        <div className="space-y-4">
+                          <SuggestedTimeSlots
+                            platform={postConfigs[0]?.platform || 'FACEBOOK'}
+                            articleDate={articleDate}
+                            selectedDate={globalScheduleDate}
+                            onSelect={setGlobalScheduleDate}
                           />
-                          <div className="space-y-2">
-                            <p className="text-ivory/50 flex items-center gap-2 text-xs">
-                              <Sparkles className="h-3 w-3" />
-                              Suggestions :
+                          <div>
+                            <p className="text-ivory/40 mb-2 text-xs uppercase tracking-wider">
+                              Ou choisir manuellement
                             </p>
-                            <div className="flex flex-wrap gap-2">
-                              {suggestedTimes.FACEBOOK.slice(0, 3).map((time, idx) => (
-                                <button
-                                  key={idx}
-                                  onClick={() => setGlobalScheduleDate(time.date)}
-                                  className={`rounded-full px-3 py-1 text-xs transition ${
-                                    time.isPrimary
-                                      ? 'bg-gold/20 text-gold hover:bg-gold/30'
-                                      : 'bg-ivory/10 text-ivory/70 hover:bg-ivory/20'
-                                  }`}
-                                >
-                                  {time.label}
-                                </button>
-                              ))}
-                            </div>
+                            <input
+                              type="datetime-local"
+                              value={
+                                globalScheduleDate ? formatDateTimeLocal(globalScheduleDate) : ''
+                              }
+                              onChange={e => {
+                                const date = e.target.value ? new Date(e.target.value) : null;
+                                setGlobalScheduleDate(date);
+                              }}
+                              min={formatDateTimeLocal(new Date())}
+                              className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-2 focus:outline-none"
+                            />
                           </div>
                         </div>
                       </div>
@@ -525,7 +437,6 @@ export function SavePostModal({
                       const platformAccounts = getAccountsForPlatform(config.platform);
                       const hasAccount = platformAccounts.length > 0;
                       const isExpanded = expandedPlatform === config.platform;
-                      const platformSuggestions = suggestedTimes[config.platform] || [];
 
                       return (
                         <div
@@ -614,49 +525,39 @@ export function SavePostModal({
 
                                   {/* Individual Schedule */}
                                   {saveMode === 'schedule' && useIndividualSchedules && (
-                                    <div>
-                                      <label className="text-ivory/60 mb-2 block text-sm">
-                                        <Clock className="mr-1 inline h-4 w-4" />
-                                        Date de publication
-                                      </label>
-                                      <input
-                                        type="datetime-local"
-                                        value={
-                                          config.scheduledAt
-                                            ? formatDateTimeLocal(config.scheduledAt)
-                                            : ''
-                                        }
-                                        onChange={e => {
-                                          const date = e.target.value
-                                            ? new Date(e.target.value)
-                                            : null;
+                                    <div className="space-y-3">
+                                      <SuggestedTimeSlots
+                                        platform={config.platform}
+                                        articleDate={articleDate}
+                                        selectedDate={config.scheduledAt}
+                                        onSelect={date =>
                                           updatePostConfig(config.platform, {
                                             scheduledAt: date,
-                                          });
-                                        }}
-                                        min={formatDateTimeLocal(new Date())}
-                                        className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-2 focus:outline-none"
+                                          })
+                                        }
                                       />
-
-                                      {/* Platform-specific suggestions */}
-                                      <div className="mt-2 flex flex-wrap gap-2">
-                                        {platformSuggestions.map((time, idx) => (
-                                          <button
-                                            key={idx}
-                                            onClick={() =>
-                                              updatePostConfig(config.platform, {
-                                                scheduledAt: time.date,
-                                              })
-                                            }
-                                            className={`rounded-full px-2.5 py-1 text-xs transition ${
-                                              time.isPrimary
-                                                ? 'bg-gold/20 text-gold hover:bg-gold/30'
-                                                : 'bg-ivory/10 text-ivory/70 hover:bg-ivory/20'
-                                            }`}
-                                          >
-                                            {time.label}
-                                          </button>
-                                        ))}
+                                      <div>
+                                        <p className="text-ivory/40 mb-2 text-xs uppercase tracking-wider">
+                                          Ou choisir manuellement
+                                        </p>
+                                        <input
+                                          type="datetime-local"
+                                          value={
+                                            config.scheduledAt
+                                              ? formatDateTimeLocal(config.scheduledAt)
+                                              : ''
+                                          }
+                                          onChange={e => {
+                                            const date = e.target.value
+                                              ? new Date(e.target.value)
+                                              : null;
+                                            updatePostConfig(config.platform, {
+                                              scheduledAt: date,
+                                            });
+                                          }}
+                                          min={formatDateTimeLocal(new Date())}
+                                          className="border-gold/20 bg-night/50 text-ivory focus:border-gold w-full rounded-lg border px-4 py-2 focus:outline-none"
+                                        />
                                       </div>
                                     </div>
                                   )}

--- a/apps/psypnos/app/admin/social/posts/new/page.tsx
+++ b/apps/psypnos/app/admin/social/posts/new/page.tsx
@@ -954,6 +954,7 @@ export default function NewSocialPostPage() {
         generations={generation.generations}
         blogSlug={selectedArticle?.slug || ''}
         blogTitle={selectedArticle?.title || ''}
+        articleDate={selectedArticle?.date}
         articleImage={selectedArticle?.image}
         tone={selectedTone}
         angle={selectedAngle}

--- a/apps/psypnos/lib/social/suggested-times.ts
+++ b/apps/psypnos/lib/social/suggested-times.ts
@@ -1,0 +1,96 @@
+import type { SocialPlatform, OptimalTimeSlot } from './types';
+import { OPTIMAL_POSTING_TIMES } from './types';
+
+// ===========================================
+// Types
+// ===========================================
+
+export interface SuggestedTime {
+  date: Date;
+  label: string;
+  isPrimary: boolean;
+  isIdeal: boolean;
+}
+
+// ===========================================
+// Helpers
+// ===========================================
+
+/**
+ * Formate une date en label lisible (ex: "Lun. 9 mars a 9h00").
+ * Affiche "Aujourd'hui" / "Demain" si applicable.
+ */
+export function formatSlotLabel(date: Date): string {
+  const now = new Date();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  const time = date.toLocaleTimeString('fr-FR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  if (date.toDateString() === now.toDateString()) return `Aujourd'hui a ${time}`;
+  if (date.toDateString() === tomorrow.toDateString()) return `Demain a ${time}`;
+
+  const day = date.toLocaleDateString('fr-FR', { weekday: 'short' });
+  const dayNum = date.getDate();
+  const month = date.toLocaleDateString('fr-FR', { month: 'short' });
+
+  return `${day.charAt(0).toUpperCase() + day.slice(1)} ${dayNum} ${month} a ${time}`;
+}
+
+/**
+ * Calcule les creneaux optimaux a partir d'une date de reference.
+ * Utilise la date de l'article si fournie, sinon la date du jour.
+ * Les creneaux passes (anterieurs a maintenant) sont toujours filtres.
+ */
+export function computeSuggestedTimes(
+  platform: SocialPlatform,
+  articleDate?: string | null,
+  maxCount: number = 8
+): SuggestedTime[] {
+  const referenceDate = articleDate ? new Date(articleDate) : new Date();
+  const now = new Date();
+
+  // Si la date article est passee, utiliser maintenant comme plancher
+  const effectiveStart = referenceDate > now ? referenceDate : now;
+
+  const slots: OptimalTimeSlot[] = OPTIMAL_POSTING_TIMES[platform] || [];
+  const suggestions: SuggestedTime[] = [];
+
+  // Generer les 14 prochains jours de creneaux a partir de la date de reference
+  for (let dayOffset = 0; dayOffset < 14 && suggestions.length < maxCount; dayOffset++) {
+    const date = new Date(effectiveStart);
+    date.setDate(effectiveStart.getDate() + dayOffset);
+    const dayOfWeek = date.getDay();
+
+    for (const slot of slots) {
+      if (slot.dayOfWeek === dayOfWeek) {
+        const slotDate = new Date(date);
+        slotDate.setHours(slot.hour, 0, 0, 0);
+
+        // Ne pas inclure les creneaux passes
+        if (slotDate <= now) continue;
+
+        suggestions.push({
+          date: slotDate,
+          label: formatSlotLabel(slotDate),
+          isPrimary: slot.priority === 'primary',
+          isIdeal: false, // sera marque apres le tri
+        });
+      }
+    }
+  }
+
+  // Trier par date
+  suggestions.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  // Marquer le premier creneau primary comme "ideal"
+  const firstPrimary = suggestions.find(s => s.isPrimary);
+  if (firstPrimary) {
+    firstPrimary.isIdeal = true;
+  }
+
+  return suggestions.slice(0, maxCount);
+}


### PR DESCRIPTION
## Summary
- Ajoute un composant `SuggestedTimeSlots` qui propose des créneaux de publication optimaux en fonction de la date de l'article de blog associé
- Refactorise `SavePostModal` et `EditPostModal` pour intégrer les suggestions d'horaires
- Ajoute la logique de calcul des créneaux suggérés dans `apps/psypnos/lib/social/suggested-times.ts`
- Ajoute des tests unitaires pour la génération des créneaux suggérés

## Test plan
- [ ] Vérifier que les créneaux suggérés s'affichent correctement lors de la création d'un nouveau post social lié à un article
- [ ] Vérifier que les créneaux suggérés s'affichent dans la modale d'édition d'un post existant
- [ ] Vérifier que la sélection d'un créneau met à jour la date de publication
- [ ] Vérifier le comportement quand aucun article n'est associé (pas de suggestions)
- [ ] Exécuter `pnpm test:coverage` pour valider les tests unitaires

Closes #284

https://claude.ai/code/session_01BJT3RVrN6eSaQ3eHhN43Y4