### PR TITLE
fix(db,api): renforcer l'isolation multi-tenant analytics et blog

### DIFF
--- a/apps/psypnos/__tests__/unit/blog-jobs-route.test.ts
+++ b/apps/psypnos/__tests__/unit/blog-jobs-route.test.ts
@@ -12,10 +12,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks hoistés — vi.hoisted() évite les erreurs de référence ──
 
-const { mockCreate, mockFindMany, mockWithAdminAuth } = vi.hoisted(() => ({
+const { mockCreate, mockFindMany, mockWithAdminAuth, mockGetSiteId } = vi.hoisted(() => ({
   mockCreate: vi.fn(),
   mockFindMany: vi.fn(),
   mockWithAdminAuth: vi.fn(),
+  mockGetSiteId: vi.fn(),
 }));
 
 // ─── Mocks — déclarés AVANT les imports ───────────────────────────
@@ -41,6 +42,10 @@ vi.mock('@/lib/db/prisma', () => ({
 
 vi.mock('../../app/api/auth/middleware', () => ({
   withAdminAuth: () => mockWithAdminAuth(),
+}));
+
+vi.mock('@/lib/db/site', () => ({
+  getSiteId: () => mockGetSiteId(),
 }));
 
 // ─── Imports (après les mocks) ────────────────────────────────────
@@ -71,6 +76,7 @@ describe('/api/blog/jobs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockWithAdminAuth.mockResolvedValue({ error: null });
+    mockGetSiteId.mockResolvedValue('site-test-123');
 
     mockCreate.mockResolvedValue({
       id: 'job-abc-123',

--- a/apps/psypnos/__tests__/unit/blog-jobs-step.test.ts
+++ b/apps/psypnos/__tests__/unit/blog-jobs-step.test.ts
@@ -13,10 +13,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks hoistés ──
 
-const { mockFindUnique, mockUpdate, mockWithAdminAuth } = vi.hoisted(() => ({
+const { mockFindUnique, mockUpdate, mockWithAdminAuth, mockGetSiteId } = vi.hoisted(() => ({
   mockFindUnique: vi.fn(),
   mockUpdate: vi.fn(),
   mockWithAdminAuth: vi.fn(),
+  mockGetSiteId: vi.fn(),
 }));
 
 // ─── Mocks ──
@@ -35,6 +36,7 @@ vi.mock('@/lib/db/prisma', () => ({
   prisma: {
     blogGenerationJob: {
       findUnique: mockFindUnique,
+      findFirst: mockFindUnique,
       update: mockUpdate,
     },
   },
@@ -42,6 +44,10 @@ vi.mock('@/lib/db/prisma', () => ({
 
 vi.mock('../../../app/api/auth/middleware', () => ({
   withAdminAuth: () => mockWithAdminAuth(),
+}));
+
+vi.mock('@/lib/db/site', () => ({
+  getSiteId: () => mockGetSiteId(),
 }));
 
 // Mock des modules IA pour éviter les appels réels
@@ -122,6 +128,7 @@ describe('executeNextStep', () => {
     vi.clearAllMocks();
     process.env.ANTHROPIC_API_KEY = 'test-key';
     mockUpdate.mockResolvedValue({});
+    mockGetSiteId.mockResolvedValue('site-test-123');
   });
 
   it('doit retourner COMPLETED directement si le job est déjà terminé', async () => {

--- a/apps/psypnos/app/api/analytics/bots/route.ts
+++ b/apps/psypnos/app/api/analytics/bots/route.ts
@@ -136,10 +136,13 @@ export async function GET(request: NextRequest): Promise<Response> {
     }
 
     const { prisma } = await import('@/lib/db/prisma');
+    const { getSiteId } = await import('@/lib/db/site');
+    const siteId = await getSiteId();
 
     // Fetch all visits in the date range
     const visits: BotVisitRecord[] = await prisma.botVisit.findMany({
       where: {
+        siteId,
         timestamp: {
           gte: dateFrom,
           lte: dateTo,

--- a/apps/psypnos/app/api/analytics/bots/track/route.ts
+++ b/apps/psypnos/app/api/analytics/bots/track/route.ts
@@ -60,8 +60,9 @@ export async function POST(request: NextRequest) {
 
     const data = validationResult.data;
 
-    // Import Prisma dynamically
+    // Import Prisma and site helper dynamically
     const { prisma } = await import('@/lib/db/prisma');
+    const { getSiteId } = await import('@/lib/db/site');
 
     // Determine country code and name
     let countryCode: string | undefined;
@@ -81,6 +82,8 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const siteId = await getSiteId();
+
     // Store the bot visit
     await prisma.botVisit.create({
       data: {
@@ -93,6 +96,7 @@ export async function POST(request: NextRequest) {
         countryCode: countryCode,
         city: data.city || undefined,
         ipHash: data.ipHash,
+        siteId,
       },
     });
 

--- a/apps/psypnos/app/api/blog/analytics/engagement/route.ts
+++ b/apps/psypnos/app/api/blog/analytics/engagement/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 /**
  * POST - Update reading engagement metrics for a blog article
@@ -32,36 +33,25 @@ export async function POST(request: NextRequest) {
       try {
         body = JSON.parse(text);
       } catch {
-        return NextResponse.json(
-          { error: 'Invalid JSON body' },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
       }
     }
 
-    const {
-      slug,
-      sessionId,
-      scrollDepthPercent,
-      timeOnPage,
-      completed,
-      isFinal,
-    } = body;
+    const { slug, sessionId, scrollDepthPercent, timeOnPage, completed, isFinal } = body;
 
     // Validation
     if (!slug || !sessionId) {
-      return NextResponse.json(
-        { error: 'slug and sessionId are required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'slug and sessionId are required' }, { status: 400 });
     }
 
     // Find the most recent analytics record for this session and article
     // (created within the last 2 hours to avoid updating old sessions)
+    const siteId = await getSiteId();
     const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
 
     const existingRecord = await prisma.blogAnalytics.findFirst({
       where: {
+        siteId,
         articleSlug: slug,
         sessionId: sessionId,
         timestamp: {
@@ -80,10 +70,7 @@ export async function POST(request: NextRequest) {
         existingRecord.scrollDepthPercent ?? 0,
         scrollDepthPercent ?? 0
       );
-      const newTimeOnPage = Math.max(
-        existingRecord.timeOnPage ?? 0,
-        timeOnPage ?? 0
-      );
+      const newTimeOnPage = Math.max(existingRecord.timeOnPage ?? 0, timeOnPage ?? 0);
       const newCompleted = existingRecord.completed || completed || false;
 
       await prisma.blogAnalytics.update({
@@ -112,6 +99,7 @@ export async function POST(request: NextRequest) {
           scrollDepthPercent: scrollDepthPercent ?? 0,
           timeOnPage: timeOnPage ?? 0,
           completed: completed || false,
+          siteId,
         },
       });
 
@@ -126,9 +114,6 @@ export async function POST(request: NextRequest) {
     }
   } catch (error) {
     console.error('Error updating engagement metrics:', error);
-    return NextResponse.json(
-      { error: 'Failed to update engagement metrics' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to update engagement metrics' }, { status: 500 });
   }
 }

--- a/apps/psypnos/app/api/blog/analytics/route.ts
+++ b/apps/psypnos/app/api/blog/analytics/route.ts
@@ -3,6 +3,7 @@ import { createHmac } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 import {
   isMockMode,
   generateMockBlogAnalytics,
@@ -81,10 +82,12 @@ export async function GET(request: NextRequest) {
     // Mode réel - récupérer les vraies données
     console.log('📊 [Blog Analytics] Using REAL data');
 
+    const siteId = await getSiteId();
+
     if (slug) {
       // Retourner les stats d'un article spécifique
       const stats = (await prisma.blogAnalytics.findMany({
-        where: { articleSlug: slug, ...dateFilter },
+        where: { siteId, articleSlug: slug, ...dateFilter },
         orderBy: { timestamp: 'desc' },
         take: 10_000,
       })) as BlogAnalyticsRecord[];
@@ -129,7 +132,7 @@ export async function GET(request: NextRequest) {
     // Retourner toutes les stats triées par nombre de vues (filtrées par période)
     // Limit to 50,000 records to prevent memory exhaustion
     const allAnalytics = (await prisma.blogAnalytics.findMany({
-      where: dateFilter,
+      where: { siteId, ...dateFilter },
       select: {
         articleSlug: true,
         sessionId: true,
@@ -299,21 +302,24 @@ export async function POST(request: NextRequest) {
         ? sessionId
         : hashVisitorId(userAgent, ip);
 
+    const siteId = await getSiteId();
+
     await prisma.blogAnalytics.create({
       data: {
         articleSlug: slug,
         sessionId: finalSessionId,
         timestamp: new Date(),
+        siteId,
       },
     });
 
     // Use count() instead of fetching all records
     const [viewCount, uniqueResult] = await Promise.all([
       prisma.blogAnalytics.count({
-        where: { articleSlug: slug },
+        where: { siteId, articleSlug: slug },
       }),
       prisma.blogAnalytics.findMany({
-        where: { articleSlug: slug },
+        where: { siteId, articleSlug: slug },
         select: { sessionId: true },
         distinct: ['sessionId'],
       }),
@@ -338,12 +344,13 @@ export async function DELETE(request: NextRequest) {
     const authResult = await withAdminAuth();
     if (authResult.error) return authResult.error;
 
+    const siteId = await getSiteId();
     const searchParams = request.nextUrl.searchParams;
     const slug = searchParams.get('slug');
 
     if (slug) {
       const result = await prisma.blogAnalytics.deleteMany({
-        where: { articleSlug: slug },
+        where: { siteId, articleSlug: slug },
       });
 
       return NextResponse.json({
@@ -351,7 +358,9 @@ export async function DELETE(request: NextRequest) {
         deletedCount: result.count,
       });
     } else {
-      const result = await prisma.blogAnalytics.deleteMany({});
+      const result = await prisma.blogAnalytics.deleteMany({
+        where: { siteId },
+      });
 
       return NextResponse.json({
         message: 'All blog analytics stats deleted',

--- a/apps/psypnos/app/api/blog/cta-clicks/route.ts
+++ b/apps/psypnos/app/api/blog/cta-clicks/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 import { isMockMode, generateMockCtaClicks, logDataMode } from '@/lib/pwaDataMode';
 
 // Type for blog CTA click record (workaround for ungenerated Prisma client)
@@ -47,8 +48,11 @@ export async function GET(request: NextRequest) {
     // Mode réel - récupérer les vraies données
     console.log('📊 [CTA Clicks] Using REAL data');
 
+    const siteId = await getSiteId();
+
     // Build where clause with date filter
     const whereClause: Record<string, unknown> = {
+      siteId,
       timestamp: {
         gte: startDate,
         lte: endDate,
@@ -59,10 +63,10 @@ export async function GET(request: NextRequest) {
     }
 
     // Récupérer tous les clics CTA depuis PostgreSQL (filtrés par période)
-    const clicks = await prisma.blogCtaClick.findMany({
+    const clicks = (await prisma.blogCtaClick.findMany({
       where: whereClause,
       orderBy: { timestamp: 'desc' },
-    }) as BlogCtaClickRecord[];
+    })) as BlogCtaClickRecord[];
 
     // Construire le résumé par type de CTA
     const summary = {
@@ -70,7 +74,7 @@ export async function GET(request: NextRequest) {
       seminar: 0,
     };
 
-    clicks.forEach((click) => {
+    clicks.forEach(click => {
       if (click.ctaType === 'appointment') {
         summary.appointment += 1;
       } else if (click.ctaType === 'seminar') {
@@ -88,10 +92,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('Error fetching CTA clicks:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch CTA clicks' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch CTA clicks' }, { status: 500 });
   }
 }
 
@@ -109,26 +110,27 @@ export async function POST(request: NextRequest) {
     }
 
     if (!articleSlug) {
-      return NextResponse.json(
-        { error: 'articleSlug is required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'articleSlug is required' }, { status: 400 });
     }
 
+    const siteId = await getSiteId();
+
     // Enregistrer le clic dans PostgreSQL
-    const click = await prisma.blogCtaClick.create({
+    const click = (await prisma.blogCtaClick.create({
       data: {
         articleSlug,
         ctaType: type,
         sessionId: sessionId || 'anonymous',
         timestamp: new Date(),
+        siteId,
       },
-    }) as BlogCtaClickRecord;
+    })) as BlogCtaClickRecord;
 
     // Calculer le résumé après insertion
-    const allClicks = await prisma.blogCtaClick.findMany({
+    const allClicks = (await prisma.blogCtaClick.findMany({
+      where: { siteId },
       select: { ctaType: true },
-    }) as Array<{ ctaType: string }>;
+    })) as Array<{ ctaType: string }>;
 
     const summary = {
       appointment: allClicks.filter(c => c.ctaType === 'appointment').length,
@@ -147,23 +149,21 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('Error tracking CTA click:', error);
-    return NextResponse.json(
-      { error: 'Failed to track CTA click' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to track CTA click' }, { status: 500 });
   }
 }
 
 // DELETE - Réinitialiser les statistiques
 export async function DELETE(request: NextRequest) {
   try {
+    const siteId = await getSiteId();
     const searchParams = request.nextUrl.searchParams;
     const articleSlug = searchParams.get('articleSlug');
 
     if (articleSlug) {
       // Supprimer les clics pour un article spécifique
       const result = await prisma.blogCtaClick.deleteMany({
-        where: { articleSlug },
+        where: { siteId, articleSlug },
       });
 
       return NextResponse.json({
@@ -171,8 +171,10 @@ export async function DELETE(request: NextRequest) {
         deletedCount: result.count,
       });
     } else {
-      // Supprimer tous les clics CTA
-      const result = await prisma.blogCtaClick.deleteMany({});
+      // Supprimer tous les clics CTA du site
+      const result = await prisma.blogCtaClick.deleteMany({
+        where: { siteId },
+      });
 
       return NextResponse.json({
         message: 'All CTA clicks data deleted',
@@ -181,9 +183,6 @@ export async function DELETE(request: NextRequest) {
     }
   } catch (error) {
     console.error('Error deleting CTA clicks data:', error);
-    return NextResponse.json(
-      { error: 'Failed to delete CTA clicks data' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to delete CTA clicks data' }, { status: 500 });
   }
 }

--- a/apps/psypnos/app/api/blog/faq-clicks/route.ts
+++ b/apps/psypnos/app/api/blog/faq-clicks/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 import { isMockMode, generateMockFaqClicks, logDataMode } from '@/lib/pwaDataMode';
 
 /**
@@ -50,8 +51,11 @@ export async function GET(request: NextRequest) {
     // Mode réel - récupérer les vraies données
     console.log('📊 [FAQ Clicks] Using REAL data');
 
+    const siteId = await getSiteId();
+
     // Build where clause with date filter
     const whereClause: Record<string, unknown> = {
+      siteId,
       timestamp: {
         gte: startDate,
         lte: endDate,
@@ -92,10 +96,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('Error fetching FAQ clicks:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch FAQ clicks' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch FAQ clicks' }, { status: 500 });
   }
 }
 
@@ -106,11 +107,10 @@ export async function POST(request: NextRequest) {
     const { articleSlug, faqIndex, question, sessionId } = body;
 
     if (!articleSlug || faqIndex === undefined) {
-      return NextResponse.json(
-        { error: 'articleSlug and faqIndex are required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'articleSlug and faqIndex are required' }, { status: 400 });
     }
+
+    const siteId = await getSiteId();
 
     // Enregistrer le clic dans PostgreSQL
     const click = await prisma.blogFaqClick.create({
@@ -120,12 +120,14 @@ export async function POST(request: NextRequest) {
         question: question || null,
         sessionId: sessionId || 'anonymous',
         timestamp: new Date(),
+        siteId,
       },
     });
 
     // Calculer le résumé pour ce FAQ
     const totalClicks = await prisma.blogFaqClick.count({
       where: {
+        siteId,
         articleSlug,
         faqIndex: parseInt(faqIndex),
       },
@@ -147,23 +149,21 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('Error tracking FAQ click:', error);
-    return NextResponse.json(
-      { error: 'Failed to track FAQ click' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to track FAQ click' }, { status: 500 });
   }
 }
 
 // DELETE - Réinitialiser les statistiques
 export async function DELETE(request: NextRequest) {
   try {
+    const siteId = await getSiteId();
     const searchParams = request.nextUrl.searchParams;
     const articleSlug = searchParams.get('articleSlug');
 
     if (articleSlug) {
       // Supprimer les clics pour un article spécifique
       const result = await prisma.blogFaqClick.deleteMany({
-        where: { articleSlug },
+        where: { siteId, articleSlug },
       });
 
       return NextResponse.json({
@@ -171,8 +171,10 @@ export async function DELETE(request: NextRequest) {
         deletedCount: result.count,
       });
     } else {
-      // Supprimer tous les clics FAQ
-      const result = await prisma.blogFaqClick.deleteMany({});
+      // Supprimer tous les clics FAQ du site
+      const result = await prisma.blogFaqClick.deleteMany({
+        where: { siteId },
+      });
 
       return NextResponse.json({
         message: 'All FAQ clicks data deleted',
@@ -181,9 +183,6 @@ export async function DELETE(request: NextRequest) {
     }
   } catch (error) {
     console.error('Error deleting FAQ clicks data:', error);
-    return NextResponse.json(
-      { error: 'Failed to delete FAQ clicks data' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to delete FAQ clicks data' }, { status: 500 });
   }
 }

--- a/apps/psypnos/app/api/blog/jobs/[id]/route.ts
+++ b/apps/psypnos/app/api/blog/jobs/[id]/route.ts
@@ -6,11 +6,12 @@
  * @description API endpoint pour consulter le statut d'un job de génération spécifique
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from 'next/server';
 
-import { prisma } from "@/lib/db/prisma";
+import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
-import { withAdminAuth } from "../../../auth/middleware";
+import { withAdminAuth } from '../../../auth/middleware';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -36,23 +37,19 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
   const { id } = await params;
 
-  if (!id || typeof id !== "string") {
-    return NextResponse.json(
-      { message: "ID de job invalide" },
-      { status: 400 }
-    );
+  if (!id || typeof id !== 'string') {
+    return NextResponse.json({ message: 'ID de job invalide' }, { status: 400 });
   }
 
   try {
-    const job = await prisma.blogGenerationJob.findUnique({
-      where: { id },
+    const siteId = await getSiteId();
+
+    const job = await prisma.blogGenerationJob.findFirst({
+      where: { id, siteId },
     });
 
     if (!job) {
-      return NextResponse.json(
-        { message: "Job non trouvé" },
-        { status: 404 }
-      );
+      return NextResponse.json({ message: 'Job non trouvé' }, { status: 404 });
     }
 
     // Construire la réponse selon le statut
@@ -86,12 +83,12 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     };
 
     // Inclure le résultat si le job est terminé
-    if (job.status === "COMPLETED" && job.result) {
+    if (job.status === 'COMPLETED' && job.result) {
       response.result = job.result;
     }
 
     // Inclure l'erreur si le job a échoué
-    if (job.status === "FAILED") {
+    if (job.status === 'FAILED') {
       response.error = job.error;
       // Inclure aussi l'input pour permettre de réessayer
       response.input = job.input;
@@ -100,7 +97,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // Inclure le topic de l'input pour l'affichage
     if (job.input) {
       response.input = {
-        topic: (job.input as any)?.topic || "Sans titre",
+        topic: (job.input as any)?.topic || 'Sans titre',
         category: (job.input as any)?.category,
       };
     }
@@ -108,9 +105,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(response);
   } catch (error) {
     console.error(`[BlogJob] Erreur récupération job ${id}:`, error);
-    return NextResponse.json(
-      { message: "Erreur lors de la récupération du job" },
-      { status: 500 }
-    );
+    return NextResponse.json({ message: 'Erreur lors de la récupération du job' }, { status: 500 });
   }
 }

--- a/apps/psypnos/app/api/blog/jobs/route.ts
+++ b/apps/psypnos/app/api/blog/jobs/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 import { withAdminAuth } from '../../auth/middleware';
 
@@ -71,6 +72,8 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    const siteId = await getSiteId();
+
     // Créer le job en base de données
     // Le frontend pilotera l'exécution via POST /api/blog/jobs/[id]/step
     const job = await prisma.blogGenerationJob.create({
@@ -81,6 +84,7 @@ export async function POST(request: NextRequest) {
         currentStep: 'En attente de traitement',
         currentStepIndex: 0,
         totalSteps: 9,
+        siteId,
       },
     });
 
@@ -119,8 +123,10 @@ export async function GET(request: NextRequest) {
   const status = statusParam as 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED' | null;
 
   try {
+    const siteId = await getSiteId();
+
     const jobs = await prisma.blogGenerationJob.findMany({
-      where: status ? { status } : undefined,
+      where: { siteId, ...(status ? { status } : {}) },
       orderBy: { createdAt: 'desc' },
       take: limit,
       select: {

--- a/apps/psypnos/app/api/blog/jobs/step-executor.ts
+++ b/apps/psypnos/app/api/blog/jobs/step-executor.ts
@@ -16,6 +16,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 import {
   generateArticleSectional,
@@ -92,9 +93,11 @@ export interface StepExecutionResult {
  * @returns Le résultat de l'exécution de l'étape
  */
 export async function executeNextStep(jobId: string): Promise<StepExecutionResult> {
+  const siteId = await getSiteId();
+
   // Récupérer le job
-  const job = await prisma.blogGenerationJob.findUnique({
-    where: { id: jobId },
+  const job = await prisma.blogGenerationJob.findFirst({
+    where: { id: jobId, siteId },
   });
 
   if (!job) {

--- a/apps/psypnos/app/api/blog/jobs/worker.ts
+++ b/apps/psypnos/app/api/blog/jobs/worker.ts
@@ -9,15 +9,16 @@
  * Il met à jour le statut du job en base de données à chaque étape.
  */
 
-import { prisma } from "@/lib/db/prisma";
+import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 import {
   generateArticleSectional,
   type GenerationProgress,
   type SectionalGenerationOptions,
-} from "../../common/claude-article-generator-sectional";
+} from '../../common/claude-article-generator-sectional';
 
-import type { CreateJobInput } from "./route";
+import type { CreateJobInput } from './route';
 
 /**
  * Met à jour la progression d'un job dans la base de données
@@ -49,9 +50,9 @@ async function markJobAsProcessing(jobId: string): Promise<void> {
   await prisma.blogGenerationJob.update({
     where: { id: jobId },
     data: {
-      status: "PROCESSING",
+      status: 'PROCESSING',
       startedAt: new Date(),
-      currentStep: "Démarrage de la génération...",
+      currentStep: 'Démarrage de la génération...',
     },
   });
   console.log(`[BlogJob:${jobId}] Job démarré (PROCESSING)`);
@@ -64,9 +65,9 @@ async function markJobAsCompleted(jobId: string, result: any): Promise<void> {
   await prisma.blogGenerationJob.update({
     where: { id: jobId },
     data: {
-      status: "COMPLETED",
+      status: 'COMPLETED',
       progress: 100,
-      currentStep: "Génération terminée",
+      currentStep: 'Génération terminée',
       result: result,
       completedAt: new Date(),
     },
@@ -81,8 +82,8 @@ async function markJobAsFailed(jobId: string, error: string): Promise<void> {
   await prisma.blogGenerationJob.update({
     where: { id: jobId },
     data: {
-      status: "FAILED",
-      currentStep: "Échec de la génération",
+      status: 'FAILED',
+      currentStep: 'Échec de la génération',
       error: error,
       completedAt: new Date(),
     },
@@ -99,16 +100,15 @@ async function markJobAsFailed(jobId: string, error: string): Promise<void> {
  * 3. Exécute la génération avec callbacks de progression
  * 4. Met à jour le job avec le résultat (COMPLETED) ou l'erreur (FAILED)
  */
-export async function runBlogGenerationWorker(
-  jobId: string,
-  apiKey: string
-): Promise<void> {
+export async function runBlogGenerationWorker(jobId: string, apiKey: string): Promise<void> {
   console.log(`[BlogJob:${jobId}] Démarrage du worker de génération`);
 
   try {
+    const siteId = await getSiteId();
+
     // Récupérer le job
-    const job = await prisma.blogGenerationJob.findUnique({
-      where: { id: jobId },
+    const job = await prisma.blogGenerationJob.findFirst({
+      where: { id: jobId, siteId },
     });
 
     if (!job) {
@@ -117,7 +117,7 @@ export async function runBlogGenerationWorker(
     }
 
     // Vérifier que le job est toujours en attente
-    if (job.status !== "PENDING") {
+    if (job.status !== 'PENDING') {
       console.warn(`[BlogJob:${jobId}] Job déjà traité (status: ${job.status})`);
       return;
     }
@@ -130,20 +130,18 @@ export async function runBlogGenerationWorker(
 
     // Construire les options de génération
     const options: SectionalGenerationOptions = {
-      topic: input.topic || input.subject || "",
+      topic: input.topic || input.subject || '',
       category: input.category,
       editorialCategory: input.editorialCategory || input.category,
       targetLength: input.targetLength,
-      seoQuery: input.seoQuery || input.seoKeyword || "",
-      searchIntent: input.searchIntent || input.searchIntention || "",
-      readerPersona: input.readerPersona || input.persona || "",
+      seoQuery: input.seoQuery || input.seoKeyword || '',
+      searchIntent: input.searchIntent || input.searchIntention || '',
+      readerPersona: input.readerPersona || input.persona || '',
       preferredTones: allTones,
       usePsypnosStyle: input.usePsypnosStyle,
       // Callback de progression pour mettre à jour le job
       onProgress: async (progress: GenerationProgress) => {
-        const progressPercent = Math.round(
-          (progress.step / progress.totalSteps) * 100
-        );
+        const progressPercent = Math.round((progress.step / progress.totalSteps) * 100);
 
         // Construire le message de progression
         let stepMessage = progress.name;
@@ -167,10 +165,7 @@ export async function runBlogGenerationWorker(
     // Vérifier le résultat
     if (!result.success && !result.content) {
       // Échec complet
-      await markJobAsFailed(
-        jobId,
-        result.error || "Erreur lors de la génération de l'article"
-      );
+      await markJobAsFailed(jobId, result.error || "Erreur lors de la génération de l'article");
       return;
     }
 
@@ -190,7 +185,7 @@ export async function runBlogGenerationWorker(
       // Avertissement si génération partielle
       ...(result.success === false &&
         result.content && {
-          warning: "Génération partielle - certaines étapes ont échoué",
+          warning: 'Génération partielle - certaines étapes ont échoué',
           error: result.error,
         }),
     };
@@ -200,7 +195,7 @@ export async function runBlogGenerationWorker(
     console.error(`[BlogJob:${jobId}] Erreur worker:`, error);
     await markJobAsFailed(
       jobId,
-      error instanceof Error ? error.message : "Erreur inconnue lors de la génération"
+      error instanceof Error ? error.message : 'Erreur inconnue lors de la génération'
     );
   }
 }
@@ -214,18 +209,19 @@ export async function runBlogGenerationWorker(
  *
  * Les jobs orphelins sont marqués comme FAILED avec un message explicatif.
  */
-export async function cleanupOrphanedJobs(
-  maxAgeMinutes: number = 30
-): Promise<number> {
-  console.log("[BlogJob] Nettoyage des jobs orphelins...");
+export async function cleanupOrphanedJobs(maxAgeMinutes: number = 30): Promise<number> {
+  console.log('[BlogJob] Nettoyage des jobs orphelins...');
 
   try {
     const cutoffTime = new Date(Date.now() - maxAgeMinutes * 60 * 1000);
 
+    const siteId = await getSiteId();
+
     // Trouver les jobs PROCESSING qui n'ont pas été mis à jour depuis longtemps
     const orphanedJobs = await prisma.blogGenerationJob.findMany({
       where: {
-        status: "PROCESSING",
+        siteId,
+        status: 'PROCESSING',
         updatedAt: {
           lt: cutoffTime,
         },
@@ -233,7 +229,7 @@ export async function cleanupOrphanedJobs(
     });
 
     if (orphanedJobs.length === 0) {
-      console.log("[BlogJob] Aucun job orphelin trouvé");
+      console.log('[BlogJob] Aucun job orphelin trouvé');
       return 0;
     }
 
@@ -245,7 +241,7 @@ export async function cleanupOrphanedJobs(
         },
       },
       data: {
-        status: "FAILED",
+        status: 'FAILED',
         error: `Job interrompu - le serveur a redémarré ou le job est resté bloqué pendant plus de ${maxAgeMinutes} minutes`,
         completedAt: new Date(),
       },
@@ -255,7 +251,7 @@ export async function cleanupOrphanedJobs(
 
     return result.count;
   } catch (error) {
-    console.error("[BlogJob] Erreur nettoyage jobs orphelins:", error);
+    console.error('[BlogJob] Erreur nettoyage jobs orphelins:', error);
     return 0;
   }
 }

--- a/apps/psypnos/app/api/blog/prisma-store.ts
+++ b/apps/psypnos/app/api/blog/prisma-store.ts
@@ -232,11 +232,13 @@ export async function createBlogPost(data: BlogPostPayload): Promise<BlogPostOut
     // Create or get tags
     const tagRecords = await Promise.all(
       tags.map(async tagName => {
-        const slug = tagName.toLowerCase().replace(/\s+/g, '-');
-        let tag = await prisma.tag.findUnique({ where: { slug } });
+        const tagSlug = tagName.toLowerCase().replace(/\s+/g, '-');
+        let tag = await prisma.tag.findUnique({
+          where: { slug_siteId: { slug: tagSlug, siteId } },
+        });
         if (!tag) {
           tag = await prisma.tag.create({
-            data: { name: tagName, slug },
+            data: { name: tagName, slug: tagSlug, siteId },
           });
         }
         return tag;
@@ -320,10 +322,12 @@ export async function updateBlogPost(
       const tagRecords = await Promise.all(
         tags.map(async tagName => {
           const tagSlug = tagName.toLowerCase().replace(/\s+/g, '-');
-          let tag = await prisma.tag.findUnique({ where: { slug: tagSlug } });
+          let tag = await prisma.tag.findUnique({
+            where: { slug_siteId: { slug: tagSlug, siteId } },
+          });
           if (!tag) {
             tag = await prisma.tag.create({
-              data: { name: tagName, slug: tagSlug },
+              data: { name: tagName, slug: tagSlug, siteId },
             });
           }
           return tag;

--- a/apps/psypnos/app/api/cron/cleanup/route.ts
+++ b/apps/psypnos/app/api/cron/cleanup/route.ts
@@ -36,6 +36,7 @@ import { EventType } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 // ── Data cleanup configuration ──────────────────────────────────────────────
 
@@ -94,12 +95,14 @@ function daysToCutoff(days: number): Date {
 async function cleanupData(): Promise<{ results: CleanupResult[]; total: number }> {
   const results: CleanupResult[] = [];
   let total = 0;
+  const siteId = await getSiteId();
 
   // 1. Clean up unified AnalyticsEvent table by event type
   for (const [groupName, config] of Object.entries(UNIFIED_RETENTION)) {
     const cutoff = daysToCutoff(config.days);
     const result = await prisma.analyticsEvent.deleteMany({
       where: {
+        siteId,
         type: { in: config.types },
         createdAt: { lt: cutoff },
       },
@@ -115,7 +118,7 @@ async function cleanupData(): Promise<{ results: CleanupResult[]; total: number 
   // 2. Clean up VisitorGeolocation
   const geoCutoff = daysToCutoff(LEGACY_RETENTION.visitorGeolocation);
   const geoResult = await prisma.visitorGeolocation.deleteMany({
-    where: { timestamp: { lt: geoCutoff } },
+    where: { siteId, timestamp: { lt: geoCutoff } },
   });
   results.push({
     table: 'VisitorGeolocation',
@@ -159,7 +162,7 @@ async function cleanupData(): Promise<{ results: CleanupResult[]; total: number 
 
       if (model) {
         const result = await model.deleteMany({
-          where: { [table.field]: { lt: cutoff } },
+          where: { siteId, [table.field]: { lt: cutoff } },
         });
         results.push({ table: table.name, deleted: result.count, retentionDays: table.days });
         total += result.count;
@@ -180,11 +183,13 @@ async function cleanupJobs(): Promise<{
 }> {
   const results: CleanupResult[] = [];
   let total = 0;
+  const siteId = await getSiteId();
 
   // 1. Mark orphaned PROCESSING jobs as FAILED
   const orphanCutoff = new Date(Date.now() - ORPHAN_TIMEOUT_MINUTES * 60 * 1000);
   const orphanedJobs = await prisma.blogGenerationJob.updateMany({
     where: {
+      siteId,
       status: 'PROCESSING',
       startedAt: { lt: orphanCutoff },
     },
@@ -201,6 +206,7 @@ async function cleanupJobs(): Promise<{
   const retentionCutoff = daysToCutoff(JOB_RETENTION_DAYS);
   const deletedJobs = await prisma.blogGenerationJob.deleteMany({
     where: {
+      siteId,
       status: { in: ['COMPLETED', 'FAILED'] },
       completedAt: { lt: retentionCutoff },
     },

--- a/apps/psypnos/scripts/migrate-blogpostextended-to-blogpost.ts
+++ b/apps/psypnos/scripts/migrate-blogpostextended-to-blogpost.ts
@@ -48,7 +48,7 @@ async function getOrCreateTag(tagName: string): Promise<string> {
 
   // Try to find existing tag
   const existingTag = await prisma.tag.findUnique({
-    where: { slug },
+    where: { slug_siteId: { slug, siteId: PSYPNOS_SITE_ID } },
   });
 
   if (existingTag) {
@@ -60,6 +60,7 @@ async function getOrCreateTag(tagName: string): Promise<string> {
     data: {
       name: tagName,
       slug,
+      site: { connect: { id: PSYPNOS_SITE_ID } },
     },
   });
 

--- a/packages/api/src/handlers/analytics/dashboard.ts
+++ b/packages/api/src/handlers/analytics/dashboard.ts
@@ -124,7 +124,7 @@ export async function handleDashboard(
     };
   }
 
-  const { period, startDate, endDate, siteId: querySiteId } = queryResult.query;
+  const { period, startDate, endDate } = queryResult.query;
 
   // Calculate date range
   const { start, end } = calculateDateRange(period, startDate, endDate);
@@ -133,7 +133,7 @@ export async function handleDashboard(
     const dashboardData = await getDashboardData({
       startDate: start,
       endDate: end,
-      siteId: querySiteId || configSiteId,
+      siteId: configSiteId,
     });
 
     // Cache for 5 minutes (admin data)

--- a/packages/api/src/handlers/analytics/export.ts
+++ b/packages/api/src/handlers/analytics/export.ts
@@ -98,7 +98,7 @@ export async function handleExport(
     };
   }
 
-  const { startDate, endDate, format, type, siteId: querySiteId } = queryResult.query;
+  const { startDate, endDate, format, type } = queryResult.query;
 
   // Validate dates
   const start = new Date(startDate);
@@ -139,7 +139,7 @@ export async function handleExport(
       endDate: end,
       format,
       type,
-      siteId: querySiteId || configSiteId,
+      siteId: configSiteId,
     });
 
     return {

--- a/packages/api/src/handlers/analytics/types.ts
+++ b/packages/api/src/handlers/analytics/types.ts
@@ -109,7 +109,6 @@ export const dashboardQuerySchema = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),
   period: z.enum(['today', '7d', '30d', '90d', 'custom']).default('7d'),
-  siteId: z.string().optional(),
 });
 
 export type DashboardQueryParams = z.infer<typeof dashboardQuerySchema>;
@@ -122,7 +121,6 @@ export const exportQuerySchema = z.object({
   endDate: z.string(),
   format: z.enum(['csv', 'xlsx', 'pdf']).default('csv'),
   type: z.enum(['overview', 'pages', 'events', 'conversions', 'full']).default('overview'),
-  siteId: z.string().optional(),
 });
 
 export type ExportQueryParams = z.infer<typeof exportQuerySchema>;
@@ -382,7 +380,7 @@ export function extractDomain(url: string | null): string | undefined {
  */
 export function hashIP(ip: string): string {
   // Use dynamic import to avoid bundling crypto in client
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   const { createHmac } = require('crypto') as typeof import('crypto');
   const secret = process.env.IP_HASH_SECRET || process.env.JWT_SECRET || 'kairn-ip-hash-fallback';
   return `ip_${createHmac('sha256', secret).update(ip).digest('hex').slice(0, 16)}`;

--- a/packages/api/src/handlers/blog/posts.ts
+++ b/packages/api/src/handlers/blog/posts.ts
@@ -64,7 +64,6 @@ export async function handleGetPosts(
     search,
     includeUnpublished,
     featuredFirst,
-    siteId: querySiteId,
   } = queryResult.query;
 
   try {
@@ -78,7 +77,7 @@ export async function handleGetPosts(
       search,
       includeUnpublished,
       featuredFirst,
-      siteId: querySiteId || configSiteId,
+      siteId: configSiteId,
     });
 
     // Cache strategy based on context
@@ -201,8 +200,7 @@ export async function handleCreatePost(
   }
 
   try {
-    // Add siteId if configured
-    const postData = siteId ? { ...data, siteId } : data;
+    const postData = { ...data, siteId };
     const post = await createPost(postData);
 
     // Invalidate cache

--- a/packages/api/src/handlers/blog/types.ts
+++ b/packages/api/src/handlers/blog/types.ts
@@ -29,7 +29,6 @@ export const blogPostSchema = z.object({
   publishedAt: z.string().datetime().optional().nullable(),
   metaTitle: z.string().max(70).optional(),
   metaDescription: z.string().max(160).optional(),
-  siteId: z.string().optional(), // For multi-tenant support
 });
 
 export type BlogPostInput = z.infer<typeof blogPostSchema>;
@@ -88,7 +87,6 @@ export const postsQuerySchema = z.object({
     .enum(['true', 'false'])
     .optional()
     .transform(v => v === 'true'),
-  siteId: z.string().optional(),
 });
 
 export type PostsQueryParams = z.infer<typeof postsQuerySchema>;
@@ -130,8 +128,8 @@ export interface Tag {
  * Blog handler configuration
  */
 export interface BlogHandlerConfig {
-  /** Site ID for multi-tenant filtering */
-  siteId?: string;
+  /** Site ID for multi-tenant filtering (required) */
+  siteId: string;
   /** Function to get all posts */
   getAllPosts: (options: {
     page?: number;

--- a/packages/api/src/handlers/seminars/index.ts
+++ b/packages/api/src/handlers/seminars/index.ts
@@ -40,7 +40,6 @@ export const seminarSchema = z.object({
   status: z.enum(['draft', 'published', 'cancelled', 'completed']).default('draft'),
   featured: z.boolean().default(false),
   tags: z.array(z.string()).default([]),
-  siteId: z.string().optional(),
 });
 
 export type SeminarInput = z.infer<typeof seminarSchema>;
@@ -83,7 +82,6 @@ export const seminarsQuerySchema = z.object({
     .optional()
     .transform(v => (v === 'true' ? true : v === 'false' ? false : undefined)),
   tag: z.string().optional(),
-  siteId: z.string().optional(),
 });
 
 export type SeminarsQueryParams = z.infer<typeof seminarsQuerySchema>;
@@ -199,7 +197,7 @@ export async function handleGetSeminars(
     };
   }
 
-  const { page, limit, status, upcoming, featured, tag, siteId: querySiteId } = queryResult.query;
+  const { page, limit, status, upcoming, featured, tag } = queryResult.query;
 
   try {
     const { seminars, total } = await getAllSeminars({
@@ -209,7 +207,7 @@ export async function handleGetSeminars(
       upcoming,
       featured,
       tag,
-      siteId: querySiteId || configSiteId,
+      siteId: configSiteId,
     });
 
     // Public seminars (published) can be cached

--- a/packages/api/src/handlers/testimonials/index.ts
+++ b/packages/api/src/handlers/testimonials/index.ts
@@ -22,7 +22,6 @@ export const testimonialSchema = z.object({
   company: z.string().max(100).optional(),
   featured: z.boolean().default(false),
   approved: z.boolean().default(false),
-  siteId: z.string().optional(),
 });
 
 export type TestimonialInput = z.infer<typeof testimonialSchema>;
@@ -48,7 +47,6 @@ export const testimonialsQuerySchema = z.object({
     .enum(['true', 'false'])
     .optional()
     .transform(v => (v === 'true' ? true : v === 'false' ? false : undefined)),
-  siteId: z.string().optional(),
 });
 
 export type TestimonialsQueryParams = z.infer<typeof testimonialsQuerySchema>;
@@ -126,7 +124,7 @@ export async function handleGetTestimonials(
     };
   }
 
-  const { page, limit, approved, featured, siteId: querySiteId } = queryResult.query;
+  const { page, limit, approved, featured } = queryResult.query;
 
   try {
     const { testimonials, total } = await getAllTestimonials({
@@ -134,7 +132,7 @@ export async function handleGetTestimonials(
       limit,
       approved,
       featured,
-      siteId: querySiteId || configSiteId,
+      siteId: configSiteId,
     });
 
     // Public testimonials (approved only) can be cached

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -51,6 +51,15 @@ model Site {
   analyticsDashboardConfigs AnalyticsDashboardConfig[]
   analyticsScheduledReports AnalyticsScheduledReport[]
 
+  // Relations - Blog Analytics & Tracking
+  blogAnalytics      BlogAnalytics[]
+  blogFaqClicks      BlogFaqClick[]
+  blogCtaClicks      BlogCtaClick[]
+  blogGenerationJobs BlogGenerationJob[]
+  botVisits          BotVisit[]
+  tags               Tag[]
+  appointments       Appointment[]
+
   // Relations - Chat
   chatConversations ChatConversation[]
 
@@ -244,7 +253,12 @@ model Tag {
   createdAt DateTime      @default(now())
   posts     BlogPostTag[]
 
-  @@unique([slug])
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@unique([slug, siteId])
+  @@index([siteId])
 }
 
 /// Many-to-many relation between posts and tags
@@ -496,8 +510,8 @@ model AnalyticsGoal {
   createdAt       DateTime  @default(now())
 
   // Multi-tenancy
-  siteId String?
-  site   Site?  @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
   // Relations
   completions AnalyticsGoalCompletion[]
@@ -582,8 +596,8 @@ model AnalyticsAlert {
   updatedAt       DateTime         @updatedAt
 
   // Multi-tenancy
-  siteId String?
-  site   Site?  @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
   // Relations
   history AnalyticsAlertHistory[]
@@ -638,8 +652,8 @@ model AnalyticsAnomaly {
   acknowledgedAt DateTime?
 
   // Multi-tenancy
-  siteId String?
-  site   Site?  @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
   @@index([siteId, detectedAt])
   @@index([acknowledged])
@@ -666,8 +680,8 @@ model AnalyticsDashboardConfig {
   updatedAt DateTime @updatedAt
 
   // Multi-tenancy
-  siteId String?
-  site   Site?  @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([siteId, userId])
@@ -703,8 +717,8 @@ model AnalyticsScheduledReport {
   updatedAt  DateTime        @updatedAt
 
   // Multi-tenancy
-  siteId String?
-  site   Site?  @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
   @@index([siteId, enabled])
   @@index([nextSendAt])
@@ -791,6 +805,11 @@ model Appointment {
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
 
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@index([siteId, startTime])
   @@index([clientEmail])
   @@index([startTime])
   @@index([status])
@@ -865,6 +884,11 @@ model BlogAnalytics {
   /// Whether the article was fully read
   completed         Boolean  @default(false)
 
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@index([siteId, articleSlug])
   @@index([articleSlug])
   @@index([timestamp])
   @@index([sessionId])
@@ -884,6 +908,11 @@ model BlogFaqClick {
   /// FAQ question text (for reporting)
   question    String?
 
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@index([siteId, articleSlug])
   @@index([articleSlug])
   @@index([timestamp])
 }
@@ -900,6 +929,11 @@ model BlogCtaClick {
   /// Event timestamp
   timestamp   DateTime @default(now())
 
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@index([siteId, articleSlug])
   @@index([articleSlug])
   @@index([ctaType])
   @@index([timestamp])
@@ -949,6 +983,11 @@ model BlogGenerationJob {
   /// Slug of created article (for duplicate prevention)
   articleSlug String?
 
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@index([siteId, status])
   @@index([status])
   @@index([createdAt])
 }
@@ -985,6 +1024,11 @@ model BotVisit {
   /// Hashed IP for privacy
   ipHash      String?
 
+  // Multi-tenancy
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+
+  @@index([siteId, timestamp])
   @@index([timestamp])
   @@index([botName])
   @@index([botType])

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -124,24 +124,34 @@ async function main() {
 
   const tags = await Promise.all([
     prisma.tag.upsert({
-      where: { slug: 'psychotherapie' },
+      where: { slug_siteId: { slug: 'psychotherapie', siteId: site.id } },
       update: {},
-      create: { name: 'Psychothérapie', slug: 'psychotherapie', color: '#4F46E5' },
+      create: { name: 'Psychothérapie', slug: 'psychotherapie', color: '#4F46E5', siteId: site.id },
     }),
     prisma.tag.upsert({
-      where: { slug: 'respiration-holotropique' },
+      where: { slug_siteId: { slug: 'respiration-holotropique', siteId: site.id } },
       update: {},
-      create: { name: 'Respiration Holotropique', slug: 'respiration-holotropique', color: '#059669' },
+      create: {
+        name: 'Respiration Holotropique',
+        slug: 'respiration-holotropique',
+        color: '#059669',
+        siteId: site.id,
+      },
     }),
     prisma.tag.upsert({
-      where: { slug: 'bien-etre' },
+      where: { slug_siteId: { slug: 'bien-etre', siteId: site.id } },
       update: {},
-      create: { name: 'Bien-être', slug: 'bien-etre', color: '#D97706' },
+      create: { name: 'Bien-être', slug: 'bien-etre', color: '#D97706', siteId: site.id },
     }),
     prisma.tag.upsert({
-      where: { slug: 'developpement-personnel' },
+      where: { slug_siteId: { slug: 'developpement-personnel', siteId: site.id } },
       update: {},
-      create: { name: 'Développement Personnel', slug: 'developpement-personnel', color: '#7C3AED' },
+      create: {
+        name: 'Développement Personnel',
+        slug: 'developpement-personnel',
+        color: '#7C3AED',
+        siteId: site.id,
+      },
     }),
   ]);
 
@@ -316,7 +326,7 @@ Bonne lecture !`,
 }
 
 main()
-  .catch((e) => {
+  .catch(e => {
     // eslint-disable-next-line no-console
     console.error('❌ Seed failed:', e);
     process.exit(1);


### PR DESCRIPTION
## Résumé

- Rend `siteId` obligatoire sur les modèles analytics (`AnalyticsGoal`, `AnalyticsAlert`, `AnalyticsAnomaly`, `AnalyticsDashboardConfig`, `AnalyticsScheduledReport`)
- Ajoute `siteId` + relation `Site` + index sur les modèles qui en manquaient (`BlogAnalytics`, `BlogFaqClick`, `BlogCtaClick`, `BotVisit`, `BlogGenerationJob`, `Appointment`, `Tag`)
- Change la contrainte d'unicité `Tag` de `@@unique([slug])` à `@@unique([slug, siteId])` pour isoler les tags par tenant
- Supprime l'acceptation du `siteId` via query string dans tous les handlers API (blog, testimonials, seminars, analytics) — le siteId est toujours dérivé du contexte serveur
- Filtre toutes les requêtes Prisma par `siteId` dans les routes analytics/bots, blog/analytics, blog/jobs, blog/cta-clicks, blog/faq-clicks, cron/cleanup

## Test plan

- [x] Lint : 0 erreurs
- [x] Type-check : passé
- [x] Tests unitaires : 32 fichiers, 637 tests passés (couverture 90%+)
- [x] Tests UI : 4 fichiers, 110 tests passés
- [x] Build : réussi
- [ ] Vérifier la migration Prisma en staging avant déploiement production
- [ ] Valider que les données existantes sans siteId sont migrées

Fixes #290, #291, #303

https://claude.ai/code/session_01RFvhSNaYj7G3sj8Agq4ozj