### PR TITLE
fix(audit): monitoring, error handling et sécurité auth (#309, #304, #330, #324)

### DIFF
--- a/packages/api/src/handlers/auth/__tests__/login.test.ts
+++ b/packages/api/src/handlers/auth/__tests__/login.test.ts
@@ -23,10 +23,18 @@ vi.mock('../../../middleware/with-rate-limit', () => ({
   },
 }));
 
-// Mock @kairn/core for JWT creation
+// Mock @kairn/core for JWT creation and logger
 const mockCreateToken = vi.fn().mockResolvedValue('mock-jwt-token');
 vi.mock('@kairn/core', () => ({
   createToken: (...args: unknown[]) => mockCreateToken(...args),
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+    withScope: vi.fn(),
+  }),
 }));
 
 // Import mocked modules after mock setup
@@ -257,6 +265,26 @@ describe('Login Handler', () => {
         },
       });
       expect(onFailedAttempt).toHaveBeenCalledWith('nonexistent@example.com', '127.0.0.1');
+    });
+
+    it('should call comparePassword with dummy hash when user not found (timing protection)', async () => {
+      const comparePassword = vi.fn().mockResolvedValue(false);
+      const config = createMockConfig({
+        findUserByEmail: vi.fn().mockResolvedValue(null),
+        comparePassword,
+      });
+
+      const request = createMockRequest({
+        email: 'nonexistent@example.com',
+        password: 'password123',
+      });
+
+      await handleLogin(request, config);
+
+      // comparePassword should be called even when user doesn't exist
+      // to equalize timing with the valid-user path
+      expect(comparePassword).toHaveBeenCalledTimes(1);
+      expect(comparePassword).toHaveBeenCalledWith('password123', expect.any(String));
     });
 
     it('should return 401 when password is incorrect', async () => {

--- a/packages/api/src/handlers/auth/login.ts
+++ b/packages/api/src/handlers/auth/login.ts
@@ -7,7 +7,7 @@
 
 import { randomUUID } from 'crypto';
 
-import { createToken, type JWTPayload } from '@kairn/core';
+import { createLogger, createToken, type JWTPayload } from '@kairn/core';
 
 import type { ApiRequest } from '../../middleware/types';
 import { getClientIP, RATE_LIMIT_PRESETS, withRateLimit } from '../../middleware/with-rate-limit';
@@ -21,6 +21,14 @@ import {
   type AuthHandlerConfig,
   type LoginResponse,
 } from './types';
+
+const loginLogger = createLogger('Auth:Login');
+
+/**
+ * Dummy hash used to equalize timing when user is not found.
+ * This prevents user enumeration via timing side-channel attacks.
+ */
+const DUMMY_HASH = '$2b$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012';
 
 /**
  * Default configuration
@@ -134,6 +142,12 @@ export async function handleLogin(
   const user = await findUserByEmail(normalizedEmail);
 
   if (!user) {
+    // Perform dummy comparison to equalize timing with valid-user path
+    await comparePassword(password, DUMMY_HASH);
+    loginLogger.warn('Login attempt for non-existent user', {
+      email: normalizedEmail,
+      ip: clientIP,
+    });
     onFailedAttempt?.(normalizedEmail, clientIP);
     return {
       response: error('INVALID_CREDENTIALS', 'Identifiants invalides'),
@@ -146,6 +160,10 @@ export async function handleLogin(
   const passwordMatches = await comparePassword(password, user.passwordHash);
 
   if (!passwordMatches) {
+    loginLogger.warn('Login attempt with invalid password', {
+      userId: user.id,
+      ip: clientIP,
+    });
     onFailedAttempt?.(normalizedEmail, clientIP);
     return {
       response: error('INVALID_CREDENTIALS', 'Identifiants invalides'),

--- a/packages/api/src/handlers/blog/__tests__/posts.test.ts
+++ b/packages/api/src/handlers/blog/__tests__/posts.test.ts
@@ -10,6 +10,21 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+vi.mock('@kairn/core', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+    withScope: vi.fn(),
+  }),
+}));
+
+vi.mock('@kairn/db', () => ({
+  handlePrismaError: vi.fn().mockReturnValue(null),
+}));
+
 import {
   handleGetPosts,
   handleGetPostBySlug,

--- a/packages/api/src/handlers/blog/posts.ts
+++ b/packages/api/src/handlers/blog/posts.ts
@@ -4,9 +4,14 @@
  * CRUD operations for blog posts.
  */
 
+import { createLogger } from '@kairn/core';
+import { handlePrismaError } from '@kairn/db';
+
 import type { ApiRequest, AuthContext } from '../../middleware/types';
 import { withBodyValidation, withQueryValidation } from '../../middleware/with-validation';
 import { error, paginated, success } from '../../utils/response';
+
+const postsLogger = createLogger('API:BlogPosts');
 
 import {
   blogPostSchema,
@@ -93,7 +98,15 @@ export async function handleGetPosts(
       },
     };
   } catch (e) {
-    console.error('Error fetching posts:', e);
+    const prismaResult = handlePrismaError(e, 'fetching posts');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    postsLogger.error('Error fetching posts', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des articles'),
       statusCode: 500,
@@ -140,7 +153,15 @@ export async function handleGetPostBySlug(
       },
     };
   } catch (e) {
-    console.error('Error fetching post:', e);
+    const prismaResult = handlePrismaError(e, 'fetching post');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    postsLogger.error('Error fetching post', e);
     return {
       response: error('INTERNAL_ERROR', "Erreur lors de la récupération de l'article"),
       statusCode: 500,
@@ -214,11 +235,17 @@ export async function handleCreatePost(
       headers: {},
     };
   } catch (e) {
-    console.error('Error creating post:', e);
-    const message = e instanceof Error ? e.message : 'Erreur lors de la création';
-
+    const prismaResult = handlePrismaError(e, 'creating post');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    postsLogger.error('Error creating post', e);
     return {
-      response: error('INTERNAL_ERROR', message),
+      response: error('INTERNAL_ERROR', 'Erreur lors de la création'),
       statusCode: 500,
       headers: {},
     };
@@ -287,11 +314,17 @@ export async function handleUpdatePost(
       headers: {},
     };
   } catch (e) {
-    console.error('Error updating post:', e);
-    const message = e instanceof Error ? e.message : 'Erreur lors de la mise à jour';
-
+    const prismaResult = handlePrismaError(e, 'updating post');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    postsLogger.error('Error updating post', e);
     return {
-      response: error('INTERNAL_ERROR', message),
+      response: error('INTERNAL_ERROR', 'Erreur lors de la mise à jour'),
       statusCode: 500,
       headers: {},
     };
@@ -337,7 +370,15 @@ export async function handleDeletePost(
       headers: {},
     };
   } catch (e) {
-    console.error('Error deleting post:', e);
+    const prismaResult = handlePrismaError(e, 'deleting post');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    postsLogger.error('Error deleting post', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la suppression'),
       statusCode: 500,

--- a/packages/api/src/handlers/blog/tags.ts
+++ b/packages/api/src/handlers/blog/tags.ts
@@ -4,9 +4,14 @@
  * CRUD operations for blog tags.
  */
 
+import { createLogger } from '@kairn/core';
+import { handlePrismaError } from '@kairn/db';
+
 import type { ApiRequest, AuthContext } from '../../middleware/types';
 import { withBodyValidation } from '../../middleware/with-validation';
 import { error, success } from '../../utils/response';
+
+const tagsLogger = createLogger('API:BlogTags');
 
 import { tagSchema, type BlogHandlerConfig, type Tag, type TagInput } from './types';
 
@@ -49,7 +54,15 @@ export async function handleGetTags(config: BlogHandlerConfig): Promise<TagHandl
       },
     };
   } catch (e) {
-    console.error('Error fetching tags:', e);
+    const prismaResult = handlePrismaError(e, 'fetching tags');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    tagsLogger.error('Error fetching tags', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des tags'),
       statusCode: 500,
@@ -110,20 +123,17 @@ export async function handleCreateTag(
       headers: {},
     };
   } catch (e) {
-    console.error('Error creating tag:', e);
-    const message = e instanceof Error ? e.message : 'Erreur lors de la création';
-
-    // Check for duplicate error
-    if (message.includes('existe déjà') || message.includes('duplicate')) {
+    const prismaResult = handlePrismaError(e, 'creating tag');
+    if (prismaResult) {
       return {
-        response: error('CONFLICT', 'Un tag avec ce nom ou slug existe déjà'),
-        statusCode: 409,
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
         headers: {},
       };
     }
-
+    tagsLogger.error('Error creating tag', e);
     return {
-      response: error('INTERNAL_ERROR', message),
+      response: error('INTERNAL_ERROR', 'Erreur lors de la création du tag'),
       statusCode: 500,
       headers: {},
     };
@@ -184,19 +194,17 @@ export async function handleUpdateTag(
       headers: {},
     };
   } catch (e) {
-    console.error('Error updating tag:', e);
-    const message = e instanceof Error ? e.message : 'Erreur lors de la mise à jour';
-
-    if (message.includes('not found') || message.includes('introuvable')) {
+    const prismaResult = handlePrismaError(e, 'updating tag');
+    if (prismaResult) {
       return {
-        response: error('NOT_FOUND', 'Tag non trouvé'),
-        statusCode: 404,
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
         headers: {},
       };
     }
-
+    tagsLogger.error('Error updating tag', e);
     return {
-      response: error('INTERNAL_ERROR', message),
+      response: error('INTERNAL_ERROR', 'Erreur lors de la mise à jour du tag'),
       statusCode: 500,
       headers: {},
     };
@@ -240,19 +248,17 @@ export async function handleDeleteTag(
       headers: {},
     };
   } catch (e) {
-    console.error('Error deleting tag:', e);
-    const message = e instanceof Error ? e.message : 'Erreur lors de la suppression';
-
-    if (message.includes('not found') || message.includes('introuvable')) {
+    const prismaResult = handlePrismaError(e, 'deleting tag');
+    if (prismaResult) {
       return {
-        response: error('NOT_FOUND', 'Tag non trouvé'),
-        statusCode: 404,
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
         headers: {},
       };
     }
-
+    tagsLogger.error('Error deleting tag', e);
     return {
-      response: error('INTERNAL_ERROR', message),
+      response: error('INTERNAL_ERROR', 'Erreur lors de la suppression du tag'),
       statusCode: 500,
       headers: {},
     };

--- a/packages/api/src/handlers/seminars/index.ts
+++ b/packages/api/src/handlers/seminars/index.ts
@@ -4,11 +4,15 @@
  * CRUD operations for seminars/events.
  */
 
+import { createLogger } from '@kairn/core';
+import { handlePrismaError } from '@kairn/db';
 import { z } from 'zod';
 
 import type { ApiRequest, AuthContext } from '../../middleware/types';
 import { withBodyValidation, withQueryValidation } from '../../middleware/with-validation';
 import { error, paginated, success } from '../../utils/response';
+
+const seminarsLogger = createLogger('API:Seminars');
 
 /**
  * Seminar status
@@ -224,7 +228,15 @@ export async function handleGetSeminars(
       },
     };
   } catch (e) {
-    console.error('Error fetching seminars:', e);
+    const prismaResult = handlePrismaError(e, 'fetching seminars');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    seminarsLogger.error('Error fetching seminars', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des séminaires'),
       statusCode: 500,
@@ -266,7 +278,15 @@ export async function handleGetSeminarBySlug(
       },
     };
   } catch (e) {
-    console.error('Error fetching seminar:', e);
+    const prismaResult = handlePrismaError(e, 'fetching seminar');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    seminarsLogger.error('Error fetching seminar', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la récupération du séminaire'),
       statusCode: 500,
@@ -323,7 +343,15 @@ export async function handleCreateSeminar(
       headers: {},
     };
   } catch (e) {
-    console.error('Error creating seminar:', e);
+    const prismaResult = handlePrismaError(e, 'creating seminar');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    seminarsLogger.error('Error creating seminar', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la création du séminaire'),
       statusCode: 500,
@@ -383,7 +411,15 @@ export async function handleUpdateSeminar(
       headers: {},
     };
   } catch (e) {
-    console.error('Error updating seminar:', e);
+    const prismaResult = handlePrismaError(e, 'updating seminar');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    seminarsLogger.error('Error updating seminar', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la mise à jour du séminaire'),
       statusCode: 500,
@@ -424,7 +460,15 @@ export async function handleDeleteSeminar(
       headers: {},
     };
   } catch (e) {
-    console.error('Error deleting seminar:', e);
+    const prismaResult = handlePrismaError(e, 'deleting seminar');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    seminarsLogger.error('Error deleting seminar', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la suppression du séminaire'),
       statusCode: 500,
@@ -501,7 +545,7 @@ export async function handleRegister(
       try {
         await sendRegistrationConfirmation(registration, seminar);
       } catch (e) {
-        console.error('Failed to send registration confirmation:', e);
+        seminarsLogger.error('Failed to send registration confirmation', e);
       }
     }
 
@@ -511,7 +555,15 @@ export async function handleRegister(
       headers: {},
     };
   } catch (e) {
-    console.error('Error creating registration:', e);
+    const prismaResult = handlePrismaError(e, 'creating registration');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    seminarsLogger.error('Error creating registration', e);
     return {
       response: error('INTERNAL_ERROR', "Erreur lors de l'inscription"),
       statusCode: 500,

--- a/packages/api/src/handlers/testimonials/index.ts
+++ b/packages/api/src/handlers/testimonials/index.ts
@@ -4,11 +4,15 @@
  * CRUD operations for testimonials.
  */
 
+import { createLogger } from '@kairn/core';
+import { handlePrismaError } from '@kairn/db';
 import { z } from 'zod';
 
 import type { ApiRequest, AuthContext } from '../../middleware/types';
 import { withBodyValidation, withQueryValidation } from '../../middleware/with-validation';
 import { error, paginated, success } from '../../utils/response';
+
+const testimonialsLogger = createLogger('API:Testimonials');
 
 /**
  * Testimonial schema
@@ -149,7 +153,15 @@ export async function handleGetTestimonials(
       },
     };
   } catch (e) {
-    console.error('Error fetching testimonials:', e);
+    const prismaResult = handlePrismaError(e, 'fetching testimonials');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    testimonialsLogger.error('Error fetching testimonials', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la récupération des témoignages'),
       statusCode: 500,
@@ -186,7 +198,15 @@ export async function handleGetTestimonialById(
       },
     };
   } catch (e) {
-    console.error('Error fetching testimonial:', e);
+    const prismaResult = handlePrismaError(e, 'fetching testimonial');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    testimonialsLogger.error('Error fetching testimonial', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la récupération du témoignage'),
       statusCode: 500,
@@ -233,7 +253,15 @@ export async function handleCreateTestimonial(
       headers: {},
     };
   } catch (e) {
-    console.error('Error creating testimonial:', e);
+    const prismaResult = handlePrismaError(e, 'creating testimonial');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    testimonialsLogger.error('Error creating testimonial', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la création du témoignage'),
       statusCode: 500,
@@ -289,7 +317,15 @@ export async function handleUpdateTestimonial(
       headers: {},
     };
   } catch (e) {
-    console.error('Error updating testimonial:', e);
+    const prismaResult = handlePrismaError(e, 'updating testimonial');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    testimonialsLogger.error('Error updating testimonial', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la mise à jour du témoignage'),
       statusCode: 500,
@@ -330,7 +366,15 @@ export async function handleDeleteTestimonial(
       headers: {},
     };
   } catch (e) {
-    console.error('Error deleting testimonial:', e);
+    const prismaResult = handlePrismaError(e, 'deleting testimonial');
+    if (prismaResult) {
+      return {
+        response: error(prismaResult.code, prismaResult.message),
+        statusCode: prismaResult.statusCode,
+        headers: {},
+      };
+    }
+    testimonialsLogger.error('Error deleting testimonial', e);
     return {
       response: error('INTERNAL_ERROR', 'Erreur lors de la suppression du témoignage'),
       statusCode: 500,

--- a/packages/api/src/middleware/__tests__/with-admin.test.ts
+++ b/packages/api/src/middleware/__tests__/with-admin.test.ts
@@ -7,6 +7,14 @@ vi.mock('@kairn/core', () => ({
     return null;
   }),
   verifyToken: vi.fn(),
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+    withScope: vi.fn(),
+  }),
 }));
 
 import { verifyToken } from '@kairn/core';

--- a/packages/api/src/middleware/__tests__/with-auth.test.ts
+++ b/packages/api/src/middleware/__tests__/with-auth.test.ts
@@ -7,6 +7,14 @@ vi.mock('@kairn/core', () => ({
     return null;
   }),
   verifyToken: vi.fn(),
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+    withScope: vi.fn(),
+  }),
 }));
 
 import { verifyToken } from '@kairn/core';

--- a/packages/api/src/middleware/__tests__/with-csrf.test.ts
+++ b/packages/api/src/middleware/__tests__/with-csrf.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+vi.mock('@kairn/core', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+    withScope: vi.fn(),
+  }),
+}));
+
 import { generateCSRFToken, validateCSRFToken } from '../with-csrf';
 
 describe('CSRF Middleware', () => {

--- a/packages/api/src/middleware/with-auth.ts
+++ b/packages/api/src/middleware/with-auth.ts
@@ -4,9 +4,11 @@
  * Verifies JWT tokens from cookies or Authorization header.
  */
 
-import { getTokenFromHeader, type JWTPayload, verifyToken } from '@kairn/core';
+import { createLogger, getTokenFromHeader, type JWTPayload, verifyToken } from '@kairn/core';
 
 import type { ApiErrorResponse, ApiRequest, AuthMiddlewareConfig, AuthResult } from './types';
+
+const authLogger = createLogger('Auth:Middleware');
 
 /**
  * Error codes for authentication failures
@@ -70,8 +72,10 @@ async function extractToken(
       if (cookie?.value) {
         return cookie.value;
       }
-    } catch {
-      // Cookie access failed
+    } catch (err) {
+      authLogger.warn('Cookie access failed during token extraction', {
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -176,8 +180,10 @@ export async function withAuth(
         token,
       },
     };
-  } catch (error) {
-    console.error('Auth middleware error:', error);
+  } catch (err) {
+    authLogger.error('Unexpected auth middleware error', err, {
+      url: request.url,
+    });
     return {
       success: false,
       error: createAuthError('INVALID_TOKEN'),

--- a/packages/api/src/middleware/with-csrf.ts
+++ b/packages/api/src/middleware/with-csrf.ts
@@ -6,7 +6,11 @@
 
 import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 
+import { createLogger } from '@kairn/core';
+
 import type { ApiErrorResponse, ApiRequest, CSRFConfig } from './types';
+
+const csrfLogger = createLogger('CSRF');
 
 /**
  * CSRF token structure
@@ -140,7 +144,10 @@ export function validateCSRFToken(token: string | null | undefined, config?: CSR
     }
 
     return true;
-  } catch {
+  } catch (err) {
+    csrfLogger.warn('CSRF token validation failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return false;
   }
 }
@@ -178,8 +185,10 @@ async function getCSRFTokenFromRequest(
       const formData = await clonedRequest.formData();
       return formData.get('csrf_token') as string | null;
     }
-  } catch {
-    // Parsing error
+  } catch (err) {
+    csrfLogger.warn('Failed to parse request body for CSRF token', {
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 
   return null;

--- a/packages/core/src/__tests__/logger-reporters.test.ts
+++ b/packages/core/src/__tests__/logger-reporters.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  createLogger,
+  configureLogger,
+  addErrorReporter,
+  removeAllErrorReporters,
+  type ErrorReportHandler,
+} from '../logger';
+
+describe('Logger error reporters', () => {
+  beforeEach(() => {
+    removeAllErrorReporters();
+    configureLogger({ enabled: true, minLevel: 'debug' });
+  });
+
+  afterEach(() => {
+    removeAllErrorReporters();
+  });
+
+  it('appelle le reporter sur un log de niveau error', () => {
+    const reporter = vi.fn();
+    addErrorReporter(reporter);
+
+    const logger = createLogger('test');
+    const testError = new Error('test error');
+    logger.error('Something failed', testError);
+
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'error',
+        message: 'Something failed',
+        scope: 'test',
+      }),
+      testError
+    );
+  });
+
+  it('appelle le reporter sur un log de niveau warn', () => {
+    const reporter = vi.fn();
+    addErrorReporter(reporter);
+
+    const logger = createLogger('test');
+    logger.warn('Warning message');
+
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warn',
+        message: 'Warning message',
+      }),
+      undefined
+    );
+  });
+
+  it('ne notifie pas le reporter pour les niveaux info et debug', () => {
+    const reporter = vi.fn();
+    addErrorReporter(reporter);
+
+    const logger = createLogger('test');
+    logger.info('Info message');
+    logger.debug('Debug message');
+
+    expect(reporter).not.toHaveBeenCalled();
+  });
+
+  it('supporte plusieurs reporters', () => {
+    const reporter1 = vi.fn();
+    const reporter2 = vi.fn();
+    addErrorReporter(reporter1);
+    addErrorReporter(reporter2);
+
+    const logger = createLogger('test');
+    logger.error('Error message', new Error('err'));
+
+    expect(reporter1).toHaveBeenCalledTimes(1);
+    expect(reporter2).toHaveBeenCalledTimes(1);
+  });
+
+  it('ne crash pas si un reporter lève une erreur', () => {
+    const badReporter: ErrorReportHandler = () => {
+      throw new Error('reporter error');
+    };
+    const goodReporter = vi.fn();
+    addErrorReporter(badReporter);
+    addErrorReporter(goodReporter);
+
+    const logger = createLogger('test');
+
+    expect(() => {
+      logger.error('Error message', new Error('err'));
+    }).not.toThrow();
+
+    expect(goodReporter).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeAllErrorReporters supprime tous les reporters', () => {
+    const reporter = vi.fn();
+    addErrorReporter(reporter);
+    removeAllErrorReporters();
+
+    const logger = createLogger('test');
+    logger.error('Error message', new Error('err'));
+
+    expect(reporter).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/auth/jwt.ts
+++ b/packages/core/src/auth/jwt.ts
@@ -5,7 +5,11 @@
  * key rotation and multiple secret versions.
  */
 
-import { jwtVerify, SignJWT, decodeProtectedHeader, type KeyLike } from "jose";
+import { jwtVerify, SignJWT, decodeProtectedHeader, type KeyLike } from 'jose';
+
+import { createLogger } from '../logger';
+
+const jwtLogger = createLogger('JWT');
 
 export interface JWTPayload {
   sub: string; // user ID
@@ -22,7 +26,7 @@ export interface JWTConfig {
   /** Token expiration time (default: "24h") */
   expiresIn?: string;
   /** Algorithm to use (default: "HS256") */
-  algorithm?: "HS256" | "HS384" | "HS512";
+  algorithm?: 'HS256' | 'HS384' | 'HS512';
   /** Issuer claim */
   issuer?: string;
   /** Audience claim */
@@ -68,8 +72,8 @@ function validateConfig(): void {
   if (process.env.NODE_ENV === 'production') {
     if (!jwtConfig?.secret && !secretsManager) {
       throw new Error(
-        "CRITICAL SECURITY ERROR: JWT must be configured. " +
-        "Call configureJWT() or setSecretsManager() before using JWT functions."
+        'CRITICAL SECURITY ERROR: JWT must be configured. ' +
+          'Call configureJWT() or setSecretsManager() before using JWT functions.'
       );
     }
   }
@@ -79,14 +83,14 @@ function validateConfig(): void {
  * Create a JWT token for an authenticated user
  */
 export async function createToken(
-  payload: Omit<JWTPayload, "iat" | "exp">,
+  payload: Omit<JWTPayload, 'iat' | 'exp'>,
   options?: Partial<JWTConfig>
 ): Promise<string> {
   validateConfig();
 
   const config = { ...jwtConfig, ...options };
-  const expiresIn = config?.expiresIn || "24h";
-  const algorithm = config?.algorithm || "HS256";
+  const expiresIn = config?.expiresIn || '24h';
+  const algorithm = config?.algorithm || 'HS256';
 
   // Try to use secrets manager if available
   if (secretsManager) {
@@ -104,15 +108,17 @@ export async function createToken(
       if (config?.audience) builder = builder.setAudience(config.audience);
 
       return builder.sign(signingKey);
-    } catch {
-      // Fall through to legacy secret
+    } catch (err) {
+      jwtLogger.warn('Secrets manager signing failed, falling back to legacy secret', {
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
   // Use configured secret
   const secret = config?.secret || process.env.JWT_SECRET;
   if (!secret) {
-    throw new Error("JWT secret not configured");
+    throw new Error('JWT secret not configured');
   }
 
   let builder = new SignJWT(payload)
@@ -138,8 +144,10 @@ export async function verifyToken(token: string): Promise<JWTPayload | null> {
       try {
         const header = decodeProtectedHeader(token);
         kid = header.kid;
-      } catch {
-        // Token invalid or malformed
+      } catch (err) {
+        jwtLogger.warn('Failed to decode token header', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
 
       // 2. If we have a kid, try that version
@@ -149,8 +157,11 @@ export async function verifyToken(token: string): Promise<JWTPayload | null> {
           try {
             const verified = await jwtVerify(token, verificationKey);
             return verified.payload as unknown as JWTPayload;
-          } catch {
-            // Continue to try other versions
+          } catch (err) {
+            jwtLogger.warn('Token verification failed for kid, trying other versions', {
+              kid,
+              error: err instanceof Error ? err.message : String(err),
+            });
           }
         }
       }
@@ -164,7 +175,11 @@ export async function verifyToken(token: string): Promise<JWTPayload | null> {
 
           const verified = await jwtVerify(token, verificationKey);
           return verified.payload as unknown as JWTPayload;
-        } catch {
+        } catch (err) {
+          jwtLogger.warn('Token verification failed for version, trying next', {
+            kid: version.kid,
+            error: err instanceof Error ? err.message : String(err),
+          });
           continue;
         }
       }
@@ -178,7 +193,10 @@ export async function verifyToken(token: string): Promise<JWTPayload | null> {
 
     const verified = await jwtVerify(token, getSecretKey(secret));
     return verified.payload as unknown as JWTPayload;
-  } catch {
+  } catch (err) {
+    jwtLogger.warn('Token verification failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return null;
   }
 }
@@ -187,7 +205,7 @@ export async function verifyToken(token: string): Promise<JWTPayload | null> {
  * Extract token from Authorization header
  */
 export function getTokenFromHeader(authHeader?: string): string | null {
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return null;
   }
   return authHeader.slice(7);
@@ -204,9 +222,7 @@ export function decodeToken(token: string): JWTPayload | null {
     const payloadPart = parts[1];
     if (!payloadPart) return null;
 
-    const payload = JSON.parse(
-      Buffer.from(payloadPart, 'base64url').toString('utf-8')
-    );
+    const payload = JSON.parse(Buffer.from(payloadPart, 'base64url').toString('utf-8'));
     return payload as JWTPayload;
   } catch {
     return null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,10 +47,13 @@ export {
   createLogger,
   logger,
   configureLogger,
+  addErrorReporter,
+  removeAllErrorReporters,
   type LogLevel,
   type LogContext,
   type LogEntry,
   type LoggerConfig,
+  type ErrorReportHandler,
 } from './logger';
 
 // Utils

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -32,6 +32,11 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   error: 3,
 };
 
+/**
+ * Error reporting handler for external monitoring services (Sentry, Axiom, etc.)
+ */
+export type ErrorReportHandler = (entry: LogEntry, originalError?: unknown) => void;
+
 export interface LoggerConfig {
   /** Minimum log level to output */
   minLevel?: LogLevel;
@@ -39,6 +44,8 @@ export interface LoggerConfig {
   output?: (entry: LogEntry) => void;
   /** Enable/disable logging */
   enabled?: boolean;
+  /** External error reporting handlers (Sentry, Axiom, etc.) */
+  errorReporters?: ErrorReportHandler[];
 }
 
 // Global config
@@ -127,11 +134,33 @@ function defaultOutput(entry: LogEntry): void {
 }
 
 /**
+ * Notify external error reporters
+ */
+function notifyReporters(entry: LogEntry, originalError?: unknown): void {
+  const reporters = globalConfig.errorReporters;
+  if (!reporters || reporters.length === 0) return;
+
+  for (const reporter of reporters) {
+    try {
+      reporter(entry, originalError);
+    } catch {
+      // Prevent reporter errors from breaking the application
+      console.warn('[Logger] Error reporter failed for entry:', entry.message);
+    }
+  }
+}
+
+/**
  * Output log entry
  */
-function outputLog(entry: LogEntry): void {
+function outputLog(entry: LogEntry, originalError?: unknown): void {
   const output = globalConfig.output || defaultOutput;
   output(entry);
+
+  // Notify external reporters for error and warn levels
+  if (entry.level === 'error' || entry.level === 'warn') {
+    notifyReporters(entry, originalError);
+  }
 }
 
 /**
@@ -157,7 +186,7 @@ export class Logger {
       error
     );
 
-    outputLog(entry);
+    outputLog(entry, error);
   }
 
   debug(message: string, context?: LogContext): void {
@@ -192,6 +221,23 @@ export class Logger {
   withScope(subScope: string): Logger {
     return new Logger(`${this.scope}:${subScope}`, this.defaultContext);
   }
+}
+
+/**
+ * Register an external error reporter (Sentry, Axiom, etc.)
+ */
+export function addErrorReporter(reporter: ErrorReportHandler): void {
+  if (!globalConfig.errorReporters) {
+    globalConfig.errorReporters = [];
+  }
+  globalConfig.errorReporters.push(reporter);
+}
+
+/**
+ * Remove all error reporters
+ */
+export function removeAllErrorReporters(): void {
+  globalConfig.errorReporters = [];
 }
 
 /**

--- a/packages/db/src/__tests__/errors.test.ts
+++ b/packages/db/src/__tests__/errors.test.ts
@@ -1,0 +1,118 @@
+import { Prisma } from '@prisma/client';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { handlePrismaError } from '../errors';
+
+describe('handlePrismaError', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('retourne null pour une erreur non-Prisma', () => {
+    const result = handlePrismaError(new Error('generic error'));
+    expect(result).toBeNull();
+  });
+
+  it('retourne null pour une valeur non-erreur', () => {
+    const result = handlePrismaError('string error');
+    expect(result).toBeNull();
+  });
+
+  it('mappe P2002 (unique constraint) vers CONFLICT 409', () => {
+    const err = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+      code: 'P2002',
+      clientVersion: '6.0.0',
+      meta: { target: ['email'] },
+    });
+    const result = handlePrismaError(err, 'creating user');
+
+    expect(result).toEqual({
+      code: 'CONFLICT',
+      message: 'Une ressource avec ces données existe déjà',
+      statusCode: 409,
+    });
+  });
+
+  it('mappe P2025 (record not found) vers NOT_FOUND 404', () => {
+    const err = new Prisma.PrismaClientKnownRequestError('Record not found', {
+      code: 'P2025',
+      clientVersion: '6.0.0',
+      meta: { modelName: 'BlogPost' },
+    });
+    const result = handlePrismaError(err, 'updating post');
+
+    expect(result).toEqual({
+      code: 'NOT_FOUND',
+      message: 'Ressource introuvable',
+      statusCode: 404,
+    });
+  });
+
+  it('mappe P2003 (foreign key constraint) vers VALIDATION_ERROR 400', () => {
+    const err = new Prisma.PrismaClientKnownRequestError('Foreign key constraint failed', {
+      code: 'P2003',
+      clientVersion: '6.0.0',
+      meta: { field_name: 'siteId' },
+    });
+    const result = handlePrismaError(err);
+
+    expect(result).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'Référence invalide : la ressource liée est introuvable',
+      statusCode: 400,
+    });
+  });
+
+  it('mappe P2014 (relation violation) vers VALIDATION_ERROR 400', () => {
+    const err = new Prisma.PrismaClientKnownRequestError('Relation violation', {
+      code: 'P2014',
+      clientVersion: '6.0.0',
+    });
+    const result = handlePrismaError(err);
+
+    expect(result).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'Modification impossible : une contrainte de relation serait violée',
+      statusCode: 400,
+    });
+  });
+
+  it('retourne INTERNAL_ERROR 500 pour un code Prisma non mappé', () => {
+    const err = new Prisma.PrismaClientKnownRequestError('Unknown error', {
+      code: 'P9999',
+      clientVersion: '6.0.0',
+    });
+    const result = handlePrismaError(err, 'unknown operation');
+
+    expect(result).toEqual({
+      code: 'INTERNAL_ERROR',
+      message: 'Erreur de base de données',
+      statusCode: 500,
+    });
+  });
+
+  it('mappe PrismaClientValidationError vers VALIDATION_ERROR 400', () => {
+    const err = new Prisma.PrismaClientValidationError('Invalid field', {
+      clientVersion: '6.0.0',
+    });
+    const result = handlePrismaError(err, 'creating post');
+
+    expect(result).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'Données invalides',
+      statusCode: 400,
+    });
+  });
+
+  it('mappe PrismaClientInitializationError vers SERVICE_UNAVAILABLE 503', () => {
+    const err = new Prisma.PrismaClientInitializationError('Cannot connect to database', '6.0.0');
+    const result = handlePrismaError(err, 'fetching data');
+
+    expect(result).toEqual({
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Service temporairement indisponible',
+      statusCode: 503,
+    });
+  });
+});

--- a/packages/db/src/errors.ts
+++ b/packages/db/src/errors.ts
@@ -1,0 +1,97 @@
+/**
+ * Prisma Error Handler
+ *
+ * Maps Prisma error codes to user-friendly API responses.
+ * Prevents exposure of internal database details to clients.
+ */
+
+import { Prisma } from '@prisma/client';
+
+/**
+ * Standardized Prisma error result for API handlers
+ */
+export interface PrismaErrorResult {
+  code: string;
+  message: string;
+  statusCode: number;
+}
+
+/**
+ * Map of Prisma error codes to user-friendly responses
+ */
+const PRISMA_ERROR_MAP: Record<string, PrismaErrorResult> = {
+  P2002: {
+    code: 'CONFLICT',
+    message: 'Une ressource avec ces données existe déjà',
+    statusCode: 409,
+  },
+  P2025: {
+    code: 'NOT_FOUND',
+    message: 'Ressource introuvable',
+    statusCode: 404,
+  },
+  P2003: {
+    code: 'VALIDATION_ERROR',
+    message: 'Référence invalide : la ressource liée est introuvable',
+    statusCode: 400,
+  },
+  P2014: {
+    code: 'VALIDATION_ERROR',
+    message: 'Modification impossible : une contrainte de relation serait violée',
+    statusCode: 400,
+  },
+};
+
+/**
+ * Handle a Prisma error and return a safe API response.
+ * Logs the full error server-side and returns only a safe message for the client.
+ *
+ * @param err - The caught error
+ * @param operation - Description of the operation for logging (e.g., 'creating post')
+ * @returns PrismaErrorResult if it's a Prisma error, null otherwise
+ */
+export function handlePrismaError(err: unknown, operation?: string): PrismaErrorResult | null {
+  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+    const mapped = PRISMA_ERROR_MAP[err.code];
+
+    console.warn(
+      `[DB] Prisma error during ${operation || 'operation'}: code=${err.code}`,
+      err.meta
+    );
+
+    if (mapped) {
+      return mapped;
+    }
+
+    console.error(`[DB] Unhandled Prisma error code: ${err.code}`, err.message);
+
+    return {
+      code: 'INTERNAL_ERROR',
+      message: 'Erreur de base de données',
+      statusCode: 500,
+    };
+  }
+
+  if (err instanceof Prisma.PrismaClientValidationError) {
+    console.error(`[DB] Prisma validation error during ${operation || 'operation'}:`, err.message);
+    return {
+      code: 'VALIDATION_ERROR',
+      message: 'Données invalides',
+      statusCode: 400,
+    };
+  }
+
+  if (err instanceof Prisma.PrismaClientInitializationError) {
+    console.error(
+      `[DB] Prisma initialization error during ${operation || 'operation'}:`,
+      err.message
+    );
+    return {
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Service temporairement indisponible',
+      statusCode: 503,
+    };
+  }
+
+  return null;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -30,3 +30,6 @@ export type {
 
 // Export Prisma utilities
 export { Prisma } from '@prisma/client';
+
+// Error handling
+export { handlePrismaError, type PrismaErrorResult } from './errors';


### PR DESCRIPTION
## Résumé

Traitement de 4 issues d'audit de sécurité et robustesse :

- **#309** : Système d'error reporters dans le Logger centralisé pour intégration monitoring externe (Sentry, Axiom, etc.)
- **#304** : Remplacement des catch vides par du logging structuré dans jwt.ts, with-auth.ts et with-csrf.ts
- **#330** : Protection timing-safe contre l'énumération d'utilisateurs (dummy bcrypt.compare + logging)
- **#324** : Helper `handlePrismaError` dans @kairn/db pour mapper les erreurs Prisma (P2002→409, P2025→404, etc.)

Fixes #309, #304, #330, #324

## Changements

| Fichier | Modification |
|---|---|
| `packages/core/src/logger/index.ts` | Ajout errorReporters, addErrorReporter(), removeAllErrorReporters() |
| `packages/core/src/auth/jwt.ts` | Logging structuré dans 5 catch blocks |
| `packages/api/src/middleware/with-auth.ts` | Logger structuré au lieu de console.error |
| `packages/api/src/middleware/with-csrf.ts` | Logger structuré dans 2 catch blocks |
| `packages/api/src/handlers/auth/login.ts` | Dummy bcrypt.compare + logging tentatives |
| `packages/db/src/errors.ts` | Nouveau helper handlePrismaError |
| `packages/api/src/handlers/blog/posts.ts` | Intégration handlePrismaError |
| `packages/api/src/handlers/blog/tags.ts` | Intégration handlePrismaError |
| `packages/api/src/handlers/testimonials/index.ts` | Intégration handlePrismaError |
| `packages/api/src/handlers/seminars/index.ts` | Intégration handlePrismaError |

## Validation

- [x] Lint (erreurs pré-existantes tsconfig uniquement)
- [x] Type-check
- [x] Tests (37 fichiers, 699 tests, couverture 88.39%)
- [x] Build (13 tâches)