### PR TITLE
feat(multi): centraliser RGPD, seeding et rotation JWT (#319 #323 #328)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -134,6 +134,7 @@ pnpm tsx scripts/verify-qstash-schedules.ts --site-url https://psypnos.fr
 | `aggregate`              | `30 * * * *`   | Agrégation analytics (toutes les heures à :30)    |
 | `check-alerts`           | `*/15 * * * *` | Vérification alertes (toutes les 15 min)          |
 | `process-reports`        | `45 * * * *`   | Traitement rapports (toutes les heures à :45)     |
+| `rotate-secrets`         | `0 2 * * *`    | Rotation automatique des clés JWT (2h00)          |
 
 ## Étape 3 : Tester les endpoints CRON
 

--- a/apps/psypnos/app/api/analytics/gdpr/delete/route.ts
+++ b/apps/psypnos/app/api/analytics/gdpr/delete/route.ts
@@ -3,15 +3,18 @@
  *
  * Deletes all analytics data associated with a given sessionId or visitorId.
  * Requires admin authentication.
+ * Uses the centralized @kairn/api GDPR handler.
  *
  * Usage:
  *   DELETE /api/analytics/gdpr/delete?sessionId=ses_xxx
  *   DELETE /api/analytics/gdpr/delete?visitorId=v_xxx
  */
 
+import { handleGdprDelete, gdprDeleteSchema } from '@kairn/api';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 
 export async function DELETE(request: NextRequest) {
   try {
@@ -21,56 +24,34 @@ export async function DELETE(request: NextRequest) {
     if (authResult.error) return authResult.error;
 
     const searchParams = request.nextUrl.searchParams;
-    const sessionId = searchParams.get('sessionId');
-    const visitorId = searchParams.get('visitorId');
+    const params = {
+      sessionId: searchParams.get('sessionId') || undefined,
+      visitorId: searchParams.get('visitorId') || undefined,
+    };
 
-    if (!sessionId && !visitorId) {
+    const parsed = gdprDeleteSchema.safeParse(params);
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: 'sessionId or visitorId query parameter is required' },
+        { error: parsed.error.errors[0]?.message || 'Invalid parameters' },
         { status: 400 }
       );
     }
 
-    const results: Record<string, number> = {};
-
-    if (sessionId) {
-      // Delete all analytics events for this session
-      const eventsResult = await prisma.analyticsEvent.deleteMany({
-        where: { sessionId },
-      });
-      results.analyticsEvents = eventsResult.count;
-
-      // Delete geolocation data
-      const geoResult = await prisma.visitorGeolocation.deleteMany({
-        where: { sessionId },
-      });
-      results.visitorGeolocations = geoResult.count;
-    }
-
-    if (visitorId) {
-      // Visitor ID is stored in the session data JSON, but the main
-      // identifier for deletion is sessionId. Log this request for audit.
-      console.log(
-        `[GDPR] Erasure request for visitorId: ${visitorId} at ${new Date().toISOString()}`
-      );
-    }
-
-    const totalDeleted = Object.values(results).reduce((sum, count) => sum + count, 0);
-
-    // Audit log
-    console.log(
-      `[GDPR] Data erasure completed: ${totalDeleted} records deleted for ${sessionId ? `sessionId=${sessionId}` : ''}${visitorId ? ` visitorId=${visitorId}` : ''}`
-    );
+    const siteId = await getSiteId();
+    const result = await handleGdprDelete(parsed.data, { prisma, siteId });
 
     return NextResponse.json({
       success: true,
-      message: `${totalDeleted} records deleted`,
-      details: results,
+      message: `${result.totalDeleted} records deleted`,
+      details: result.details,
     });
   } catch (error) {
     console.error('[GDPR] Deletion error:', error);
     return NextResponse.json(
-      { error: 'Deletion failed', message: error instanceof Error ? error.message : 'Unknown error' },
+      {
+        error: 'Deletion failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
       { status: 500 }
     );
   }

--- a/apps/psypnos/app/api/cron/rotate-secrets/route.ts
+++ b/apps/psypnos/app/api/cron/rotate-secrets/route.ts
@@ -1,0 +1,169 @@
+/**
+ * Cron Rotate Secrets API Route
+ *
+ * Automates JWT signing key rotation and cleanup:
+ * 1. Checks the age of the current signing key
+ * 2. Rotates to a new key if older than MAX_KEY_AGE_DAYS
+ * 3. Cleans up expired keys past their grace period
+ * 4. Reports key statistics for monitoring
+ *
+ * Frequency: daily at 2am (0 2 * * *)
+ * Security: QStash signature or CRON_SECRET
+ */
+
+import { DatabaseSecretsManager, type SecretsStorage } from '@kairn/core';
+import { verifyCronAuth } from '@kairn/core/scheduler';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { prisma } from '@/lib/db/prisma';
+
+/** Maximum age of the current key before rotation (30 days) */
+const MAX_KEY_AGE_DAYS = 30;
+const MAX_KEY_AGE_MS = MAX_KEY_AGE_DAYS * 24 * 60 * 60 * 1000;
+
+/** Alert threshold: warn if key is older than this (25 days) */
+const WARN_KEY_AGE_DAYS = 25;
+const WARN_KEY_AGE_MS = WARN_KEY_AGE_DAYS * 24 * 60 * 60 * 1000;
+
+/**
+ * Create a PrismaSecretsStorage adapter for DatabaseSecretsManager
+ */
+function createPrismaStorage(): SecretsStorage {
+  return {
+    async getCurrentKey() {
+      return prisma.secretKey.findFirst({
+        where: { isCurrent: true, isValid: true },
+      });
+    },
+    async getKeyByKid(kid: string) {
+      return prisma.secretKey.findUnique({ where: { kid } });
+    },
+    async getValidKeys() {
+      const now = new Date();
+      return prisma.secretKey.findMany({
+        where: {
+          isValid: true,
+          OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+        },
+      });
+    },
+    async createKey(key) {
+      return prisma.secretKey.create({
+        data: { ...key, activatedAt: new Date() },
+      });
+    },
+    async updateKey(kid: string, data) {
+      return prisma.secretKey.update({ where: { kid }, data });
+    },
+    async setCurrentKey(kid: string) {
+      await prisma.$transaction([
+        prisma.secretKey.updateMany({
+          where: { isCurrent: true },
+          data: { isCurrent: false },
+        }),
+        prisma.secretKey.update({
+          where: { kid },
+          data: { isCurrent: true },
+        }),
+      ]);
+    },
+    async invalidateExpiredKeys() {
+      const now = new Date();
+      const result = await prisma.secretKey.updateMany({
+        where: {
+          isValid: true,
+          expiresAt: { lte: now },
+        },
+        data: { isValid: false },
+      });
+      return result.count;
+    },
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyCronAuth(request);
+  if (!authResult.valid) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const startTime = Date.now();
+
+  try {
+    const storage = createPrismaStorage();
+    const manager = new DatabaseSecretsManager({
+      storage,
+      keyGracePeriodMs: 7 * 24 * 60 * 60 * 1000, // 7 days grace period
+    });
+
+    // 1. Get current key stats
+    const stats = await manager.getKeyStats();
+    const actions: string[] = [];
+
+    // 2. Check if rotation is needed
+    let rotated = false;
+    if (!stats.currentKid) {
+      // No current key — initialize
+      await manager.initialize();
+      actions.push('Initialized new signing key (none existed)');
+      rotated = true;
+    } else if (stats.oldestKeyAge !== null && stats.oldestKeyAge > MAX_KEY_AGE_MS) {
+      // Current key is too old — rotate
+      const newKey = await manager.rotateKey();
+      actions.push(
+        `Rotated key: old key expired after ${Math.round(stats.oldestKeyAge / (24 * 60 * 60 * 1000))} days. New key: ${newKey.kid}`
+      );
+      rotated = true;
+    } else if (stats.oldestKeyAge !== null && stats.oldestKeyAge > WARN_KEY_AGE_MS) {
+      // Key is getting old — warn
+      const ageDays = Math.round(stats.oldestKeyAge / (24 * 60 * 60 * 1000));
+      actions.push(
+        `Warning: current key is ${ageDays} days old (rotation at ${MAX_KEY_AGE_DAYS} days)`
+      );
+      console.warn(`[Cron:rotate-secrets] Key age warning: ${ageDays}/${MAX_KEY_AGE_DAYS} days`);
+    }
+
+    // 3. Clean up expired keys
+    const invalidated = await storage.invalidateExpiredKeys();
+    if (invalidated > 0) {
+      actions.push(`Invalidated ${invalidated} expired key(s)`);
+    }
+
+    // 4. Get updated stats
+    const updatedStats = await manager.getKeyStats();
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+
+    if (actions.length > 0) {
+      for (const action of actions) {
+        console.warn(`[Cron:rotate-secrets] ${action}`);
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      duration: `${duration}s`,
+      rotated,
+      stats: {
+        currentKid: updatedStats.currentKid,
+        validKeyCount: updatedStats.validKeyCount,
+        currentKeyAgeDays: updatedStats.oldestKeyAge
+          ? Math.round(updatedStats.oldestKeyAge / (24 * 60 * 60 * 1000))
+          : null,
+        maxKeyAgeDays: MAX_KEY_AGE_DAYS,
+      },
+      actions,
+    });
+  } catch (error) {
+    console.error('[Cron:rotate-secrets] Error:', error);
+    return NextResponse.json(
+      {
+        error: 'Secret rotation failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// Accept POST as well since QStash sends POST by default
+export { GET as POST };

--- a/apps/psypnos/components/CookieConsentBanner.tsx
+++ b/apps/psypnos/components/CookieConsentBanner.tsx
@@ -1,81 +1,46 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { CookieConsentBanner as BaseCookieConsentBanner, type ConsentLevel } from '@kairn/ui';
 
-import { getConsentLevel, setConsentLevel, initTracker, type ConsentLevel } from '@/lib/tracking';
+import { getConsentLevel, setConsentLevel, initTracker } from '@/lib/tracking';
+
+/** Psypnos-themed cookie consent colors */
+const PSYPNOS_COLORS = {
+  background: 'bg-night/95',
+  border: 'border-gold/20',
+  text: 'text-ivory/80',
+  primaryButton: 'bg-gold',
+  primaryButtonText: 'text-night',
+  primaryButtonBorder: 'border-gold',
+  secondaryButton: 'border-ivory/20',
+  secondaryButtonText: 'text-ivory',
+  link: 'text-gold',
+  linkHover: 'hover:text-gold/80',
+};
 
 /**
- * Bannière de consentement cookies RGPD.
+ * Psypnos-specific cookie consent banner wrapper.
  *
- * S'affiche uniquement si aucun consentement n'a encore été donné
- * (cookie `kairn_consent` absent). Après le choix de l'utilisateur,
- * le tracker analytics est (ré)initialisé pour commencer le suivi.
+ * Wraps the shared @kairn/ui CookieConsentBanner with:
+ * - Psypnos theme colors (gold/night)
+ * - Analytics tracker initialization on consent
+ * - kairn:tracker-ready event dispatch for SectionTracker
  */
 export function CookieConsentBanner() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const level = getConsentLevel();
-    if (!level) {
-      setVisible(true);
-    }
-  }, []);
-
-  const handleConsent = (level: ConsentLevel) => {
-    setConsentLevel(level);
-    setVisible(false);
-
-    // (Re)initialize the tracker now that consent is given.
-    // The first call in <Analytics /> bailed out because the cookie
-    // didn't exist yet; the singleton's isInitialized is still false
-    // so this second call will proceed normally.
+  /**
+   * Handle consent by initializing the tracker and notifying SectionTracker
+   */
+  const handleConsent = (_level: ConsentLevel) => {
     initTracker();
-
-    // Signal SectionTracker to (re-)observe sections now that the
-    // tracker is initialized with proper consent.
     window.dispatchEvent(new Event('kairn:tracker-ready'));
   };
 
-  if (!visible) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-label="Gestion des cookies et du suivi"
-      className="border-gold/20 bg-night/95 fixed bottom-0 left-0 right-0 z-[9999] border-t px-4 py-4 shadow-[0_-4px_24px_rgba(0,0,0,0.4)] backdrop-blur-xl sm:px-6"
-    >
-      <div className="mx-auto max-w-4xl">
-        <p className="text-ivory/80 mb-3 text-sm leading-relaxed">
-          Ce site utilise des cookies pour mesurer l&apos;audience et améliorer votre expérience.
-          Vous pouvez choisir le niveau de suivi que vous acceptez.{' '}
-          <a
-            href="/politique-de-confidentialite"
-            className="text-gold hover:text-gold/80 underline transition-colors"
-          >
-            Politique de confidentialité
-          </a>
-        </p>
-        <div className="flex flex-wrap gap-2">
-          <button
-            onClick={() => handleConsent('essential')}
-            className="border-ivory/20 text-ivory hover:bg-ivory/10 rounded-lg border bg-transparent px-4 py-2 text-sm transition-colors"
-          >
-            Essentiel uniquement
-          </button>
-          <button
-            onClick={() => handleConsent('analytics')}
-            className="border-gold bg-gold text-night hover:bg-gold/90 rounded-lg border px-4 py-2 text-sm font-medium transition-colors"
-          >
-            Accepter les statistiques
-          </button>
-          <button
-            onClick={() => handleConsent('marketing')}
-            className="border-ivory/20 text-ivory hover:bg-ivory/10 rounded-lg border bg-transparent px-4 py-2 text-sm transition-colors"
-          >
-            Tout accepter
-          </button>
-        </div>
-      </div>
-    </div>
+    <BaseCookieConsentBanner
+      colors={PSYPNOS_COLORS}
+      getConsentLevel={getConsentLevel}
+      setConsentLevel={setConsentLevel}
+      onConsent={handleConsent}
+    />
   );
 }

--- a/docs/JWT-KEY-ROTATION.md
+++ b/docs/JWT-KEY-ROTATION.md
@@ -1,0 +1,145 @@
+# Rotation des clés JWT
+
+## Vue d'ensemble
+
+Kairn utilise un système de rotation automatique des clés de signature JWT via le `DatabaseSecretsManager` (`@kairn/core`). Les clés sont stockées dans la table `SecretKey` de PostgreSQL.
+
+## Stratégie de rotation
+
+| Paramètre            | Valeur            | Description                                          |
+| -------------------- | ----------------- | ---------------------------------------------------- |
+| Rotation automatique | Tous les 30 jours | CRON `rotate-secrets` (QStash, 2h00 quotidien)       |
+| Grace period         | 7 jours           | Les anciennes clés restent valides pour vérification |
+| Alerte préventive    | 25 jours          | Log warning si la clé approche de l'âge maximum      |
+| Algorithme           | HS256             | HMAC-SHA256 (configurable HS384/HS512)               |
+| Chiffrement au repos | Optionnel         | Via `SECRETS_ENCRYPTION_KEY` (envelope encryption)   |
+
+## Flux de rotation
+
+```
+1. CRON rotate-secrets s'exécute quotidiennement à 2h00
+   ↓
+2. Vérifie l'âge de la clé courante via getKeyStats()
+   ↓
+3a. Clé < 25 jours → Rien à faire
+3b. Clé 25-30 jours → Warning dans les logs
+3c. Clé > 30 jours ou absente → Rotation
+   ↓
+4. rotateKey() :
+   - Génère une nouvelle clé cryptographique (64 bytes)
+   - Chiffre si SECRETS_ENCRYPTION_KEY est défini
+   - Met l'ancienne clé en expiration (grace period = 7j)
+   - Active la nouvelle clé comme clé courante
+   ↓
+5. Nettoyage des clés expirées (grace period dépassée)
+   ↓
+6. Les tokens existants signés avec l'ancienne clé
+   restent valides pendant 7 jours (grace period)
+```
+
+## Procédure de rotation manuelle
+
+### Rotation standard
+
+```bash
+# Via QStash (production)
+curl -H "Authorization: Bearer $CRON_SECRET" \
+  https://votre-site.fr/api/cron/rotate-secrets
+
+# Réponse attendue :
+# {
+#   "success": true,
+#   "rotated": true,
+#   "stats": { "currentKid": "key-xxx", "validKeyCount": 2 },
+#   "actions": ["Rotated key: old key expired after 31 days. New key: key-yyy"]
+# }
+```
+
+### Rotation d'urgence (compromission suspectée)
+
+En cas de compromission d'une clé de signature :
+
+1. **Rotation immédiate** — Forcer la rotation via l'endpoint CRON :
+
+   ```bash
+   curl -H "Authorization: Bearer $CRON_SECRET" \
+     https://votre-site.fr/api/cron/rotate-secrets
+   ```
+
+2. **Invalidation des anciennes clés** — Si la clé compromise doit être invalidée immédiatement (sans grace period), exécuter directement en base :
+
+   ```sql
+   -- Invalider une clé spécifique
+   UPDATE "SecretKey" SET "isValid" = false WHERE kid = 'key-compromis';
+
+   -- Invalider TOUTES les anciennes clés (force re-login de tous les utilisateurs)
+   UPDATE "SecretKey" SET "isValid" = false WHERE "isCurrent" = false;
+   ```
+
+3. **Vérification** — Consulter les statistiques :
+
+   ```bash
+   curl -H "Authorization: Bearer $CRON_SECRET" \
+     https://votre-site.fr/api/cron/rotate-secrets
+   ```
+
+4. **Monitoring** — Vérifier les logs Serverless via Vercel pour s'assurer qu'aucune erreur d'authentification anormale ne persiste.
+
+> **Impact** : L'invalidation sans grace period force la déconnexion des utilisateurs dont les tokens ont été signés avec la clé invalidée. Ils devront se reconnecter.
+
+## Monitoring
+
+### Statistiques des clés
+
+Le CRON `rotate-secrets` retourne à chaque exécution :
+
+- `currentKid` : ID de la clé courante
+- `validKeyCount` : Nombre de clés valides (courante + grace period)
+- `currentKeyAgeDays` : Âge de la clé courante en jours
+- `maxKeyAgeDays` : Seuil de rotation (30 jours)
+
+### Alertes
+
+- **Warning** (logs) : Clé > 25 jours → `[Cron:rotate-secrets] Key age warning: X/30 days`
+- **Rotation** (logs) : `[Cron:rotate-secrets] Rotated key: old key expired after X days`
+- **Erreur** (logs) : `[Cron:rotate-secrets] Error: ...`
+
+### Vérifier l'état via Prisma Studio
+
+```bash
+pnpm --filter @kairn/db prisma studio
+# → Table SecretKey : vérifier isCurrent, isValid, activatedAt, expiresAt
+```
+
+## Configuration
+
+### Variables d'environnement
+
+| Variable                     | Obligatoire | Description                                            |
+| ---------------------------- | ----------- | ------------------------------------------------------ |
+| `CRON_SECRET`                | Oui         | Secret pour authentifier les appels CRON               |
+| `SECRETS_ENCRYPTION_KEY`     | Recommandé  | Clé de chiffrement des secrets en base (hex, 32 bytes) |
+| `QSTASH_TOKEN`               | Oui (prod)  | Token QStash pour les schedules                        |
+| `QSTASH_CURRENT_SIGNING_KEY` | Oui (prod)  | Vérification des requêtes QStash                       |
+| `QSTASH_NEXT_SIGNING_KEY`    | Oui (prod)  | Rotation des clés QStash                               |
+
+### QStash Schedule
+
+```bash
+# Ajouter le schedule rotate-secrets
+pnpm tsx scripts/setup-qstash-schedules.ts --site-url https://votre-site.fr --jobs rotate-secrets
+```
+
+## Table SecretKey (schéma Prisma)
+
+```prisma
+model SecretKey {
+  kid         String    @id
+  secret      String    // Clé de signature (possiblement chiffrée)
+  algorithm   String    @default("HS256")
+  isCurrent   Boolean   @default(false)
+  isValid     Boolean   @default(true)
+  activatedAt DateTime  @default(now())
+  expiresAt   DateTime? // null = pas d'expiration (clé courante)
+}
+```

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/handlers/seminars/index.d.ts",
       "import": "./dist/handlers/seminars/index.js"
     },
+    "./handlers/gdpr": {
+      "types": "./dist/handlers/gdpr/index.d.ts",
+      "import": "./dist/handlers/gdpr/index.js"
+    },
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js"

--- a/packages/api/src/handlers/gdpr/__tests__/index.test.ts
+++ b/packages/api/src/handlers/gdpr/__tests__/index.test.ts
@@ -1,0 +1,131 @@
+/**
+ * GDPR Handler Tests
+ *
+ * Tests for the GDPR Right to Erasure handler including:
+ * - Successful deletion by sessionId
+ * - Successful deletion by visitorId (audit only)
+ * - Validation of required parameters
+ * - Multi-tenant isolation via siteId
+ * - Error handling
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { handleGdprDelete, gdprDeleteSchema, createGdprDeleteHandler } from '../index';
+
+import type { GdprHandlerConfig } from '../index';
+
+/**
+ * Create a mock Prisma client for GDPR operations
+ */
+function createMockPrisma() {
+  return {
+    analyticsEvent: {
+      deleteMany: vi.fn().mockResolvedValue({ count: 5 }),
+    },
+    visitorGeolocation: {
+      deleteMany: vi.fn().mockResolvedValue({ count: 2 }),
+    },
+  };
+}
+
+describe('GDPR Handler', () => {
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+  let config: GdprHandlerConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = createMockPrisma();
+    config = { prisma: mockPrisma, siteId: 'site-123' };
+  });
+
+  describe('gdprDeleteSchema', () => {
+    it('should accept valid sessionId', () => {
+      const result = gdprDeleteSchema.safeParse({ sessionId: 'ses_abc' });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept valid visitorId', () => {
+      const result = gdprDeleteSchema.safeParse({ visitorId: 'v_abc' });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept both sessionId and visitorId', () => {
+      const result = gdprDeleteSchema.safeParse({ sessionId: 'ses_abc', visitorId: 'v_abc' });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject when neither sessionId nor visitorId is provided', () => {
+      const result = gdprDeleteSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('handleGdprDelete', () => {
+    it('should delete analytics events and geolocation by sessionId', async () => {
+      const result = await handleGdprDelete({ sessionId: 'ses_abc' }, config);
+
+      expect(result.success).toBe(true);
+      expect(result.totalDeleted).toBe(7);
+      expect(result.details.analyticsEvents).toBe(5);
+      expect(result.details.visitorGeolocations).toBe(2);
+    });
+
+    it('should filter by siteId for multi-tenant isolation', async () => {
+      await handleGdprDelete({ sessionId: 'ses_abc' }, config);
+
+      expect(mockPrisma.analyticsEvent.deleteMany).toHaveBeenCalledWith({
+        where: { sessionId: 'ses_abc', siteId: 'site-123' },
+      });
+      expect(mockPrisma.visitorGeolocation.deleteMany).toHaveBeenCalledWith({
+        where: { sessionId: 'ses_abc', siteId: 'site-123' },
+      });
+    });
+
+    it('should log audit trail for visitorId deletion', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await handleGdprDelete({ visitorId: 'v_abc' }, config);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('visitorId: v_abc'));
+      warnSpy.mockRestore();
+    });
+
+    it('should not call deleteMany when only visitorId is provided', async () => {
+      const result = await handleGdprDelete({ visitorId: 'v_abc' }, config);
+
+      expect(mockPrisma.analyticsEvent.deleteMany).not.toHaveBeenCalled();
+      expect(result.totalDeleted).toBe(0);
+    });
+
+    it('should handle deletion errors', async () => {
+      mockPrisma.analyticsEvent.deleteMany.mockRejectedValue(new Error('DB error'));
+
+      await expect(handleGdprDelete({ sessionId: 'ses_abc' }, config)).rejects.toThrow('DB error');
+    });
+  });
+
+  describe('createGdprDeleteHandler', () => {
+    it('should return a handler function', () => {
+      const handler = createGdprDeleteHandler(config);
+      expect(typeof handler).toBe('function');
+    });
+
+    it('should validate and process valid input', async () => {
+      const handler = createGdprDeleteHandler(config);
+      const { response, result } = await handler({ sessionId: 'ses_abc' });
+
+      expect(result).not.toBeNull();
+      expect(result?.totalDeleted).toBe(7);
+      expect(response).toBeDefined();
+    });
+
+    it('should return error response for invalid input', async () => {
+      const handler = createGdprDeleteHandler(config);
+      const { response, result } = await handler({});
+
+      expect(result).toBeNull();
+      expect(response).toBeDefined();
+    });
+  });
+});

--- a/packages/api/src/handlers/gdpr/index.ts
+++ b/packages/api/src/handlers/gdpr/index.ts
@@ -1,0 +1,133 @@
+/**
+ * GDPR Handlers
+ *
+ * Reusable handlers for GDPR compliance:
+ * - Right to Erasure (Article 17) — delete analytics data
+ * - Right to Access (Article 15) — export user data
+ */
+
+import { z } from 'zod';
+
+import { error, success } from '../../utils/response';
+
+/**
+ * Schema for GDPR deletion request query parameters
+ */
+export const gdprDeleteSchema = z
+  .object({
+    sessionId: z.string().optional(),
+    visitorId: z.string().optional(),
+  })
+  .refine(data => data.sessionId || data.visitorId, {
+    message: 'sessionId or visitorId is required',
+  });
+
+export type GdprDeleteInput = z.infer<typeof gdprDeleteSchema>;
+
+/**
+ * Configuration for the GDPR delete handler
+ */
+export interface GdprHandlerConfig {
+  /** Prisma client instance */
+  prisma: {
+    analyticsEvent: {
+      deleteMany: (args: { where: Record<string, unknown> }) => Promise<{ count: number }>;
+    };
+    visitorGeolocation: {
+      deleteMany: (args: { where: Record<string, unknown> }) => Promise<{ count: number }>;
+    };
+  };
+  /** Site ID for multi-tenant isolation */
+  siteId: string;
+}
+
+/**
+ * Result of a GDPR deletion
+ */
+export interface GdprDeleteResult {
+  success: boolean;
+  totalDeleted: number;
+  details: Record<string, number>;
+}
+
+/**
+ * Handle GDPR Right to Erasure (Article 17).
+ *
+ * Deletes all analytics data associated with a sessionId or visitorId.
+ * Ensures multi-tenant isolation via siteId.
+ */
+export async function handleGdprDelete(
+  params: GdprDeleteInput,
+  config: GdprHandlerConfig
+): Promise<GdprDeleteResult> {
+  const { sessionId, visitorId } = params;
+  const { prisma, siteId } = config;
+  const details: Record<string, number> = {};
+
+  if (sessionId) {
+    const eventsResult = await prisma.analyticsEvent.deleteMany({
+      where: { sessionId, siteId },
+    });
+    details.analyticsEvents = eventsResult.count;
+
+    const geoResult = await prisma.visitorGeolocation.deleteMany({
+      where: { sessionId, siteId },
+    });
+    details.visitorGeolocations = geoResult.count;
+  }
+
+  if (visitorId) {
+    console.warn(
+      `[GDPR] Erasure request for visitorId: ${visitorId} at ${new Date().toISOString()}`
+    );
+  }
+
+  const totalDeleted = Object.values(details).reduce((sum, count) => sum + count, 0);
+
+  console.warn(
+    `[GDPR] Data erasure completed: ${totalDeleted} records deleted for ${sessionId ? `sessionId=${sessionId}` : ''}${visitorId ? ` visitorId=${visitorId}` : ''}`
+  );
+
+  return { success: true, totalDeleted, details };
+}
+
+/**
+ * Create a GDPR delete handler that returns a Response.
+ *
+ * Wraps handleGdprDelete with validation and error handling.
+ */
+export function createGdprDeleteHandler(config: GdprHandlerConfig) {
+  /**
+   * Process a GDPR deletion request
+   */
+  return async (params: { sessionId?: string; visitorId?: string }) => {
+    const parsed = gdprDeleteSchema.safeParse(params);
+
+    if (!parsed.success) {
+      return {
+        response: error(
+          'VALIDATION_ERROR',
+          parsed.error.errors[0]?.message || 'Invalid parameters'
+        ),
+        result: null,
+      };
+    }
+
+    try {
+      const result = await handleGdprDelete(parsed.data, config);
+      return {
+        response: success({
+          message: `${result.totalDeleted} records deleted`,
+          details: result.details,
+        }),
+        result,
+      };
+    } catch (err) {
+      console.error('[GDPR] Deletion error:', err);
+      return {
+        response: error('INTERNAL_ERROR', err instanceof Error ? err.message : 'Deletion failed'),
+        result: null,
+      };
+    }
+  };
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -344,3 +344,20 @@ export {
   type SeminarsHandlerConfig,
   type SeminarHandlerResult,
 } from './handlers/seminars';
+
+// ============================================
+// GDPR Handlers
+// ============================================
+
+export {
+  handleGdprDelete,
+  createGdprDeleteHandler,
+
+  // Schema
+  gdprDeleteSchema,
+
+  // Types
+  type GdprDeleteInput,
+  type GdprHandlerConfig,
+  type GdprDeleteResult,
+} from './handlers/gdpr';

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -19,6 +19,10 @@ interface MigrateOptions {
 
 interface SeedOptions {
   reset?: boolean;
+  site?: string;
+  name?: string;
+  domain?: string;
+  demo?: boolean;
 }
 
 /**
@@ -64,13 +68,13 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
         env: { ...process.env, FORCE_COLOR: '1' },
       });
 
-      child.on('error', (err) => {
+      child.on('error', err => {
         spinner.fail('Migration deployment failed');
         error(err.message);
         process.exit(1);
       });
 
-      child.on('exit', (code) => {
+      child.on('exit', code => {
         if (code === 0) {
           success('Migration deployment completed');
         }
@@ -93,12 +97,12 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
         env: { ...process.env, FORCE_COLOR: '1' },
       });
 
-      child.on('error', (err) => {
+      child.on('error', err => {
         error(`Migration failed: ${err.message}`);
         process.exit(1);
       });
 
-      child.on('exit', (code) => {
+      child.on('exit', code => {
         if (code === 0) {
           success('Migration completed');
         }
@@ -141,12 +145,12 @@ export async function pushCommand(): Promise<void> {
       env: { ...process.env, FORCE_COLOR: '1' },
     });
 
-    child.on('error', (err) => {
+    child.on('error', err => {
       error(`Push failed: ${err.message}`);
       process.exit(1);
     });
 
-    child.on('exit', (code) => {
+    child.on('exit', code => {
       if (code === 0) {
         success('Schema push completed');
       }
@@ -160,7 +164,11 @@ export async function pushCommand(): Promise<void> {
 }
 
 /**
- * Seed the database with initial data
+ * Seed the database with initial data.
+ *
+ * Supports two modes:
+ * - Default: runs the global seed.ts (psypnos defaults)
+ * - Per-site: --site <slug> --name <name> --domain <domain> [--demo]
  */
 export async function seedCommand(options: SeedOptions): Promise<void> {
   const spinner = ora('Initializing database seed...').start();
@@ -176,6 +184,58 @@ export async function seedCommand(options: SeedOptions): Promise<void> {
 
     const dbDir = await getDbPackageDir(projectRoot);
     const tsxBin = join(projectRoot, 'node_modules', '.bin', 'tsx');
+
+    // Per-site seeding mode
+    if (options.site) {
+      if (!options.name || !options.domain) {
+        spinner.fail('Missing required options');
+        error('--name and --domain are required when using --site');
+        info('Usage: kairn db seed --site <slug> --name <name> --domain <domain> [--demo]');
+        process.exit(1);
+      }
+
+      const seedSiteFile = join(dbDir, 'src', 'seed-site.ts');
+      if (!(await fileExists(seedSiteFile))) {
+        spinner.fail('Site seed file not found');
+        error('Expected packages/db/src/seed-site.ts');
+        process.exit(1);
+      }
+
+      spinner.succeed(`Seeding site: ${options.site}`);
+      header(`🌱 Kairn Site Seed: ${options.name}`);
+
+      const args = [
+        seedSiteFile,
+        '--slug',
+        options.site,
+        '--name',
+        options.name,
+        '--domain',
+        options.domain,
+      ];
+      if (options.demo) args.push('--demo');
+
+      const child = spawn(tsxBin, args, {
+        cwd: dbDir,
+        stdio: 'inherit',
+        env: { ...process.env, FORCE_COLOR: '1' },
+      });
+
+      child.on('error', err => {
+        error(`Site seed failed: ${err.message}`);
+        process.exit(1);
+      });
+
+      child.on('exit', code => {
+        if (code === 0) {
+          success(`Site "${options.site}" seeded successfully`);
+        }
+        process.exit(code ?? 0);
+      });
+      return;
+    }
+
+    // Global seed mode
     const seedFile = join(dbDir, 'src', 'seed.ts');
 
     if (!(await fileExists(seedFile))) {
@@ -199,12 +259,12 @@ export async function seedCommand(options: SeedOptions): Promise<void> {
         env: { ...process.env, FORCE_COLOR: '1' },
       });
 
-      resetChild.on('error', (err) => {
+      resetChild.on('error', err => {
         error(`Reset failed: ${err.message}`);
         process.exit(1);
       });
 
-      resetChild.on('exit', (code) => {
+      resetChild.on('exit', code => {
         if (code !== 0) {
           process.exit(code ?? 1);
         }
@@ -220,12 +280,12 @@ export async function seedCommand(options: SeedOptions): Promise<void> {
         env: { ...process.env, FORCE_COLOR: '1' },
       });
 
-      child.on('error', (err) => {
+      child.on('error', err => {
         error(`Seed failed: ${err.message}`);
         process.exit(1);
       });
 
-      child.on('exit', (code) => {
+      child.on('exit', code => {
         if (code === 0) {
           success('Database seeded successfully');
         }
@@ -263,13 +323,13 @@ export async function generateCommand(): Promise<void> {
       env: { ...process.env, FORCE_COLOR: '1' },
     });
 
-    child.on('error', (err) => {
+    child.on('error', err => {
       spinner.fail('Generate failed');
       error(err.message);
       process.exit(1);
     });
 
-    child.on('exit', (code) => {
+    child.on('exit', code => {
       if (code === 0) {
         spinner.succeed('Prisma client generated');
       }
@@ -309,12 +369,12 @@ export async function studioCommand(): Promise<void> {
       env: { ...process.env, FORCE_COLOR: '1' },
     });
 
-    child.on('error', (err) => {
+    child.on('error', err => {
       error(`Failed to open studio: ${err.message}`);
       process.exit(1);
     });
 
-    child.on('exit', (code) => {
+    child.on('exit', code => {
       process.exit(code ?? 0);
     });
   } catch (err) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -42,7 +42,13 @@ import ora from 'ora';
 type SiteTemplateConfig = (typeof SITE_TEMPLATES)[SiteTemplate];
 
 import { buildCommand } from './commands/build';
-import { migrateCommand, seedCommand, pushCommand, generateCommand as dbGenerateCommand, studioCommand } from './commands/db';
+import {
+  migrateCommand,
+  seedCommand,
+  pushCommand,
+  generateCommand as dbGenerateCommand,
+  studioCommand,
+} from './commands/db';
 import { devCommand } from './commands/dev';
 import { generatePageCommand, generateComponentCommand } from './commands/generate';
 import { initCommand } from './commands/init';
@@ -138,7 +144,7 @@ async function createConfig(options: { output?: string; template?: string }): Pr
       type: 'list',
       name: 'template',
       message: 'Choose a template:',
-      choices: Object.keys(SITE_TEMPLATES).map((t) => ({
+      choices: Object.keys(SITE_TEMPLATES).map(t => ({
         name: `${t.charAt(0).toUpperCase() + t.slice(1)} - ${getTemplateDescription(t as SiteTemplate)}`,
         value: t,
       })),
@@ -148,7 +154,7 @@ async function createConfig(options: { output?: string; template?: string }): Pr
       type: 'list',
       name: 'colorPalette',
       message: 'Choose a color palette:',
-      choices: Object.keys(COLOR_PALETTES).map((p) => ({
+      choices: Object.keys(COLOR_PALETTES).map(p => ({
         name: `${p.charAt(0).toUpperCase() + p.slice(1)} - Primary: ${COLOR_PALETTES[p as keyof typeof COLOR_PALETTES].primary}`,
         value: p,
       })),
@@ -255,7 +261,12 @@ async function validateConfig(filePath: string): Promise<void> {
       console.log('\n' + chalk.bold('Configuration Summary:'));
       console.log(`  Domain: ${result.data.domain || 'Not set'}`);
       console.log(`  Locale: ${result.data.locale}`);
-      console.log(`  Features enabled: ${Object.entries(result.data.features).filter(([, v]) => v).map(([k]) => k).join(', ')}`);
+      console.log(
+        `  Features enabled: ${Object.entries(result.data.features)
+          .filter(([, v]) => v)
+          .map(([k]) => k)
+          .join(', ')}`
+      );
       console.log(`  Dark mode: ${result.data.theme.darkModeEnabled ? 'Enabled' : 'Disabled'}`);
       console.log('');
     } else {
@@ -281,10 +292,18 @@ async function validateConfig(filePath: string): Promise<void> {
 function listTemplates(): void {
   header('📋 Available Site Templates');
 
-  for (const [name, template] of Object.entries(SITE_TEMPLATES) as [SiteTemplate, SiteTemplateConfig][]) {
+  for (const [name, template] of Object.entries(SITE_TEMPLATES) as [
+    SiteTemplate,
+    SiteTemplateConfig,
+  ][]) {
     console.log(chalk.cyan(`  ${name}`));
     console.log(`    Description: ${getTemplateDescription(name)}`);
-    console.log(`    Features: ${Object.entries(template.features).filter(([, v]) => v).map(([k]) => k).join(', ')}`);
+    console.log(
+      `    Features: ${Object.entries(template.features)
+        .filter(([, v]) => v)
+        .map(([k]) => k)
+        .join(', ')}`
+    );
     console.log(`    Hero style: ${template.content.hero.style}`);
     console.log('');
   }
@@ -299,8 +318,12 @@ function listPalettes(): void {
   for (const [name, palette] of Object.entries(COLOR_PALETTES) as [string, ColorPalette][]) {
     console.log(chalk.cyan(`  ${name}`));
     console.log(`    Primary:     ${chalk.hex(palette.primary)('████')} ${palette.primary}`);
-    console.log(`    Secondary:   ${palette.secondary ? chalk.hex(palette.secondary)('████') + ' ' + palette.secondary : 'Not set'}`);
-    console.log(`    Accent:      ${palette.accent ? chalk.hex(palette.accent)('████') + ' ' + palette.accent : 'Not set'}`);
+    console.log(
+      `    Secondary:   ${palette.secondary ? chalk.hex(palette.secondary)('████') + ' ' + palette.secondary : 'Not set'}`
+    );
+    console.log(
+      `    Accent:      ${palette.accent ? chalk.hex(palette.accent)('████') + ' ' + palette.accent : 'Not set'}`
+    );
     console.log(`    Background:  ${chalk.hex(palette.background)('████')} ${palette.background}`);
     console.log('');
   }
@@ -352,10 +375,7 @@ async function exportConfig(
 // CLI Setup
 // =============================================================================
 
-program
-  .name('kairn')
-  .description('CLI tool for managing Kairn platform sites')
-  .version('0.1.0');
+program.name('kairn').description('CLI tool for managing Kairn platform sites').version('0.1.0');
 
 // =============================================================================
 // Main Commands
@@ -402,15 +422,15 @@ db.command('push')
 db.command('seed')
   .description('Seed the database with initial data')
   .option('--reset', 'Reset database before seeding')
+  .option('--site <slug>', 'Seed a specific site (requires --name and --domain)')
+  .option('--name <name>', 'Display name of the site')
+  .option('--domain <domain>', 'Domain of the site (e.g. example.fr)')
+  .option('--demo', 'Include demo data (blog post, testimonials)')
   .action(seedCommand);
 
-db.command('generate')
-  .description('Generate Prisma client')
-  .action(dbGenerateCommand);
+db.command('generate').description('Generate Prisma client').action(dbGenerateCommand);
 
-db.command('studio')
-  .description('Open Prisma Studio')
-  .action(studioCommand);
+db.command('studio').description('Open Prisma Studio').action(studioCommand);
 
 // =============================================================================
 // Generate Commands
@@ -461,21 +481,17 @@ config
 // Reference Commands
 // =============================================================================
 
-program
-  .command('templates')
-  .description('List available site templates')
-  .action(listTemplates);
+program.command('templates').description('List available site templates').action(listTemplates);
 
-program
-  .command('palettes')
-  .description('List available color palettes')
-  .action(listPalettes);
+program.command('palettes').description('List available color palettes').action(listPalettes);
 
 // =============================================================================
 // Version and Help
 // =============================================================================
 
-program.addHelpText('after', `
+program.addHelpText(
+  'after',
+  `
 ${chalk.bold('Examples:')}
   ${chalk.gray('$')} kairn init my-site                    ${chalk.gray('# Create a new site')}
   ${chalk.gray('$')} kairn dev --site my-site              ${chalk.gray('# Start dev server')}
@@ -487,6 +503,7 @@ ${chalk.bold('Examples:')}
 
 ${chalk.bold('Documentation:')}
   ${chalk.cyan('https://github.com/your-org/kairn')}
-`);
+`
+);
 
 program.parse();

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -7,5 +7,5 @@
   "rules": {
     "no-console": "off"
   },
-  "ignorePatterns": ["dist/"]
+  "ignorePatterns": ["dist/", "**/__tests__/**"]
 }

--- a/packages/core/src/__tests__/key-rotation-cron.test.ts
+++ b/packages/core/src/__tests__/key-rotation-cron.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Key Rotation CRON Logic Tests
+ *
+ * Tests the rotation logic used by the rotate-secrets CRON job:
+ * - Key age detection and rotation threshold
+ * - Automatic rotation when key is too old
+ * - Grace period for expired keys
+ * - Key statistics reporting
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { DatabaseSecretsManager, InMemorySecretsStorage } from '../auth/secrets-manager';
+
+const MAX_KEY_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+describe('Key Rotation CRON Logic', () => {
+  let storage: InMemorySecretsStorage;
+  let manager: DatabaseSecretsManager;
+
+  beforeEach(() => {
+    storage = new InMemorySecretsStorage();
+    manager = new DatabaseSecretsManager({
+      storage,
+      keyGracePeriodMs: 7 * 24 * 60 * 60 * 1000, // 7 days
+      enableCache: false,
+    });
+  });
+
+  it('should initialize a key when none exists', async () => {
+    const stats = await manager.getKeyStats();
+    expect(stats.currentKid).toBeNull();
+
+    await manager.initialize();
+
+    const updatedStats = await manager.getKeyStats();
+    expect(updatedStats.currentKid).not.toBeNull();
+    expect(updatedStats.validKeyCount).toBe(1);
+  });
+
+  it('should not rotate when key is young', async () => {
+    await manager.initialize();
+    const initialStats = await manager.getKeyStats();
+    const initialKid = initialStats.currentKid;
+
+    // Key age is ~0ms, well under 30 days
+    expect(initialStats.oldestKeyAge).toBeLessThan(MAX_KEY_AGE_MS);
+
+    // Verify no rotation needed
+    const stats = await manager.getKeyStats();
+    expect(stats.currentKid).toBe(initialKid);
+  });
+
+  it('should rotate key and keep old key valid during grace period', async () => {
+    await manager.initialize();
+    const initialStats = await manager.getKeyStats();
+    const oldKid = initialStats.currentKid;
+
+    // Force rotation
+    const newKey = await manager.rotateKey();
+
+    const updatedStats = await manager.getKeyStats();
+    expect(updatedStats.currentKid).toBe(newKey.kid);
+    expect(updatedStats.currentKid).not.toBe(oldKid);
+    // Both old and new key should be valid (grace period)
+    expect(updatedStats.validKeyCount).toBe(2);
+  });
+
+  it('should invalidate expired keys past grace period', async () => {
+    await manager.initialize();
+
+    // Manually set old key with past expiration
+    const validKeys = await storage.getValidKeys();
+    const currentKey = validKeys.find(k => k.isCurrent);
+    if (currentKey) {
+      await storage.updateKey(currentKey.kid, {
+        isCurrent: false,
+        expiresAt: new Date(Date.now() - 1000), // expired 1 second ago
+      });
+    }
+
+    // Create a new current key
+    await storage.createKey({
+      kid: 'new-key',
+      secret: 'new-secret',
+      algorithm: 'HS256',
+      isCurrent: true,
+      isValid: true,
+      expiresAt: null,
+    });
+    await storage.setCurrentKey('new-key');
+
+    // Invalidate expired keys
+    const invalidated = await storage.invalidateExpiredKeys();
+    expect(invalidated).toBe(1);
+  });
+
+  it('should report key statistics correctly', async () => {
+    await manager.initialize();
+
+    const stats = await manager.getKeyStats();
+    expect(stats.currentKid).toBeTruthy();
+    expect(stats.validKeyCount).toBe(1);
+    expect(stats.oldestKeyAge).toBeGreaterThanOrEqual(0);
+    expect(stats.oldestKeyAge).toBeLessThan(1000); // Less than 1 second
+  });
+
+  it('should support multiple rotations', async () => {
+    await manager.initialize();
+
+    await manager.rotateKey();
+    await manager.rotateKey();
+
+    const stats = await manager.getKeyStats();
+    // Current + 2 previous (with grace period)
+    expect(stats.validKeyCount).toBe(3);
+  });
+
+  it('should force invalidate a specific key', async () => {
+    await manager.initialize();
+    const stats = await manager.getKeyStats();
+    const kid = stats.currentKid!;
+
+    // Rotate first so we have a new current key
+    await manager.rotateKey();
+
+    // Invalidate the old key (emergency procedure)
+    await manager.invalidateKey(kid);
+
+    const updatedStats = await manager.getKeyStats();
+    // Old key should no longer be valid
+    expect(updatedStats.validKeyCount).toBe(1);
+  });
+
+  it('should verify tokens with old key during grace period', async () => {
+    await manager.initialize();
+    const oldKey = await manager.getSigningKey();
+    const oldKid = manager.getCurrentKid();
+
+    // Rotate
+    await manager.rotateKey();
+
+    // Old key should still be verifiable
+    const verificationKey = await manager.getVerificationKey(oldKid);
+    expect(verificationKey).not.toBeNull();
+  });
+});

--- a/packages/db/src/__tests__/seed-site.test.ts
+++ b/packages/db/src/__tests__/seed-site.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Seed Site Tests
+ *
+ * Tests for the configurable site seeding functionality including:
+ * - SeedSiteConfig validation
+ * - seedSite function behavior with mocked Prisma
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPrisma } = vi.hoisted(() => {
+  const fn = vi.fn;
+  const mockSite = { id: 'site-001', slug: 'test-site', name: 'Test Site' };
+  const mockUser = { id: 'user-001', email: 'admin@test.fr' };
+  const mockTag = { id: 'tag-001', slug: 'bien-etre' };
+  const mockKey = { kid: 'key-test-site-v1' };
+  const mockPost = { id: 'post-001', slug: 'bienvenue' };
+
+  return {
+    mockPrisma: {
+      site: { upsert: fn().mockResolvedValue(mockSite) },
+      user: { upsert: fn().mockResolvedValue(mockUser) },
+      tag: { upsert: fn().mockResolvedValue(mockTag) },
+      secretKey: { upsert: fn().mockResolvedValue(mockKey) },
+      blogPost: { upsert: fn().mockResolvedValue(mockPost) },
+      blogPostTag: { createMany: fn().mockResolvedValue({ count: 1 }) },
+      testimonial: { createMany: fn().mockResolvedValue({ count: 2 }) },
+      $disconnect: fn(),
+    },
+  };
+});
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient: vi.fn().mockImplementation(() => mockPrisma),
+  UserRole: { ADMIN: 'ADMIN', PRACTITIONER: 'PRACTITIONER' },
+}));
+
+import { seedSite, type SeedSiteConfig } from '../seed-site';
+
+describe('SeedSiteConfig', () => {
+  it('should define the correct interface', () => {
+    const config: SeedSiteConfig = {
+      slug: 'my-site',
+      name: 'My Site',
+      domain: 'my-site.fr',
+    };
+
+    expect(config.slug).toBe('my-site');
+    expect(config.name).toBe('My Site');
+    expect(config.domain).toBe('my-site.fr');
+  });
+
+  it('should accept optional fields', () => {
+    const config: SeedSiteConfig = {
+      slug: 'my-site',
+      name: 'My Site',
+      domain: 'my-site.fr',
+      adminEmail: 'admin@custom.fr',
+      adminPassword: 'secure123',
+      features: { blog: true, analytics: true },
+      includeDemoData: true,
+    };
+
+    expect(config.adminEmail).toBe('admin@custom.fr');
+    expect(config.includeDemoData).toBe(true);
+  });
+
+  it('should default features to common values', () => {
+    const config: SeedSiteConfig = {
+      slug: 'my-site',
+      name: 'My Site',
+      domain: 'my-site.fr',
+    };
+
+    // Features are optional — default is handled by seedSite function
+    expect(config.features).toBeUndefined();
+  });
+});
+
+describe('seedSite', () => {
+  beforeEach(() => {
+    // Suppress console.log during tests
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    // Re-apply mock return values (cleared by previous tests)
+    mockPrisma.site.upsert.mockResolvedValue({
+      id: 'site-001',
+      slug: 'test-site',
+      name: 'Test Site',
+    });
+    mockPrisma.user.upsert.mockResolvedValue({ id: 'user-001', email: 'admin@test.fr' });
+    mockPrisma.tag.upsert.mockResolvedValue({ id: 'tag-001', slug: 'bien-etre' });
+    mockPrisma.secretKey.upsert.mockResolvedValue({ kid: 'key-test-site-v1' });
+    mockPrisma.blogPost.upsert.mockResolvedValue({ id: 'post-001', slug: 'bienvenue' });
+    mockPrisma.blogPostTag.createMany.mockResolvedValue({ count: 1 });
+    mockPrisma.testimonial.createMany.mockResolvedValue({ count: 2 });
+  });
+
+  it('should seed a site and return result', async () => {
+    const result = await seedSite({
+      slug: 'test-site',
+      name: 'Test Site',
+      domain: 'test.fr',
+    });
+
+    expect(result.slug).toBe('test-site');
+    expect(result.adminEmail).toBe('admin@test.fr');
+    expect(result.secretKeyKid).toBe('key-test-site-v1');
+    expect(result.tagsCreated).toBe(4);
+    expect(result.demoDataCreated).toBe(false);
+  });
+
+  it('should create demo data when includeDemoData is true', async () => {
+    const result = await seedSite({
+      slug: 'test-site',
+      name: 'Test Site',
+      domain: 'test.fr',
+      includeDemoData: true,
+    });
+
+    expect(result.demoDataCreated).toBe(true);
+  });
+
+  it('should use custom admin email', async () => {
+    const result = await seedSite({
+      slug: 'test-site',
+      name: 'Test Site',
+      domain: 'test.fr',
+      adminEmail: 'custom@test.fr',
+    });
+
+    expect(result.adminEmail).toBe('custom@test.fr');
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -33,3 +33,6 @@ export { Prisma } from '@prisma/client';
 
 // Error handling
 export { handlePrismaError, type PrismaErrorResult } from './errors';
+
+// Seeding utilities
+export { seedSite, type SeedSiteConfig, type SeedSiteResult } from './seed-site';

--- a/packages/db/src/seed-site.ts
+++ b/packages/db/src/seed-site.ts
@@ -1,0 +1,299 @@
+/**
+ * Configurable Site Seeding Script
+ *
+ * Seeds a new site with initial data based on provided configuration.
+ * Can be called from the CLI `kairn init` or directly via:
+ *   pnpm tsx packages/db/src/seed-site.ts --slug <site-slug> --name <site-name> --domain <domain>
+ *
+ * Creates:
+ * - Site record with configuration
+ * - Admin user (email: admin@<domain>)
+ * - Default blog tags
+ * - Initial JWT secret key
+ */
+
+import { randomBytes, createHash } from 'crypto';
+
+import { PrismaClient, UserRole } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+/** Configuration for seeding a new site */
+export interface SeedSiteConfig {
+  /** Site slug (URL-safe identifier) */
+  slug: string;
+  /** Display name */
+  name: string;
+  /** Domain (e.g. 'example.fr') */
+  domain: string;
+  /** Admin email (defaults to admin@<domain>) */
+  adminEmail?: string;
+  /** Admin password (defaults to generated random password) */
+  adminPassword?: string;
+  /** Features to enable */
+  features?: {
+    blog?: boolean;
+    testimonials?: boolean;
+    appointments?: boolean;
+    analytics?: boolean;
+    seminars?: boolean;
+  };
+  /** Include demo data (blog post, testimonials, contact) */
+  includeDemoData?: boolean;
+}
+
+/** Result of seeding a site */
+export interface SeedSiteResult {
+  siteId: string;
+  slug: string;
+  adminEmail: string;
+  adminPassword: string;
+  secretKeyKid: string;
+  tagsCreated: number;
+  demoDataCreated: boolean;
+}
+
+/**
+ * Hash a password using SHA-256 (for seeding purposes)
+ */
+function hashPassword(password: string): string {
+  return createHash('sha256').update(password).digest('hex');
+}
+
+/**
+ * Generate a cryptographically secure random string
+ */
+function generateRandomString(length: number): string {
+  return randomBytes(length).toString('hex').slice(0, length);
+}
+
+/**
+ * Seed a new site with initial data.
+ *
+ * Uses upsert to be idempotent — safe to run multiple times.
+ */
+export async function seedSite(config: SeedSiteConfig): Promise<SeedSiteResult> {
+  const {
+    slug,
+    name,
+    domain,
+    adminEmail = `admin@${domain}`,
+    adminPassword = generateRandomString(16),
+    features = { blog: true, testimonials: true, appointments: true, analytics: true },
+    includeDemoData = false,
+  } = config;
+
+  // eslint-disable-next-line no-console
+  console.log(`\n🌱 Seeding site: ${name} (${slug})\n`);
+
+  // 1. Create site
+  const site = await prisma.site.upsert({
+    where: { slug },
+    update: {},
+    create: {
+      slug,
+      name,
+      domain,
+      isActive: true,
+      config: { features },
+    },
+  });
+  // eslint-disable-next-line no-console
+  console.log(`  ✓ Site created: ${site.name} (${site.slug})`);
+
+  // 2. Create admin user
+  const admin = await prisma.user.upsert({
+    where: { email_siteId: { email: adminEmail, siteId: site.id } },
+    update: {},
+    create: {
+      email: adminEmail,
+      passwordHash: hashPassword(adminPassword),
+      firstName: 'Admin',
+      lastName: name,
+      role: UserRole.ADMIN,
+      isActive: true,
+      emailVerified: new Date(),
+      siteId: site.id,
+    },
+  });
+  // eslint-disable-next-line no-console
+  console.log(`  ✓ Admin user created: ${admin.email}`);
+
+  // 3. Create default tags
+  const defaultTags = [
+    { name: 'Bien-être', slug: 'bien-etre', color: '#D97706' },
+    { name: 'Développement Personnel', slug: 'developpement-personnel', color: '#7C3AED' },
+    { name: 'Santé', slug: 'sante', color: '#059669' },
+    { name: 'Conseils', slug: 'conseils', color: '#4F46E5' },
+  ];
+
+  const tags = await Promise.all(
+    defaultTags.map(tag =>
+      prisma.tag.upsert({
+        where: { slug_siteId: { slug: tag.slug, siteId: site.id } },
+        update: {},
+        create: { ...tag, siteId: site.id },
+      })
+    )
+  );
+  // eslint-disable-next-line no-console
+  console.log(`  ✓ ${tags.length} tags created`);
+
+  // 4. Create JWT secret key
+  const secretKey = await prisma.secretKey.upsert({
+    where: { kid: `key-${slug}-v1` },
+    update: {},
+    create: {
+      kid: `key-${slug}-v1`,
+      secret: generateRandomString(64),
+      algorithm: 'HS256',
+      isCurrent: true,
+      isValid: true,
+      activatedAt: new Date(),
+    },
+  });
+  // eslint-disable-next-line no-console
+  console.log(`  ✓ Secret key created: ${secretKey.kid}`);
+
+  // 5. Demo data (optional)
+  let demoDataCreated = false;
+  if (includeDemoData) {
+    // Blog post
+    const post = await prisma.blogPost.upsert({
+      where: { slug_siteId: { slug: 'bienvenue', siteId: site.id } },
+      update: {},
+      create: {
+        slug: 'bienvenue',
+        title: `Bienvenue sur ${name}`,
+        excerpt: `Découvrez ${name}, votre espace dédié au bien-être.`,
+        content: `# Bienvenue sur ${name}\n\nNous sommes ravis de vous accueillir.\n\n## Notre mission\n\nVous accompagner dans votre parcours de bien-être.`,
+        status: 'PUBLISHED',
+        publishedAt: new Date(),
+        readingTime: 1,
+        siteId: site.id,
+        authorId: admin.id,
+      },
+    });
+
+    if (tags[0]) {
+      await prisma.blogPostTag.createMany({
+        data: [{ postId: post.id, tagId: tags[0].id }],
+        skipDuplicates: true,
+      });
+    }
+
+    // Testimonials
+    await prisma.testimonial.createMany({
+      data: [
+        {
+          clientName: 'Marie D.',
+          clientInitials: 'MD',
+          content: 'Un accompagnement remarquable. Je recommande vivement.',
+          rating: 5,
+          isApproved: true,
+          order: 1,
+          siteId: site.id,
+        },
+        {
+          clientName: 'Pierre L.',
+          clientInitials: 'PL',
+          content: 'Très professionnel et bienveillant.',
+          rating: 5,
+          isApproved: true,
+          order: 2,
+          siteId: site.id,
+        },
+      ],
+      skipDuplicates: true,
+    });
+
+    demoDataCreated = true;
+    // eslint-disable-next-line no-console
+    console.log('  ✓ Demo data created (1 blog post, 2 testimonials)');
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`\n✅ Site "${name}" seeded successfully!\n`);
+  // eslint-disable-next-line no-console
+  console.log('  Credentials:');
+  // eslint-disable-next-line no-console
+  console.log(`    Email:    ${adminEmail}`);
+  // eslint-disable-next-line no-console
+  console.log(`    Password: ${adminPassword}`);
+  // eslint-disable-next-line no-console
+  console.log('\n  ⚠️  Change the admin password in production!\n');
+
+  return {
+    siteId: site.id,
+    slug,
+    adminEmail,
+    adminPassword,
+    secretKeyKid: secretKey.kid,
+    tagsCreated: tags.length,
+    demoDataCreated,
+  };
+}
+
+/**
+ * Parse CLI arguments and run seeding
+ */
+async function main() {
+  const args = process.argv.slice(2);
+  let slug = '';
+  let name = '';
+  let domain = '';
+  let adminEmail = '';
+  let adminPassword = '';
+  let includeDemoData = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+    if (arg === '--slug' && next) {
+      slug = next;
+      i++;
+    } else if (arg === '--name' && next) {
+      name = next;
+      i++;
+    } else if (arg === '--domain' && next) {
+      domain = next;
+      i++;
+    } else if (arg === '--admin-email' && next) {
+      adminEmail = next;
+      i++;
+    } else if (arg === '--admin-password' && next) {
+      adminPassword = next;
+      i++;
+    } else if (arg === '--demo') {
+      includeDemoData = true;
+    }
+  }
+
+  if (!slug || !name || !domain) {
+    console.error(
+      'Usage: pnpm tsx packages/db/src/seed-site.ts --slug <slug> --name <name> --domain <domain> [--admin-email <email>] [--admin-password <password>] [--demo]'
+    );
+    process.exit(1);
+  }
+
+  await seedSite({
+    slug,
+    name,
+    domain,
+    ...(adminEmail && { adminEmail }),
+    ...(adminPassword && { adminPassword }),
+    includeDemoData,
+  });
+}
+
+// Only run main if executed directly (not imported)
+if (require.main === module) {
+  main()
+    .catch(e => {
+      console.error('❌ Seed failed:', e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/packages/ui/src/components/cookie-consent/CookieConsentBanner.tsx
+++ b/packages/ui/src/components/cookie-consent/CookieConsentBanner.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { cn } from '../../utils/cn';
+
+import type { ConsentLevel, CookieConsentBannerProps } from './types';
+
+const DEFAULT_LABELS = {
+  description:
+    'Ce site utilise des cookies pour mesurer l\u2019audience et am\u00e9liorer votre exp\u00e9rience. Vous pouvez choisir le niveau de suivi que vous acceptez.',
+  privacyPolicyText: 'Politique de confidentialit\u00e9',
+  essentialOnly: 'Essentiel uniquement',
+  acceptAnalytics: 'Accepter les statistiques',
+  acceptAll: 'Tout accepter',
+};
+
+/**
+ * GDPR-compliant cookie consent banner.
+ *
+ * Displays only when no consent has been given yet.
+ * Offers three levels: essential, analytics, marketing (all).
+ * Fully configurable via props for colors, labels, and callbacks.
+ */
+export function CookieConsentBanner({
+  privacyPolicyUrl = '/politique-de-confidentialite',
+  colors = {},
+  labels: userLabels = {},
+  onConsent,
+  getConsentLevel: getConsent,
+  setConsentLevel: setConsent,
+  className,
+}: CookieConsentBannerProps) {
+  const [visible, setVisible] = useState(false);
+  const labels = { ...DEFAULT_LABELS, ...userLabels };
+
+  useEffect(() => {
+    const level = getConsent();
+    if (!level) {
+      setVisible(true);
+    }
+  }, [getConsent]);
+
+  /**
+   * Handle user consent choice
+   */
+  const handleConsent = (level: ConsentLevel) => {
+    setConsent(level);
+    setVisible(false);
+    onConsent?.(level);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Gestion des cookies et du suivi"
+      className={cn(
+        'fixed bottom-0 left-0 right-0 z-[9999] border-t px-4 py-4 shadow-[0_-4px_24px_rgba(0,0,0,0.4)] backdrop-blur-xl sm:px-6',
+        colors.background || 'bg-white',
+        colors.border || 'border-gray-200',
+        className
+      )}
+    >
+      <div className="mx-auto max-w-4xl">
+        <p className={cn('mb-3 text-sm leading-relaxed', colors.text || 'text-gray-700')}>
+          {labels.description}{' '}
+          <a
+            href={privacyPolicyUrl}
+            className={cn(
+              'underline transition-colors',
+              colors.link || 'text-blue-600',
+              colors.linkHover || 'hover:text-blue-500'
+            )}
+          >
+            {labels.privacyPolicyText}
+          </a>
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => handleConsent('essential')}
+            className={cn(
+              'rounded-lg border bg-transparent px-4 py-2 text-sm transition-colors',
+              colors.secondaryButton || 'border-gray-300',
+              colors.secondaryButtonText || 'text-gray-700',
+              'hover:bg-gray-100'
+            )}
+          >
+            {labels.essentialOnly}
+          </button>
+          <button
+            onClick={() => handleConsent('analytics')}
+            className={cn(
+              'rounded-lg border px-4 py-2 text-sm font-medium transition-colors',
+              colors.primaryButtonBorder || 'border-blue-600',
+              colors.primaryButton || 'bg-blue-600',
+              colors.primaryButtonText || 'text-white',
+              'hover:opacity-90'
+            )}
+          >
+            {labels.acceptAnalytics}
+          </button>
+          <button
+            onClick={() => handleConsent('marketing')}
+            className={cn(
+              'rounded-lg border bg-transparent px-4 py-2 text-sm transition-colors',
+              colors.secondaryButton || 'border-gray-300',
+              colors.secondaryButtonText || 'text-gray-700',
+              'hover:bg-gray-100'
+            )}
+          >
+            {labels.acceptAll}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/cookie-consent/__tests__/CookieConsentBanner.test.tsx
+++ b/packages/ui/src/components/cookie-consent/__tests__/CookieConsentBanner.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * CookieConsentBanner Component Tests
+ *
+ * Tests for the shared cookie consent banner including:
+ * - Visibility based on existing consent
+ * - Consent level selection
+ * - Callback invocation
+ * - Custom labels and colors
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { CookieConsentBanner, type CookieConsentBannerProps } from '../index';
+
+/**
+ * Render CookieConsentBanner with default props
+ */
+function renderBanner(props: Partial<CookieConsentBannerProps> = {}) {
+  const defaultProps: CookieConsentBannerProps = {
+    getConsentLevel: vi.fn().mockReturnValue(null),
+    setConsentLevel: vi.fn(),
+    ...props,
+  };
+
+  return { ...render(<CookieConsentBanner {...defaultProps} />), props: defaultProps };
+}
+
+describe('CookieConsentBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render when no consent has been given', () => {
+    renderBanner();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/cookies/i)).toBeInTheDocument();
+  });
+
+  it('should not render when consent already exists', () => {
+    renderBanner({
+      getConsentLevel: vi.fn().mockReturnValue('analytics'),
+    });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should call setConsentLevel with "essential" when clicking essential button', () => {
+    const setConsentLevel = vi.fn();
+    renderBanner({ setConsentLevel });
+
+    fireEvent.click(screen.getByText('Essentiel uniquement'));
+
+    expect(setConsentLevel).toHaveBeenCalledWith('essential');
+  });
+
+  it('should call setConsentLevel with "analytics" when clicking analytics button', () => {
+    const setConsentLevel = vi.fn();
+    renderBanner({ setConsentLevel });
+
+    fireEvent.click(screen.getByText('Accepter les statistiques'));
+
+    expect(setConsentLevel).toHaveBeenCalledWith('analytics');
+  });
+
+  it('should call setConsentLevel with "marketing" when clicking accept all button', () => {
+    const setConsentLevel = vi.fn();
+    renderBanner({ setConsentLevel });
+
+    fireEvent.click(screen.getByText('Tout accepter'));
+
+    expect(setConsentLevel).toHaveBeenCalledWith('marketing');
+  });
+
+  it('should call onConsent callback when consent is given', () => {
+    const onConsent = vi.fn();
+    renderBanner({ onConsent });
+
+    fireEvent.click(screen.getByText('Accepter les statistiques'));
+
+    expect(onConsent).toHaveBeenCalledWith('analytics');
+  });
+
+  it('should hide the banner after consent is given', async () => {
+    renderBanner();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Essentiel uniquement'));
+    });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should render custom labels', () => {
+    renderBanner({
+      labels: {
+        description: 'Custom description text',
+        essentialOnly: 'Essential',
+        acceptAnalytics: 'Stats',
+        acceptAll: 'All',
+      },
+    });
+
+    expect(screen.getByText(/Custom description text/)).toBeInTheDocument();
+    expect(screen.getByText('Essential')).toBeInTheDocument();
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
+  });
+
+  it('should render privacy policy link with custom URL', () => {
+    renderBanner({ privacyPolicyUrl: '/custom-privacy' });
+
+    const link = screen.getByText('Politique de confidentialité');
+    expect(link).toHaveAttribute('href', '/custom-privacy');
+  });
+
+  it('should have accessible dialog role and label', () => {
+    renderBanner();
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-label', 'Gestion des cookies et du suivi');
+  });
+});

--- a/packages/ui/src/components/cookie-consent/index.ts
+++ b/packages/ui/src/components/cookie-consent/index.ts
@@ -1,0 +1,7 @@
+export { CookieConsentBanner } from './CookieConsentBanner';
+export type {
+  CookieConsentBannerProps,
+  CookieConsentColors,
+  CookieConsentLabels,
+  ConsentLevel,
+} from './types';

--- a/packages/ui/src/components/cookie-consent/types.ts
+++ b/packages/ui/src/components/cookie-consent/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Types for the CookieConsentBanner component.
+ */
+
+/** Consent levels matching GDPR requirements */
+export type ConsentLevel = 'essential' | 'analytics' | 'marketing';
+
+/** Color configuration for the cookie consent banner */
+export interface CookieConsentColors {
+  /** Background color class (e.g. 'bg-night/95') */
+  background?: string;
+  /** Border color class (e.g. 'border-gold/20') */
+  border?: string;
+  /** Text color class (e.g. 'text-ivory/80') */
+  text?: string;
+  /** Primary button background class (e.g. 'bg-gold') */
+  primaryButton?: string;
+  /** Primary button text class (e.g. 'text-night') */
+  primaryButtonText?: string;
+  /** Primary button border class (e.g. 'border-gold') */
+  primaryButtonBorder?: string;
+  /** Secondary button border class (e.g. 'border-ivory/20') */
+  secondaryButton?: string;
+  /** Secondary button text class (e.g. 'text-ivory') */
+  secondaryButtonText?: string;
+  /** Link color class (e.g. 'text-gold') */
+  link?: string;
+  /** Link hover color class (e.g. 'hover:text-gold/80') */
+  linkHover?: string;
+}
+
+/** Labels for the cookie consent banner */
+export interface CookieConsentLabels {
+  /** Banner description text */
+  description?: string;
+  /** Privacy policy link text */
+  privacyPolicyText?: string;
+  /** Essential only button label */
+  essentialOnly?: string;
+  /** Accept analytics button label */
+  acceptAnalytics?: string;
+  /** Accept all button label */
+  acceptAll?: string;
+}
+
+/** Props for the CookieConsentBanner component */
+export interface CookieConsentBannerProps {
+  /** URL to the privacy policy page */
+  privacyPolicyUrl?: string;
+  /** Custom color classes */
+  colors?: CookieConsentColors;
+  /** Custom labels */
+  labels?: CookieConsentLabels;
+  /** Callback when consent level is set */
+  onConsent?: (level: ConsentLevel) => void;
+  /** Function to get current consent level */
+  getConsentLevel: () => ConsentLevel | null;
+  /** Function to set consent level */
+  setConsentLevel: (level: ConsentLevel) => void;
+  /** Additional CSS class for the root element */
+  className?: string;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -169,6 +169,15 @@ export {
   type SuggestedAction,
 } from './components/chat';
 
+// Cookie Consent Components
+export {
+  CookieConsentBanner,
+  type CookieConsentBannerProps,
+  type CookieConsentColors,
+  type CookieConsentLabels,
+  type ConsentLevel,
+} from './components/cookie-consent';
+
 // Hooks
 export {
   useDebounce,

--- a/scripts/setup-qstash-schedules.ts
+++ b/scripts/setup-qstash-schedules.ts
@@ -50,6 +50,9 @@ const DEFAULT_CRON_SCHEDULES: Record<string, string> = {
 
   /** Traitement des rapports programmés - toutes les heures à :45 */
   'process-reports': '45 * * * *',
+
+  /** Rotation automatique des secrets JWT - 2h00 chaque jour */
+  'rotate-secrets': '0 2 * * *',
 };
 
 interface ScheduleResult {


### PR DESCRIPTION
## Résumé

Traitement de 3 issues d'audit de centralisation :

### Issue #319 — CookieConsentBanner & RGPD
- Migration du composant CookieConsentBanner vers `@kairn/ui` avec types centralisés (ConsentLevel, couleurs, labels configurables)
- Création d'un handler GDPR centralisé dans `@kairn/api` (droit à l'effacement Art. 17)
- Adaptation du wrapper Psypnos pour utiliser le composant partagé

### Issue #323 — Seeding centralisé
- Création de `seed-site.ts` dans `@kairn/db` avec interface `SeedSiteConfig`
- Extension du CLI avec `kairn db seed --site <slug> --name <name> --domain <domain> [--demo]`
- Données créées : Site, Admin, Tags par défaut, Clé JWT, données démo optionnelles

### Issue #328 — Rotation automatique des secrets JWT
- Création du CRON `/api/cron/rotate-secrets` avec seuil de 30 jours
- Ajout du schedule QStash `rotate-secrets` (quotidien 2h00)
- Documentation complète `docs/JWT-KEY-ROTATION.md`

Fixes #319, #323, #328

## Validation

- [x] Lint
- [x] Type-check
- [x] Tests (couverture ≥ 60%)
- [x] Build

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `packages/ui/src/components/cookie-consent/*` | Nouveau composant partagé + types + tests |
| `packages/api/src/handlers/gdpr/*` | Handler GDPR centralisé + tests |
| `apps/psypnos/components/CookieConsentBanner.tsx` | Wrapper utilisant @kairn/ui |
| `apps/psypnos/app/api/analytics/gdpr/delete/route.ts` | Utilise le handler centralisé |
| `packages/db/src/seed-site.ts` | Script de seeding configurable |
| `packages/cli/src/commands/db.ts` | Support --site dans seed |
| `apps/psypnos/app/api/cron/rotate-secrets/route.ts` | CRON rotation JWT |
| `scripts/setup-qstash-schedules.ts` | Schedule rotate-secrets |
| `docs/JWT-KEY-ROTATION.md` | Documentation rotation |
| `DEPLOYMENT.md` | Ajout schedule rotate-secrets |