### PR TITLE
feat(ui): extraire sections réutilisables vers @kairn/ui

### DIFF
--- a/apps/psypnos/app/(pages)/sections/blog.tsx
+++ b/apps/psypnos/app/(pages)/sections/blog.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import { motion } from 'framer-motion';
-import Image from 'next/image';
+import { BlogSection as BlogSectionUI } from '@kairn/ui';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import { CTAButton } from '../../../components/CTAButton';
-import { SectionTitle } from '../../../components/SectionTitle';
 import type { BlogPostData } from '../../../lib/server/data-fetchers';
 
-const defaultColors = { bg: 'bg-gold/20', text: 'text-gold', gradient: 'from-gold to-gold/60' };
-
-const categoryColors: Record<string, { bg: string; text: string; gradient: string }> = {
+const CATEGORY_COLORS: Record<string, { bg: string; text: string; gradient: string }> = {
   Psychothérapie: {
     bg: 'bg-blue-500/20',
     text: 'text-blue-300',
@@ -38,37 +34,21 @@ interface BlogSectionProps {
   initialData?: BlogPostData[];
 }
 
+/**
+ * Psypnos blog section wrapper.
+ * Provides site-specific data fetching, category colors, and CTA to the shared @kairn/ui component.
+ */
 export function BlogSection({ initialData }: BlogSectionProps) {
   const [blogPosts, setBlogPosts] = useState<BlogPostData[]>(initialData ?? []);
   const [loading, setLoading] = useState(!initialData);
   const [hasMounted, setHasMounted] = useState(false);
-  const [imageExists, setImageExists] = useState<Record<string, boolean>>({});
 
-  // Track mounting to avoid hydration mismatch
   useEffect(() => {
     setHasMounted(true);
   }, []);
 
-  // Check which blog post images exist (client-side only)
-  useEffect(() => {
-    if (!hasMounted || blogPosts.length === 0) return;
-
-    blogPosts.forEach(post => {
-      const src = post.image || `/images/blog/${post.slug}.webp`;
-      fetch(src, { method: 'HEAD' })
-        .then(res => {
-          setImageExists(prev => ({ ...prev, [post.slug]: res.ok }));
-        })
-        .catch(() => {
-          setImageExists(prev => ({ ...prev, [post.slug]: false }));
-        });
-    });
-  }, [hasMounted, blogPosts]);
-
-  // Only fetch if no initialData provided
   useEffect(() => {
     if (initialData && initialData.length > 0) {
-      // Already have data, no need to fetch
       return;
     }
 
@@ -88,195 +68,26 @@ export function BlogSection({ initialData }: BlogSectionProps) {
     fetchPosts();
   }, [initialData]);
 
-  // Show skeleton only if no initialData AND (not mounted OR still loading)
-  if (!initialData && (!hasMounted || loading)) {
-    return (
-      <section id="blog" className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
-        <div className="mx-auto max-w-6xl space-y-12">
-          <div className="space-y-4">
-            <div className="bg-ivory/10 h-4 w-32 animate-pulse rounded" />
-            <div className="bg-ivory/10 h-8 w-80 max-w-full animate-pulse rounded" />
-            <div className="bg-ivory/10 h-4 w-full max-w-2xl animate-pulse rounded" />
-          </div>
-          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-            {[1, 2, 3].map(i => (
-              <div
-                key={i}
-                className="border-ivory/10 bg-night/50 relative flex h-72 flex-col overflow-hidden rounded-2xl border p-6"
-              >
-                <div className="bg-ivory/10 absolute bottom-0 left-0 top-0 w-1 animate-pulse" />
-                <div className="space-y-4 pl-2">
-                  <div className="bg-ivory/10 h-6 w-24 animate-pulse rounded-full" />
-                  <div className="bg-ivory/10 h-6 w-full animate-pulse rounded" />
-                  <div className="space-y-2">
-                    <div className="bg-ivory/10 h-4 w-full animate-pulse rounded" />
-                    <div className="bg-ivory/10 h-4 w-3/4 animate-pulse rounded" />
-                  </div>
-                  <div className="bg-ivory/10 h-4 w-32 animate-pulse rounded" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-    );
-  }
-
-  // Ne pas afficher la section si pas d'articles
-  if (blogPosts.length === 0) {
-    return null;
-  }
+  const showLoading = !initialData && (!hasMounted || loading);
 
   return (
-    <section
-      id="blog"
-      className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16"
-      data-track-section="blog"
-      data-track-section-name="Blog"
-    >
-      <div className="mx-auto max-w-6xl space-y-12">
-        <SectionTitle
-          eyebrow="Ressources & Articles"
-          title="Découvrez nos derniers contenus"
-          description="Des articles pour mieux comprendre la psychothérapie, l'hypnose ericksonienne et la respiration holotropique. Ressources gratuites pour votre développement personnel et votre bien-être."
-        />
-
-        {/* Grille d'articles */}
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {blogPosts.map((post, index) => {
-            const colors = categoryColors[post.category] || defaultColors;
-            const formattedDate = new Date(post.date).toLocaleDateString('fr-FR', {
-              day: 'numeric',
-              month: 'long',
-              year: 'numeric',
-              timeZone: 'Europe/Paris',
-            });
-
-            return (
-              <motion.article
-                key={post.slug}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.3 }}
-                transition={{ duration: 0.6, ease: 'easeOut', delay: index * 0.1 }}
-                className="border-ivory/10 bg-night/50 shadow-night/60 hover:border-ivory/20 hover:bg-night/70 group relative flex h-full flex-col overflow-hidden rounded-2xl border shadow-xl transition-all"
-              >
-                {/* Barre de couleur selon la catégorie */}
-                <div
-                  className={`absolute bottom-0 left-0 top-0 w-1 bg-gradient-to-b ${colors.gradient}`}
-                />
-
-                <Link
-                  href={`/blog/${post.slug}`}
-                  className="focus:ring-gold focus:ring-offset-night flex h-full flex-col focus:outline-none focus:ring-2 focus:ring-offset-2"
-                >
-                  {/* Vignette */}
-                  {hasMounted && imageExists[post.slug] && (
-                    <div className="bg-night/80 relative h-48 overflow-hidden">
-                      <Image
-                        src={post.image || `/images/blog/${post.slug}.webp`}
-                        alt={post.title}
-                        fill
-                        unoptimized
-                        className="object-cover transition-transform group-hover:scale-105"
-                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                      />
-                    </div>
-                  )}
-
-                  <div className="flex flex-1 flex-col p-6 pl-8">
-                    {/* Badge catégorie */}
-                    <div className="mb-3">
-                      <span
-                        className={`inline-flex items-center gap-1.5 rounded-full ${colors.bg} px-3 py-1 text-xs font-medium ${colors.text}`}
-                      >
-                        <svg
-                          className="h-3 w-3"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                          />
-                        </svg>
-                        {post.category}
-                      </span>
-                    </div>
-
-                    {/* Titre */}
-                    <h3 className="text-ivory group-hover:text-gold mb-3 text-xl font-semibold transition-colors">
-                      {post.title}
-                    </h3>
-
-                    {/* Description */}
-                    <p className="text-ivory/70 mb-4 line-clamp-3 flex-1 text-sm">
-                      {post.description}
-                    </p>
-
-                    {/* Métadonnées */}
-                    <div className="text-ivory/60 flex flex-wrap items-center gap-3 text-xs">
-                      <div className="flex items-center gap-1">
-                        <svg
-                          className="h-3.5 w-3.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                          />
-                        </svg>
-                        <time dateTime={post.date}>{formattedDate}</time>
-                      </div>
-                    </div>
-
-                    {/* Indicateur "Lire" */}
-                    <div className="text-gold mt-4 flex items-center gap-2 text-sm font-medium opacity-0 transition-opacity group-hover:opacity-100">
-                      <span>Lire l'article</span>
-                      <svg
-                        className="h-4 w-4 transition-transform group-hover:translate-x-1"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M14 5l7 7m0 0l-7 7m7-7H3"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-
-                  {/* Barre de progression au hover */}
-                  <div className="from-gold to-gold/50 absolute bottom-0 left-0 h-1 w-full origin-left scale-x-0 bg-gradient-to-r transition-transform group-hover:scale-x-100" />
-                </Link>
-              </motion.article>
-            );
-          })}
-        </div>
-
-        {/* CTA vers le blog complet */}
-        <motion.div
-          initial={{ opacity: 0, y: 24 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-          className="flex justify-center"
-        >
-          <CTAButton variant="secondary" href="/blog">
-            Découvrir tous les articles
-          </CTAButton>
-        </motion.div>
-      </div>
-    </section>
+    <BlogSectionUI
+      posts={blogPosts}
+      isLoading={showLoading}
+      title={{
+        eyebrow: 'Ressources & Articles',
+        title: 'Découvrez nos derniers contenus',
+        description:
+          "Des articles pour mieux comprendre la psychothérapie, l'hypnose ericksonienne et la respiration holotropique. Ressources gratuites pour votre développement personnel et votre bien-être.",
+      }}
+      categoryColors={CATEGORY_COLORS}
+      linkComponent={Link}
+      ctaComponent={
+        <CTAButton variant="secondary" href="/blog">
+          Découvrir tous les articles
+        </CTAButton>
+      }
+      trackingName="Blog"
+    />
   );
 }

--- a/apps/psypnos/app/(pages)/sections/contact.tsx
+++ b/apps/psypnos/app/(pages)/sections/contact.tsx
@@ -1,49 +1,26 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { ContactSection as ContactSectionUI } from '@kairn/ui';
 
 import { ContactForm } from '../../../components/ContactForm';
-import { SectionTitle } from '../../../components/SectionTitle';
 import { SocialLinks } from '../../../components/SocialLinks';
 
+/**
+ * Psypnos contact section wrapper.
+ * Provides site-specific form, social links, and labels to the shared @kairn/ui component.
+ */
 export function ContactSection() {
   return (
-    <section
-      id="contact"
-      className="px-6 py-20 sm:px-10 lg:px-16"
-      data-track-section="contact"
-      data-track-section-name="Contact"
-    >
-      <div className="mx-auto max-w-4xl space-y-12">
-        <SectionTitle
-          eyebrow="Contact"
-          title="Prêt à explorer davantage ?"
-          description="Partagez vos intentions et recevez une réponse chaleureuse sous 48 heures."
-        />
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.3 }}
-          transition={{ duration: 0.6, ease: 'easeOut' }}
-          className="border-ivory/10 bg-night/40 shadow-night/60 rounded-3xl border p-10 shadow-xl md:col-span-1"
-        >
-          <ContactForm />
-        </motion.div>
-
-        {/* Liens réseaux sociaux */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.3 }}
-          transition={{ duration: 0.6, delay: 0.2, ease: 'easeOut' }}
-          className="mt-10 text-center"
-        >
-          <p className="text-ivory/60 mb-4 text-sm">
-            Suivez-moi sur les réseaux sociaux pour des réflexions et ressources régulières
-          </p>
-          <SocialLinks variant="stacked" showLabels />
-        </motion.div>
-      </div>
-    </section>
+    <ContactSectionUI
+      title={{
+        eyebrow: 'Contact',
+        title: 'Prêt à explorer davantage ?',
+        description: 'Partagez vos intentions et recevez une réponse chaleureuse sous 48 heures.',
+      }}
+      contactForm={<ContactForm />}
+      socialLinks={<SocialLinks variant="stacked" showLabels />}
+      socialLinksLabel="Suivez-moi sur les réseaux sociaux pour des réflexions et ressources régulières"
+      trackingName="Contact"
+    />
   );
 }

--- a/apps/psypnos/app/(pages)/sections/seminars.tsx
+++ b/apps/psypnos/app/(pages)/sections/seminars.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { SeminarsSection as SeminarsSectionUI } from '@kairn/ui';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
 import { CTAButton } from '../../../components/CTAButton';
-import { SectionTitle } from '../../../components/SectionTitle';
 import { useSeminars } from '../../../lib/hooks';
 import { BLUR_DATA_URL, IMAGE_DIMENSIONS } from '../../../lib/image-utils';
 import type { SeminarData } from '../../../lib/server/data-fetchers';
@@ -14,202 +13,55 @@ interface SeminarsSectionProps {
   initialData?: SeminarData[];
 }
 
-function formatSeminarDate(startAt: string, endAt: string): string {
-  const start = new Date(startAt);
-  const end = new Date(endAt);
-  const options: Intl.DateTimeFormatOptions = {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-    timeZone: 'Europe/Paris',
-  };
-
-  if (start.toDateString() === end.toDateString()) {
-    return start.toLocaleDateString('fr-FR', options);
-  }
-
-  const startStr = start.toLocaleDateString('fr-FR', {
-    day: 'numeric',
-    month: 'long',
-    timeZone: 'Europe/Paris',
-  });
-  const endStr = end.toLocaleDateString('fr-FR', options);
-  return `${startStr} - ${endStr}`;
-}
-
+/**
+ * Psypnos seminars section wrapper.
+ * Provides site-specific data fetching, image optimization, and CTA to the shared @kairn/ui component.
+ */
 export function SeminarsSection({ initialData }: SeminarsSectionProps) {
   const [hasMounted, setHasMounted] = useState(false);
 
-  // Use SWR for optimized data fetching with caching
-  // If initialData is provided, SWR will use it immediately and skip initial fetch
   const { seminars: fetchedSeminars, isLoading } = useSeminars({
     upcoming: true,
     limit: 3,
     initialData,
   });
 
-  // Use initialData if available, otherwise use fetched data
   const upcomingSeminars = initialData && initialData.length > 0 ? initialData : fetchedSeminars;
 
-  // Track mounting to avoid hydration mismatch
   useEffect(() => {
     setHasMounted(true);
   }, []);
 
-  // Show loading only if no initialData AND still loading from SWR
-  const showLoading = !initialData && !hasMounted;
-
-  // During SSR and initial client render, show skeleton to prevent hydration mismatch
-  if (showLoading || (!initialData && isLoading)) {
-    return (
-      <section id="seminaires" className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
-        <div className="mx-auto max-w-6xl space-y-12">
-          <SectionTitle
-            eyebrow="Séminaires à venir"
-            title="Une exploration profonde au Cœur de Soi"
-            description="Nos séminaires sont limités en places pour préserver une attention personnalisée et un cercle intime."
-          />
-          <div className="grid gap-10 md:grid-cols-3">
-            {[1, 2, 3].map(i => (
-              <div
-                key={i}
-                className="border-ivory/10 bg-night/50 shadow-night/60 flex h-full animate-pulse flex-col overflow-hidden rounded-3xl border shadow-xl"
-              >
-                <div className="bg-night/80 aspect-[16/9] w-full" />
-                <div className="flex flex-1 flex-col justify-between space-y-4 p-6">
-                  <div className="bg-ivory/10 h-6 w-3/4 rounded" />
-                  <div className="space-y-2">
-                    <div className="bg-ivory/10 h-4 rounded" />
-                    <div className="bg-ivory/10 h-4 w-5/6 rounded" />
-                  </div>
-                  <div className="bg-ivory/10 mx-auto h-10 w-1/2 rounded-full" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-    );
-  }
+  const showLoading = !initialData && (!hasMounted || isLoading);
 
   return (
-    <section
-      id="seminaires"
-      className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16"
-      data-track-section="seminaires"
-      data-track-section-name="Séminaires"
-    >
-      <div className="mx-auto max-w-6xl space-y-12">
-        <SectionTitle
-          eyebrow="Séminaires à venir"
-          title="Une exploration profonde au Cœur de Soi"
-          description="Nos séminaires sont limités en places pour préserver une attention personnalisée et un cercle intime."
+    <SeminarsSectionUI
+      seminars={upcomingSeminars}
+      isLoading={showLoading}
+      title={{
+        eyebrow: 'Séminaires à venir',
+        title: 'Une exploration profonde au Cœur de Soi',
+        description:
+          'Nos séminaires sont limités en places pour préserver une attention personnalisée et un cercle intime.',
+      }}
+      emptyMessage="Aucun séminaire à venir pour le moment. Inscrivez-vous à la newsletter pour être informé des prochaines dates."
+      ctaComponent={() => (
+        <CTAButton className="" href="/inscription-seminaire">
+          Réserver ma place
+        </CTAButton>
+      )}
+      imageComponent={({ src, alt, width, height, className }) => (
+        <Image
+          src={src}
+          alt={alt}
+          width={width || IMAGE_DIMENSIONS.seminarCard.width}
+          height={height || IMAGE_DIMENSIONS.seminarCard.height}
+          placeholder="blur"
+          blurDataURL={BLUR_DATA_URL}
+          className={className}
         />
-        <div className="grid gap-10 md:grid-cols-3">
-          {upcomingSeminars.length > 0 ? (
-            upcomingSeminars.map(
-              (
-                { id, title, description, startAt, endAt, seminarType, capacity, thumbnail },
-                index
-              ) => (
-                <motion.article
-                  key={id}
-                  initial={{ opacity: 0, y: 24 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  transition={{ duration: 0.6, ease: 'easeOut', delay: index * 0.05 }}
-                  className="border-ivory/10 bg-night/50 shadow-night/60 group flex h-full flex-col overflow-hidden rounded-3xl border shadow-xl"
-                >
-                  <div className="from-night/80 to-night/40 relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br">
-                    {thumbnail ? (
-                      <Image
-                        src={thumbnail}
-                        alt={title}
-                        width={IMAGE_DIMENSIONS.seminarCard.width}
-                        height={IMAGE_DIMENSIONS.seminarCard.height}
-                        placeholder="blur"
-                        blurDataURL={BLUR_DATA_URL}
-                        className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                      />
-                    ) : (
-                      <div className="absolute inset-0 flex items-center justify-center">
-                        <svg
-                          className="text-ivory/10 h-16 w-16"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={1}
-                            d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-                          />
-                        </svg>
-                      </div>
-                    )}
-                    {seminarType && (
-                      <span className="bg-gold/90 text-night absolute left-4 top-4 rounded-full px-3 py-1 text-xs font-semibold backdrop-blur-sm">
-                        {seminarType}
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex flex-1 flex-col justify-between p-6">
-                    <div>
-                      <h3 className="text-ivory text-xl font-semibold">{title}</h3>
-                      <p className="text-ivory/70 mt-3 line-clamp-3 text-sm">{description}</p>
-                    </div>
-                    <dl className="text-ivory/60 mt-5 space-y-2 text-sm">
-                      <div className="flex items-center gap-2">
-                        <svg
-                          className="text-gold h-4 w-4 flex-shrink-0"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                          />
-                        </svg>
-                        <span>{formatSeminarDate(startAt, endAt)}</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <svg
-                          className="text-gold h-4 w-4 flex-shrink-0"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                          />
-                        </svg>
-                        <span>{capacity} places</span>
-                      </div>
-                    </dl>
-                    <div className="mt-6 flex justify-center">
-                      <CTAButton className="" href="/inscription-seminaire">
-                        Réserver ma place
-                      </CTAButton>
-                    </div>
-                  </div>
-                </motion.article>
-              )
-            )
-          ) : (
-            <div className="border-ivory/10 bg-night/40 text-ivory/60 rounded-3xl border p-8 text-center text-sm md:col-span-3">
-              Aucun séminaire à venir pour le moment. Inscrivez-vous à la newsletter pour être
-              informé des prochaines dates.
-            </div>
-          )}
-        </div>
-      </div>
-    </section>
+      )}
+      trackingName="Séminaires"
+    />
   );
 }

--- a/apps/psypnos/app/(pages)/sections/testimonials.tsx
+++ b/apps/psypnos/app/(pages)/sections/testimonials.tsx
@@ -1,256 +1,43 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { TestimonialsSection as TestimonialsSectionUI } from '@kairn/ui';
 import { useEffect, useState } from 'react';
 
-import { SectionTitle } from '../../../components/SectionTitle';
 import { useTestimonials } from '../../../lib/hooks';
 import type { TestimonialData } from '../../../lib/server/data-fetchers';
-
-/**
- * Compact testimonial card for the marquee
- * Features a subtle glass morphism effect and gold accent
- */
-function TestimonialCard({ quote, author }: { quote: string; author: string }) {
-  return (
-    <article className="border-ivory/[0.08] from-ivory/[0.04] hover:border-gold/20 hover:bg-ivory/[0.06] group relative flex w-[320px] shrink-0 flex-col gap-4 rounded-2xl border bg-gradient-to-br to-transparent p-6 backdrop-blur-sm transition-all duration-300 sm:w-[380px]">
-      {/* Subtle gold accent line */}
-      <div className="from-gold/60 absolute left-6 top-0 h-px w-12 bg-gradient-to-r to-transparent" />
-
-      {/* Quote */}
-      <p className="text-ivory/75 group-hover:text-ivory/90 text-[15px] leading-relaxed transition-colors duration-300">
-        "{quote}"
-      </p>
-
-      {/* Author with decorative dash */}
-      <div className="flex items-center gap-2">
-        <span className="bg-gold/40 h-px w-4" />
-        <span className="text-gold/80 text-sm font-medium">{author}</span>
-      </div>
-    </article>
-  );
-}
-
-/**
- * Infinite marquee component with pause on hover
- * Uses CSS animations for truly seamless infinite scrolling
- *
- * Key insight: We animate a WRAPPER containing two copies of content.
- * - The wrapper width = 2x content width (since it has 2 copies)
- * - Animation moves wrapper by 50% of its width = 100% of one copy
- * - When wrapper moves -50%, Copy2 is where Copy1 started -> seamless loop
- *
- * Direction LEFT:  wrapper moves from 0% to -50%
- * Direction RIGHT: wrapper moves from -50% to 0%
- */
-function Marquee({
-  children,
-  direction = 'left',
-  speed = 25,
-  pauseOnHover = true,
-}: {
-  children: React.ReactNode;
-  direction?: 'left' | 'right';
-  speed?: number;
-  pauseOnHover?: boolean;
-}) {
-  const [isPaused, setIsPaused] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setPrefersReducedMotion(mediaQuery.matches);
-
-    const handleChange = (e: MediaQueryListEvent) => {
-      setPrefersReducedMotion(e.matches);
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
-
-  if (prefersReducedMotion) {
-    return <div className="flex gap-4 overflow-x-auto px-6 sm:gap-6">{children}</div>;
-  }
-
-  const isRight = direction === 'right';
-
-  return (
-    <div
-      className="group relative flex overflow-hidden"
-      onMouseEnter={() => pauseOnHover && setIsPaused(true)}
-      onMouseLeave={() => pauseOnHover && setIsPaused(false)}
-    >
-      {/* Gradient fade edges */}
-      <div className="from-night/80 pointer-events-none absolute left-0 top-0 z-10 h-full w-16 bg-gradient-to-r to-transparent sm:w-24" />
-      <div className="from-night/80 pointer-events-none absolute right-0 top-0 z-10 h-full w-16 bg-gradient-to-l to-transparent sm:w-24" />
-
-      {/* Animated wrapper containing two copies */}
-      <div
-        className={isRight ? 'animate-marquee-right' : 'animate-marquee-left'}
-        style={{
-          display: 'flex',
-          animationDuration: `${speed}s`,
-          animationPlayState: isPaused ? 'paused' : 'running',
-        }}
-      >
-        {/* First copy */}
-        <div className="flex shrink-0 gap-4 pr-4 sm:gap-6 sm:pr-6">{children}</div>
-        {/* Second copy for seamless loop */}
-        <div className="flex shrink-0 gap-4 pr-4 sm:gap-6 sm:pr-6" aria-hidden="true">
-          {children}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 interface TestimonialsSectionProps {
   initialData?: TestimonialData[];
 }
 
 /**
- * Testimonials section with dual-direction infinite marquee
- * - Two rows scrolling in opposite directions create visual interest
- * - Hover to pause allows reading individual testimonials
- * - Reduced motion support for accessibility
+ * Psypnos testimonials section wrapper.
+ * Provides site-specific data fetching and configuration to the shared @kairn/ui component.
  */
 export function TestimonialsSection({ initialData }: TestimonialsSectionProps) {
   const [hasMounted, setHasMounted] = useState(false);
 
-  // Use SWR for optimized data fetching with caching
   const { testimonials: fetchedTestimonials, isLoading } = useTestimonials({ limit: 10 });
 
-  // Use initialData if available, otherwise use fetched data
   const testimonials = initialData && initialData.length > 0 ? initialData : fetchedTestimonials;
 
   useEffect(() => {
     setHasMounted(true);
   }, []);
 
-  // For 10 or fewer testimonials, show all on both rows (second row reversed)
-  // For more than 10, split into two separate halves
-  const shouldShowAllOnBothRows = testimonials.length <= 10;
-  const topRow = shouldShowAllOnBothRows
-    ? testimonials
-    : testimonials.slice(0, Math.ceil(testimonials.length / 2));
-  const bottomRow = shouldShowAllOnBothRows
-    ? [...testimonials].reverse()
-    : testimonials.slice(Math.ceil(testimonials.length / 2));
-
-  // Show skeleton only if no initialData AND (not mounted OR still loading)
-  if (!initialData && (!hasMounted || isLoading)) {
-    return (
-      <section className="bg-night/60 overflow-hidden py-20">
-        <div className="mx-auto max-w-6xl space-y-10 px-6 sm:px-10 lg:px-16">
-          <div className="space-y-4">
-            <div className="bg-ivory/10 h-4 w-24 animate-pulse rounded" />
-            <div className="bg-ivory/10 h-8 w-80 max-w-full animate-pulse rounded" />
-          </div>
-        </div>
-        <div className="mt-12 space-y-4">
-          {[1, 2].map(row => (
-            <div key={row} className="flex gap-4 overflow-hidden px-4 sm:gap-6">
-              {[1, 2, 3, 4].map(i => (
-                <div
-                  key={i}
-                  className="border-ivory/[0.08] bg-ivory/[0.02] w-[320px] shrink-0 rounded-2xl border p-6 sm:w-[380px]"
-                >
-                  <div className="space-y-4">
-                    <div className="space-y-2">
-                      <div className="bg-ivory/10 h-4 w-full animate-pulse rounded" />
-                      <div className="bg-ivory/10 h-4 w-4/5 animate-pulse rounded" />
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <div className="bg-ivory/10 h-px w-4" />
-                      <div className="bg-ivory/10 h-3 w-16 animate-pulse rounded" />
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ))}
-        </div>
-        <p className="text-ivory/40 mt-8 text-center text-xs">Survolez pour mettre en pause</p>
-      </section>
-    );
-  }
-
-  // Empty state
-  if (testimonials.length === 0) {
-    return (
-      <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
-        <div className="mx-auto max-w-6xl space-y-12">
-          <SectionTitle
-            eyebrow="Témoignages"
-            title="Ils et elles témoignent de leur métamorphose"
-          />
-          <div className="border-ivory/10 bg-ivory/[0.02] text-ivory/60 rounded-2xl border p-8 text-center text-sm">
-            Aucun témoignage pour le moment.
-          </div>
-        </div>
-      </section>
-    );
-  }
+  const showLoading = !initialData && (!hasMounted || isLoading);
 
   return (
-    <section
-      className="bg-night/60 overflow-hidden py-20"
-      data-track-section="temoignages"
-      data-track-section-name="Témoignages"
-    >
-      {/* Title with constrained width */}
-      <div className="mx-auto max-w-6xl px-6 sm:px-10 lg:px-16">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.3 }}
-          transition={{ duration: 0.6, ease: 'easeOut' }}
-        >
-          <SectionTitle
-            eyebrow="Témoignages"
-            title="Ils et elles témoignent de leur métamorphose"
-          />
-        </motion.div>
-      </div>
-
-      {/* Full-width marquee container */}
-      <div className="mt-12 space-y-4 sm:space-y-6">
-        {/* Top row - scrolls left */}
-        <Marquee direction="left" speed={35}>
-          {topRow.map(testimonial => (
-            <TestimonialCard
-              key={testimonial.id}
-              quote={testimonial.quote}
-              author={testimonial.author}
-            />
-          ))}
-        </Marquee>
-
-        {/* Bottom row - scrolls right (only if enough testimonials) */}
-        {bottomRow.length > 0 && (
-          <Marquee direction="right" speed={30}>
-            {bottomRow.map(testimonial => (
-              <TestimonialCard
-                key={testimonial.id}
-                quote={testimonial.quote}
-                author={testimonial.author}
-              />
-            ))}
-          </Marquee>
-        )}
-      </div>
-
-      {/* Hover hint */}
-      <motion.p
-        initial={{ opacity: 0 }}
-        whileInView={{ opacity: 1 }}
-        viewport={{ once: true }}
-        transition={{ delay: 0.5, duration: 0.5 }}
-        className="text-ivory/40 mt-8 text-center text-xs"
-      >
-        Survolez pour mettre en pause
-      </motion.p>
-    </section>
+    <TestimonialsSectionUI
+      testimonials={testimonials}
+      isLoading={showLoading}
+      title={{
+        eyebrow: 'Témoignages',
+        title: 'Ils et elles témoignent de leur métamorphose',
+      }}
+      trackingName="Témoignages"
+      emptyMessage="Aucun témoignage pour le moment."
+      hoverHint="Survolez pour mettre en pause"
+    />
   );
 }

--- a/packages/ui/src/components/marquee.tsx
+++ b/packages/ui/src/components/marquee.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+
+import { cn } from '../utils/cn';
+
+/**
+ * Props for the Marquee component
+ */
+export interface MarqueeProps {
+  /** Content to scroll infinitely */
+  children: ReactNode;
+  /** Scroll direction */
+  direction?: 'left' | 'right';
+  /** Animation duration in seconds */
+  speed?: number;
+  /** Pause animation on hover */
+  pauseOnHover?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+  /** Custom gradient fade color (default: 'night') */
+  fadeColor?: string;
+}
+
+/**
+ * Infinite marquee component with pause on hover and reduced motion support.
+ *
+ * Animates a wrapper containing two copies of content for seamless looping.
+ * Uses CSS animation classes `animate-marquee-left` and `animate-marquee-right`
+ * which must be defined in the consuming app's Tailwind config.
+ *
+ * @example
+ * ```tsx
+ * <Marquee direction="left" speed={35}>
+ *   {items.map(item => <Card key={item.id} {...item} />)}
+ * </Marquee>
+ * ```
+ */
+export function Marquee({
+  children,
+  direction = 'left',
+  speed = 25,
+  pauseOnHover = true,
+  className,
+  fadeColor = 'night',
+}: MarqueeProps) {
+  const [isPaused, setIsPaused] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setPrefersReducedMotion(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  if (prefersReducedMotion) {
+    return (
+      <div className={cn('flex gap-4 overflow-x-auto px-6 sm:gap-6', className)}>{children}</div>
+    );
+  }
+
+  const isRight = direction === 'right';
+
+  return (
+    <div
+      className={cn('group relative flex overflow-hidden', className)}
+      onMouseEnter={() => pauseOnHover && setIsPaused(true)}
+      onMouseLeave={() => pauseOnHover && setIsPaused(false)}
+    >
+      {/* Gradient fade edges */}
+      <div
+        className={`from-${fadeColor}/80 pointer-events-none absolute left-0 top-0 z-10 h-full w-16 bg-gradient-to-r to-transparent sm:w-24`}
+      />
+      <div
+        className={`from-${fadeColor}/80 pointer-events-none absolute right-0 top-0 z-10 h-full w-16 bg-gradient-to-l to-transparent sm:w-24`}
+      />
+
+      {/* Animated wrapper containing two copies */}
+      <div
+        className={isRight ? 'animate-marquee-right' : 'animate-marquee-left'}
+        style={{
+          display: 'flex',
+          animationDuration: `${speed}s`,
+          animationPlayState: isPaused ? 'paused' : 'running',
+        }}
+      >
+        {/* First copy */}
+        <div className="flex shrink-0 gap-4 pr-4 sm:gap-6 sm:pr-6">{children}</div>
+        {/* Second copy for seamless loop */}
+        <div className="flex shrink-0 gap-4 pr-4 sm:gap-6 sm:pr-6" aria-hidden="true">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/section-title.tsx
+++ b/packages/ui/src/components/section-title.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { cn } from '../utils/cn';
+
+/**
+ * Props for the SectionTitle component
+ */
+export interface SectionTitleProps {
+  /** Small text displayed above the title */
+  eyebrow?: string;
+  /** Main heading text */
+  title: string;
+  /** Optional description below the title */
+  description?: ReactNode;
+  /** Additional CSS classes for the container */
+  className?: string;
+  /** Custom colors configuration */
+  colors?: {
+    /** Eyebrow text color class (default: 'text-gold/80') */
+    eyebrow?: string;
+    /** Title text color class (default: 'text-ivory') */
+    title?: string;
+    /** Description text color class (default: 'text-ivory/80') */
+    description?: string;
+  };
+}
+
+/**
+ * Reusable section title component with eyebrow, heading, and description.
+ * Used as a header for page sections across sites.
+ *
+ * @example
+ * ```tsx
+ * <SectionTitle
+ *   eyebrow="Témoignages"
+ *   title="Ce que disent nos clients"
+ *   description="Des retours authentiques de nos utilisateurs."
+ * />
+ * ```
+ */
+export function SectionTitle({
+  eyebrow,
+  title,
+  description,
+  className,
+  colors = {},
+}: SectionTitleProps) {
+  const {
+    eyebrow: eyebrowColor = 'text-gold/80',
+    title: titleColor = 'text-ivory',
+    description: descriptionColor = 'text-ivory/80',
+  } = colors;
+
+  return (
+    <header className={cn('mx-auto max-w-3xl text-center', className)}>
+      {eyebrow && (
+        <p className={cn('mb-2 text-sm uppercase tracking-[0.3em]', eyebrowColor)}>{eyebrow}</p>
+      )}
+      <h2 className={cn('font-display text-3xl font-semibold sm:text-4xl', titleColor)}>{title}</h2>
+      {description && (
+        <p className={cn('mt-4 text-base sm:text-lg', descriptionColor)}>{description}</p>
+      )}
+    </header>
+  );
+}

--- a/packages/ui/src/components/sections/__tests__/BlogSection.test.tsx
+++ b/packages/ui/src/components/sections/__tests__/BlogSection.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * BlogSection Component Tests
+ *
+ * Tests for the reusable BlogSection component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { BlogSectionPost } from '../blog-section';
+import { BlogSection } from '../blog-section';
+
+/** Create mock blog posts */
+function createMockPosts(count = 3): BlogSectionPost[] {
+  return Array.from({ length: count }, (_, i) => ({
+    slug: `article-${i + 1}`,
+    title: `Article ${i + 1}`,
+    description: `Description de l'article ${i + 1}`,
+    category: 'Tech',
+    date: '2025-01-15T10:00:00Z',
+    image: `/images/blog/article-${i + 1}.webp`,
+  }));
+}
+
+describe('BlogSection', () => {
+  it('renders posts with default title', () => {
+    render(<BlogSection posts={createMockPosts()} />);
+    expect(screen.getByText('Nos derniers articles')).toBeInTheDocument();
+  });
+
+  it('renders with custom title', () => {
+    render(
+      <BlogSection
+        posts={createMockPosts()}
+        title={{ eyebrow: 'Blog', title: 'Articles récents', description: 'Nos articles.' }}
+      />
+    );
+    expect(screen.getByText('Articles récents')).toBeInTheDocument();
+    expect(screen.getByText('Blog')).toBeInTheDocument();
+  });
+
+  it('renders nothing when posts array is empty', () => {
+    const { container } = render(<BlogSection posts={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders loading skeleton when isLoading is true', () => {
+    const { container } = render(<BlogSection posts={[]} isLoading />);
+    const pulsingElements = container.querySelectorAll('.animate-pulse');
+    expect(pulsingElements.length).toBeGreaterThan(0);
+  });
+
+  it('renders post titles and descriptions', () => {
+    render(<BlogSection posts={createMockPosts(2)} />);
+    expect(screen.getByText('Article 1')).toBeInTheDocument();
+    expect(screen.getByText('Article 2')).toBeInTheDocument();
+    expect(screen.getByText("Description de l'article 1")).toBeInTheDocument();
+  });
+
+  it('renders category badges', () => {
+    render(<BlogSection posts={createMockPosts(1)} />);
+    expect(screen.getByText('Tech')).toBeInTheDocument();
+  });
+
+  it('applies category colors', () => {
+    const posts = createMockPosts(1);
+    posts[0].category = 'Design';
+    render(
+      <BlogSection
+        posts={posts}
+        categoryColors={{
+          Design: {
+            bg: 'bg-pink-500/20',
+            text: 'text-pink-300',
+            gradient: 'from-pink-500 to-pink-600',
+          },
+        }}
+      />
+    );
+    expect(screen.getByText('Design')).toBeInTheDocument();
+  });
+
+  it('renders default CTA link', () => {
+    render(<BlogSection posts={createMockPosts()} ctaLabel="Voir tout" ctaHref="/blog" />);
+    const ctaLink = screen.getByText('Voir tout');
+    expect(ctaLink).toBeInTheDocument();
+    expect(ctaLink.closest('a')).toHaveAttribute('href', '/blog');
+  });
+
+  it('renders custom CTA component', () => {
+    render(
+      <BlogSection
+        posts={createMockPosts()}
+        ctaComponent={<button data-testid="custom-cta">Custom CTA</button>}
+      />
+    );
+    expect(screen.getByTestId('custom-cta')).toBeInTheDocument();
+  });
+
+  it('formats dates with the specified locale', () => {
+    const posts = [{ ...createMockPosts(1)[0], date: '2025-03-15T10:00:00Z' }];
+    render(<BlogSection posts={posts} locale="fr-FR" />);
+    expect(screen.getByText('15 mars 2025')).toBeInTheDocument();
+  });
+
+  it('sets tracking attributes', () => {
+    const { container } = render(<BlogSection posts={createMockPosts()} trackingName="Blog" />);
+    const section = container.querySelector('[data-track-section="blog"]');
+    expect(section).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/sections/__tests__/ContactSection.test.tsx
+++ b/packages/ui/src/components/sections/__tests__/ContactSection.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * ContactSection Component Tests
+ *
+ * Tests for the reusable ContactSection component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ContactSection } from '../contact-section';
+
+describe('ContactSection', () => {
+  it('renders with default title', () => {
+    render(<ContactSection contactForm={<form data-testid="form" />} />);
+    expect(screen.getByText('Contactez-nous')).toBeInTheDocument();
+  });
+
+  it('renders with custom title', () => {
+    render(
+      <ContactSection
+        title={{
+          eyebrow: 'Contact',
+          title: 'Écrivez-nous',
+          description: 'Réponse sous 24h.',
+        }}
+        contactForm={<form />}
+      />
+    );
+    expect(screen.getByText('Écrivez-nous')).toBeInTheDocument();
+    expect(screen.getByText('Contact')).toBeInTheDocument();
+    expect(screen.getByText('Réponse sous 24h.')).toBeInTheDocument();
+  });
+
+  it('renders the contact form', () => {
+    render(<ContactSection contactForm={<form data-testid="my-form" />} />);
+    expect(screen.getByTestId('my-form')).toBeInTheDocument();
+  });
+
+  it('renders social links when provided', () => {
+    render(
+      <ContactSection
+        contactForm={<form />}
+        socialLinks={<div data-testid="social-links">Social</div>}
+      />
+    );
+    expect(screen.getByTestId('social-links')).toBeInTheDocument();
+  });
+
+  it('does not render social links section when not provided', () => {
+    const { container } = render(<ContactSection contactForm={<form />} />);
+    expect(container.querySelector('[data-testid="social-links"]')).toBeNull();
+  });
+
+  it('renders custom social links label', () => {
+    render(
+      <ContactSection
+        contactForm={<form />}
+        socialLinks={<div>Links</div>}
+        socialLinksLabel="Retrouvez-nous"
+      />
+    );
+    expect(screen.getByText('Retrouvez-nous')).toBeInTheDocument();
+  });
+
+  it('sets tracking attributes', () => {
+    const { container } = render(<ContactSection contactForm={<form />} trackingName="Contact" />);
+    const section = container.querySelector('[data-track-section="contact"]');
+    expect(section).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <ContactSection contactForm={<form />} className="custom-class" />
+    );
+    expect(container.querySelector('section')).toHaveClass('custom-class');
+  });
+});

--- a/packages/ui/src/components/sections/__tests__/SectionTitle.test.tsx
+++ b/packages/ui/src/components/sections/__tests__/SectionTitle.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * SectionTitle Component Tests
+ *
+ * Tests for the reusable SectionTitle component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { SectionTitle } from '../../section-title';
+
+describe('SectionTitle', () => {
+  it('renders the title', () => {
+    render(<SectionTitle title="Mon titre" />);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Mon titre');
+  });
+
+  it('renders the eyebrow when provided', () => {
+    render(<SectionTitle eyebrow="Sous-titre" title="Titre" />);
+    expect(screen.getByText('Sous-titre')).toBeInTheDocument();
+  });
+
+  it('does not render the eyebrow when not provided', () => {
+    const { container } = render(<SectionTitle title="Titre" />);
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs).toHaveLength(0);
+  });
+
+  it('renders the description when provided', () => {
+    render(<SectionTitle title="Titre" description="Une description." />);
+    expect(screen.getByText('Une description.')).toBeInTheDocument();
+  });
+
+  it('does not render the description when not provided', () => {
+    const { container } = render(<SectionTitle title="Titre" />);
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs).toHaveLength(0);
+  });
+
+  it('renders eyebrow, title, and description together', () => {
+    render(<SectionTitle eyebrow="Label" title="Heading" description="Some description text." />);
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Heading');
+    expect(screen.getByText('Some description text.')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<SectionTitle title="Titre" className="custom-class" />);
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('accepts ReactNode as description', () => {
+    render(
+      <SectionTitle
+        title="Titre"
+        description={<span data-testid="custom-desc">Custom content</span>}
+      />
+    );
+    expect(screen.getByTestId('custom-desc')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/sections/__tests__/SeminarsSection.test.tsx
+++ b/packages/ui/src/components/sections/__tests__/SeminarsSection.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * SeminarsSection Component Tests
+ *
+ * Tests for the reusable SeminarsSection component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { SeminarSectionItem } from '../seminars-section';
+import { SeminarsSection } from '../seminars-section';
+
+/** Create mock seminars */
+function createMockSeminars(count = 3): SeminarSectionItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `s-${i + 1}`,
+    title: `Séminaire ${i + 1}`,
+    description: `Description du séminaire ${i + 1}`,
+    startAt: '2025-06-15T09:00:00Z',
+    endAt: '2025-06-16T17:00:00Z',
+    seminarType: 'Présentiel',
+    capacity: 12,
+    thumbnail: null,
+  }));
+}
+
+describe('SeminarsSection', () => {
+  it('renders seminars with default title', () => {
+    render(<SeminarsSection seminars={createMockSeminars()} />);
+    expect(screen.getByText('Nos prochains événements')).toBeInTheDocument();
+  });
+
+  it('renders with custom title', () => {
+    render(
+      <SeminarsSection
+        seminars={createMockSeminars()}
+        title={{ eyebrow: 'Événements', title: 'Prochains séminaires' }}
+      />
+    );
+    expect(screen.getByText('Prochains séminaires')).toBeInTheDocument();
+    expect(screen.getByText('Événements')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no seminars', () => {
+    render(<SeminarsSection seminars={[]} emptyMessage="Aucun événement." />);
+    expect(screen.getByText('Aucun événement.')).toBeInTheDocument();
+  });
+
+  it('renders loading skeleton when isLoading is true', () => {
+    const { container } = render(<SeminarsSection seminars={[]} isLoading />);
+    const pulsingElements = container.querySelectorAll('.animate-pulse');
+    expect(pulsingElements.length).toBeGreaterThan(0);
+  });
+
+  it('renders seminar titles and descriptions', () => {
+    render(<SeminarsSection seminars={createMockSeminars(2)} />);
+    expect(screen.getByText('Séminaire 1')).toBeInTheDocument();
+    expect(screen.getByText('Séminaire 2')).toBeInTheDocument();
+    expect(screen.getByText('Description du séminaire 1')).toBeInTheDocument();
+  });
+
+  it('renders capacity with places label', () => {
+    render(<SeminarsSection seminars={createMockSeminars(1)} placesLabel="places" />);
+    expect(screen.getByText('12 places')).toBeInTheDocument();
+  });
+
+  it('renders seminar type badge', () => {
+    render(<SeminarsSection seminars={createMockSeminars(1)} />);
+    expect(screen.getByText('Présentiel')).toBeInTheDocument();
+  });
+
+  it('formats date range correctly for multi-day seminars', () => {
+    const seminars = [
+      {
+        ...createMockSeminars(1)[0],
+        startAt: '2025-06-15T09:00:00Z',
+        endAt: '2025-06-17T17:00:00Z',
+      },
+    ];
+    render(<SeminarsSection seminars={seminars} locale="fr-FR" />);
+    expect(screen.getByText(/15 juin - 17 juin 2025/)).toBeInTheDocument();
+  });
+
+  it('formats single-day seminar date', () => {
+    const seminars = [
+      {
+        ...createMockSeminars(1)[0],
+        startAt: '2025-06-15T09:00:00Z',
+        endAt: '2025-06-15T17:00:00Z',
+      },
+    ];
+    render(<SeminarsSection seminars={seminars} locale="fr-FR" />);
+    expect(screen.getByText('15 juin 2025')).toBeInTheDocument();
+  });
+
+  it('renders default CTA', () => {
+    render(
+      <SeminarsSection
+        seminars={createMockSeminars(1)}
+        ctaLabel="Réserver"
+        ctaHref="/inscription"
+      />
+    );
+    const cta = screen.getByText('Réserver');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/inscription');
+  });
+
+  it('renders custom CTA component', () => {
+    render(
+      <SeminarsSection
+        seminars={createMockSeminars(1)}
+        ctaComponent={s => <button data-testid="custom-cta">{s.title}</button>}
+      />
+    );
+    expect(screen.getByTestId('custom-cta')).toHaveTextContent('Séminaire 1');
+  });
+
+  it('sets tracking attributes', () => {
+    const { container } = render(
+      <SeminarsSection seminars={createMockSeminars()} trackingName="Séminaires" />
+    );
+    const section = container.querySelector('[data-track-section="séminaires"]');
+    expect(section).toBeInTheDocument();
+  });
+
+  it('renders fallback image when no thumbnail', () => {
+    const { container } = render(<SeminarsSection seminars={createMockSeminars(1)} />);
+    const svgPlaceholder = container.querySelector('svg');
+    expect(svgPlaceholder).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/sections/__tests__/TestimonialsSection.test.tsx
+++ b/packages/ui/src/components/sections/__tests__/TestimonialsSection.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * TestimonialsSection Component Tests
+ *
+ * Tests for the reusable TestimonialsSection component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { TestimonialSectionItem } from '../testimonials-section';
+import { TestimonialsSection } from '../testimonials-section';
+
+/** Mock matchMedia for reduced motion support */
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+/** Create mock testimonials */
+function createMockTestimonials(count = 5): TestimonialSectionItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `t-${i + 1}`,
+    quote: `Témoignage numéro ${i + 1}`,
+    author: `Auteur ${i + 1}`,
+  }));
+}
+
+describe('TestimonialsSection', () => {
+  it('renders testimonials with default title', () => {
+    render(<TestimonialsSection testimonials={createMockTestimonials()} />);
+    expect(screen.getByText('Ce que disent nos clients')).toBeInTheDocument();
+  });
+
+  it('renders with custom title', () => {
+    render(
+      <TestimonialsSection
+        testimonials={createMockTestimonials()}
+        title={{ eyebrow: 'Avis', title: 'Titre personnalisé' }}
+      />
+    );
+    expect(screen.getByText('Titre personnalisé')).toBeInTheDocument();
+    expect(screen.getByText('Avis')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no testimonials', () => {
+    render(<TestimonialsSection testimonials={[]} emptyMessage="Pas de témoignages." />);
+    expect(screen.getByText('Pas de témoignages.')).toBeInTheDocument();
+  });
+
+  it('renders loading skeleton when isLoading is true', () => {
+    const { container } = render(<TestimonialsSection testimonials={[]} isLoading />);
+    const pulsingElements = container.querySelectorAll('.animate-pulse');
+    expect(pulsingElements.length).toBeGreaterThan(0);
+  });
+
+  it('renders testimonial quotes and authors', () => {
+    const testimonials = createMockTestimonials(2);
+    render(<TestimonialsSection testimonials={testimonials} />);
+    // Quotes are rendered in marquee (duplicated), so check at least one instance
+    expect(screen.getAllByText(/Témoignage numéro 1/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Auteur 1/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders hover hint text', () => {
+    render(
+      <TestimonialsSection testimonials={createMockTestimonials()} hoverHint="Pause au survol" />
+    );
+    expect(screen.getByText('Pause au survol')).toBeInTheDocument();
+  });
+
+  it('sets tracking attributes', () => {
+    const { container } = render(
+      <TestimonialsSection testimonials={createMockTestimonials()} trackingName="Temoignages" />
+    );
+    const section = container.querySelector('[data-track-section="temoignages"]');
+    expect(section).toBeInTheDocument();
+  });
+
+  it('uses custom renderCard when provided', () => {
+    render(
+      <TestimonialsSection
+        testimonials={createMockTestimonials(1)}
+        renderCard={t => (
+          <div data-testid="custom-card" key={t.id}>
+            {t.quote}
+          </div>
+        )}
+      />
+    );
+    expect(screen.getAllByTestId('custom-card').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/ui/src/components/sections/blog-section.tsx
+++ b/packages/ui/src/components/sections/blog-section.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { cn } from '../../utils/cn';
+import { SectionTitle, type SectionTitleProps } from '../section-title';
+
+/**
+ * Blog post data for the section
+ */
+export interface BlogSectionPost {
+  /** URL slug */
+  slug: string;
+  /** Post title */
+  title: string;
+  /** Short description */
+  description?: string;
+  /** Category name */
+  category: string;
+  /** Publication date ISO string */
+  date: string;
+  /** Optional cover image URL */
+  image?: string;
+}
+
+/**
+ * Category color configuration
+ */
+export interface BlogCategoryColor {
+  /** Background color class */
+  bg: string;
+  /** Text color class */
+  text: string;
+  /** Gradient classes */
+  gradient: string;
+}
+
+/**
+ * Props for the BlogSection component
+ */
+export interface BlogSectionProps {
+  /** Blog posts to display */
+  posts: BlogSectionPost[];
+  /** Whether data is loading */
+  isLoading?: boolean;
+  /** Section title configuration */
+  title?: SectionTitleProps;
+  /** Category color mapping */
+  categoryColors?: Record<string, BlogCategoryColor>;
+  /** Default category colors when no match */
+  defaultCategoryColor?: BlogCategoryColor;
+  /** Locale for date formatting */
+  locale?: string;
+  /** Timezone for date formatting */
+  timezone?: string;
+  /** CTA label for "View all" button */
+  ctaLabel?: string;
+  /** CTA href for "View all" button */
+  ctaHref?: string;
+  /** "Read article" hover text */
+  readLabel?: string;
+  /** Custom link component (e.g., Next.js Link) */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  linkComponent?: React.ComponentType<any>;
+  /** Custom image component */
+  imageComponent?: React.ComponentType<{
+    src: string;
+    alt: string;
+    fill?: boolean;
+    unoptimized?: boolean;
+    className?: string;
+    sizes?: string;
+  }>;
+  /** Custom CTA button component */
+  ctaComponent?: ReactNode;
+  /** Analytics tracking section name */
+  trackingName?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Loading skeleton for blog section
+ */
+function BlogSkeleton() {
+  return (
+    <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+      <div className="mx-auto max-w-6xl space-y-12">
+        <div className="space-y-4">
+          <div className="bg-ivory/10 h-4 w-32 animate-pulse rounded" />
+          <div className="bg-ivory/10 h-8 w-80 max-w-full animate-pulse rounded" />
+          <div className="bg-ivory/10 h-4 w-full max-w-2xl animate-pulse rounded" />
+        </div>
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map(i => (
+            <div
+              key={i}
+              className="border-ivory/10 bg-night/50 relative flex h-72 flex-col overflow-hidden rounded-2xl border p-6"
+            >
+              <div className="bg-ivory/10 absolute bottom-0 left-0 top-0 w-1 animate-pulse" />
+              <div className="space-y-4 pl-2">
+                <div className="bg-ivory/10 h-6 w-24 animate-pulse rounded-full" />
+                <div className="bg-ivory/10 h-6 w-full animate-pulse rounded" />
+                <div className="space-y-2">
+                  <div className="bg-ivory/10 h-4 w-full animate-pulse rounded" />
+                  <div className="bg-ivory/10 h-4 w-3/4 animate-pulse rounded" />
+                </div>
+                <div className="bg-ivory/10 h-4 w-32 animate-pulse rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const DEFAULT_CATEGORY_COLOR: BlogCategoryColor = {
+  bg: 'bg-gold/20',
+  text: 'text-gold',
+  gradient: 'from-gold to-gold/60',
+};
+
+/**
+ * Blog section displaying a grid of blog post cards with category colors.
+ * Accepts data via props for framework-agnostic usage.
+ *
+ * @example
+ * ```tsx
+ * <BlogSection
+ *   posts={blogPosts}
+ *   title={{ eyebrow: "Blog", title: "Nos derniers articles" }}
+ *   categoryColors={{ "Tech": { bg: "bg-blue-500/20", text: "text-blue-300", gradient: "from-blue-500 to-blue-600" } }}
+ *   ctaLabel="Voir tous les articles"
+ *   ctaHref="/blog"
+ * />
+ * ```
+ */
+export function BlogSection({
+  posts,
+  isLoading = false,
+  title = { eyebrow: 'Blog', title: 'Nos derniers articles' },
+  categoryColors = {},
+  defaultCategoryColor = DEFAULT_CATEGORY_COLOR,
+  locale = 'fr-FR',
+  timezone = 'Europe/Paris',
+  ctaLabel = 'Découvrir tous les articles',
+  ctaHref = '/blog',
+  readLabel = "Lire l'article",
+  linkComponent: LinkComp,
+  ctaComponent,
+  trackingName = 'Blog',
+  className,
+}: BlogSectionProps) {
+  if (isLoading) {
+    return <BlogSkeleton />;
+  }
+
+  if (posts.length === 0) {
+    return null;
+  }
+
+  const Link =
+    LinkComp ??
+    (({
+      href,
+      className: lc,
+      children,
+    }: {
+      href: string;
+      className?: string;
+      children: ReactNode;
+    }) => (
+      <a href={href} className={lc}>
+        {children}
+      </a>
+    ));
+
+  return (
+    <section
+      id="blog"
+      className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}
+      data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
+      data-track-section-name={trackingName}
+    >
+      <div className="mx-auto max-w-6xl space-y-12">
+        <SectionTitle {...title} />
+
+        {/* Posts grid */}
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {posts.map(post => {
+            const colors = categoryColors[post.category] ?? defaultCategoryColor;
+            const formattedDate = new Date(post.date).toLocaleDateString(locale, {
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric',
+              timeZone: timezone,
+            });
+
+            return (
+              <article
+                key={post.slug}
+                className="border-ivory/10 bg-night/50 shadow-night/60 hover:border-ivory/20 hover:bg-night/70 group relative flex h-full flex-col overflow-hidden rounded-2xl border shadow-xl transition-all"
+              >
+                {/* Category color bar */}
+                <div
+                  className={cn(
+                    'absolute bottom-0 left-0 top-0 w-1 bg-gradient-to-b',
+                    colors.gradient
+                  )}
+                />
+
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="focus:ring-gold focus:ring-offset-night flex h-full flex-col focus:outline-none focus:ring-2 focus:ring-offset-2"
+                >
+                  <div className="flex flex-1 flex-col p-6 pl-8">
+                    {/* Category badge */}
+                    <div className="mb-3">
+                      <span
+                        className={cn(
+                          'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
+                          colors.bg,
+                          colors.text
+                        )}
+                      >
+                        <svg
+                          className="h-3 w-3"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                          />
+                        </svg>
+                        {post.category}
+                      </span>
+                    </div>
+
+                    {/* Title */}
+                    <h3 className="text-ivory group-hover:text-gold mb-3 text-xl font-semibold transition-colors">
+                      {post.title}
+                    </h3>
+
+                    {/* Description */}
+                    <p className="text-ivory/70 mb-4 line-clamp-3 flex-1 text-sm">
+                      {post.description}
+                    </p>
+
+                    {/* Date */}
+                    <div className="text-ivory/60 flex flex-wrap items-center gap-3 text-xs">
+                      <div className="flex items-center gap-1">
+                        <svg
+                          className="h-3.5 w-3.5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                          />
+                        </svg>
+                        <time dateTime={post.date}>{formattedDate}</time>
+                      </div>
+                    </div>
+
+                    {/* Read indicator */}
+                    <div className="text-gold mt-4 flex items-center gap-2 text-sm font-medium opacity-0 transition-opacity group-hover:opacity-100">
+                      <span>{readLabel}</span>
+                      <svg
+                        className="h-4 w-4 transition-transform group-hover:translate-x-1"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M14 5l7 7m0 0l-7 7m7-7H3"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+
+                  {/* Progress bar on hover */}
+                  <div className="from-gold to-gold/50 absolute bottom-0 left-0 h-1 w-full origin-left scale-x-0 bg-gradient-to-r transition-transform group-hover:scale-x-100" />
+                </Link>
+              </article>
+            );
+          })}
+        </div>
+
+        {/* CTA */}
+        {ctaComponent ? (
+          <div className="flex justify-center">{ctaComponent}</div>
+        ) : (
+          <div className="flex justify-center">
+            <Link
+              href={ctaHref}
+              className="border-gold/50 text-gold hover:border-gold hover:bg-gold/10 inline-flex items-center justify-center gap-2 rounded-lg border-2 bg-transparent px-7 py-3.5 text-sm font-medium tracking-wide backdrop-blur-sm transition-all duration-300"
+            >
+              {ctaLabel}
+            </Link>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/sections/contact-section.tsx
+++ b/packages/ui/src/components/sections/contact-section.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { cn } from '../../utils/cn';
+import { SectionTitle, type SectionTitleProps } from '../section-title';
+
+/**
+ * Props for the ContactSection component
+ */
+export interface ContactSectionProps {
+  /** Section title configuration */
+  title?: SectionTitleProps;
+  /** Contact form component to render */
+  contactForm: ReactNode;
+  /** Optional social links component to render below the form */
+  socialLinks?: ReactNode;
+  /** Social links label text */
+  socialLinksLabel?: string;
+  /** Analytics tracking section name */
+  trackingName?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Contact section with configurable form and social links.
+ * The form and social links are injected as children for maximum flexibility.
+ *
+ * @example
+ * ```tsx
+ * <ContactSection
+ *   title={{
+ *     eyebrow: "Contact",
+ *     title: "Contactez-nous",
+ *     description: "Nous vous répondons sous 48h.",
+ *   }}
+ *   contactForm={<ContactForm />}
+ *   socialLinks={<SocialLinks variant="stacked" />}
+ * />
+ * ```
+ */
+export function ContactSection({
+  title = {
+    eyebrow: 'Contact',
+    title: 'Contactez-nous',
+    description: 'Nous vous répondons dans les meilleurs délais.',
+  },
+  contactForm,
+  socialLinks,
+  socialLinksLabel = 'Suivez-nous sur les réseaux sociaux',
+  trackingName = 'Contact',
+  className,
+}: ContactSectionProps) {
+  return (
+    <section
+      id="contact"
+      className={cn('px-6 py-20 sm:px-10 lg:px-16', className)}
+      data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
+      data-track-section-name={trackingName}
+    >
+      <div className="mx-auto max-w-4xl space-y-12">
+        <SectionTitle {...title} />
+
+        <div className="border-ivory/10 bg-night/40 shadow-night/60 rounded-3xl border p-10 shadow-xl md:col-span-1">
+          {contactForm}
+        </div>
+
+        {socialLinks && (
+          <div className="mt-10 text-center">
+            <p className="text-ivory/60 mb-4 text-sm">{socialLinksLabel}</p>
+            {socialLinks}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/sections/index.ts
+++ b/packages/ui/src/components/sections/index.ts
@@ -1,0 +1,20 @@
+export {
+  TestimonialsSection,
+  type TestimonialsSectionProps,
+  type TestimonialSectionItem,
+} from './testimonials-section';
+
+export {
+  BlogSection,
+  type BlogSectionProps,
+  type BlogSectionPost,
+  type BlogCategoryColor,
+} from './blog-section';
+
+export { ContactSection, type ContactSectionProps } from './contact-section';
+
+export {
+  SeminarsSection,
+  type SeminarsSectionProps,
+  type SeminarSectionItem,
+} from './seminars-section';

--- a/packages/ui/src/components/sections/seminars-section.tsx
+++ b/packages/ui/src/components/sections/seminars-section.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { cn } from '../../utils/cn';
+import { SectionTitle, type SectionTitleProps } from '../section-title';
+
+/**
+ * Seminar data for the section
+ */
+export interface SeminarSectionItem {
+  /** Unique identifier */
+  id: string;
+  /** Seminar title */
+  title: string;
+  /** Seminar description */
+  description: string;
+  /** Start date ISO string */
+  startAt: string;
+  /** End date ISO string */
+  endAt: string;
+  /** Seminar type label */
+  seminarType?: string;
+  /** Number of available places */
+  capacity: number;
+  /** Optional thumbnail image URL */
+  thumbnail?: string | null;
+}
+
+/**
+ * Props for the SeminarsSection component
+ */
+export interface SeminarsSectionProps {
+  /** Seminar data to display */
+  seminars: SeminarSectionItem[];
+  /** Whether data is loading */
+  isLoading?: boolean;
+  /** Section title configuration */
+  title?: SectionTitleProps;
+  /** Empty state message */
+  emptyMessage?: string;
+  /** CTA label for registration button */
+  ctaLabel?: string;
+  /** CTA href for registration */
+  ctaHref?: string;
+  /** Custom CTA button component */
+  ctaComponent?: (seminar: SeminarSectionItem) => ReactNode;
+  /** Locale for date formatting */
+  locale?: string;
+  /** Timezone for date formatting */
+  timezone?: string;
+  /** "places" label */
+  placesLabel?: string;
+  /** Custom image component */
+  imageComponent?: React.ComponentType<{
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+    placeholder?: string;
+    blurDataURL?: string;
+    className?: string;
+  }>;
+  /** Analytics tracking section name */
+  trackingName?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Format seminar date range
+ */
+function formatSeminarDate(
+  startAt: string,
+  endAt: string,
+  locale: string,
+  timezone: string
+): string {
+  const start = new Date(startAt);
+  const end = new Date(endAt);
+  const options: Intl.DateTimeFormatOptions = {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: timezone,
+  };
+
+  if (start.toDateString() === end.toDateString()) {
+    return start.toLocaleDateString(locale, options);
+  }
+
+  const startStr = start.toLocaleDateString(locale, {
+    day: 'numeric',
+    month: 'long',
+    timeZone: timezone,
+  });
+  const endStr = end.toLocaleDateString(locale, options);
+  return `${startStr} - ${endStr}`;
+}
+
+/**
+ * Loading skeleton for seminars section
+ */
+function SeminarsSkeleton({ title }: { title: SectionTitleProps }) {
+  return (
+    <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+      <div className="mx-auto max-w-6xl space-y-12">
+        <SectionTitle {...title} />
+        <div className="grid gap-10 md:grid-cols-3">
+          {[1, 2, 3].map(i => (
+            <div
+              key={i}
+              className="border-ivory/10 bg-night/50 shadow-night/60 flex h-full animate-pulse flex-col overflow-hidden rounded-3xl border shadow-xl"
+            >
+              <div className="bg-night/80 aspect-[16/9] w-full" />
+              <div className="flex flex-1 flex-col justify-between space-y-4 p-6">
+                <div className="bg-ivory/10 h-6 w-3/4 rounded" />
+                <div className="space-y-2">
+                  <div className="bg-ivory/10 h-4 rounded" />
+                  <div className="bg-ivory/10 h-4 w-5/6 rounded" />
+                </div>
+                <div className="bg-ivory/10 mx-auto h-10 w-1/2 rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Seminars section displaying upcoming seminars in a responsive grid.
+ * Supports custom image and CTA components for framework flexibility.
+ *
+ * @example
+ * ```tsx
+ * <SeminarsSection
+ *   seminars={upcomingSeminars}
+ *   title={{
+ *     eyebrow: "Séminaires",
+ *     title: "Nos prochains événements",
+ *   }}
+ *   ctaLabel="Réserver"
+ *   ctaHref="/inscription"
+ * />
+ * ```
+ */
+export function SeminarsSection({
+  seminars,
+  isLoading = false,
+  title = { eyebrow: 'Séminaires', title: 'Nos prochains événements' },
+  emptyMessage = 'Aucun séminaire à venir pour le moment.',
+  ctaLabel = 'Réserver ma place',
+  ctaHref = '/inscription-seminaire',
+  ctaComponent,
+  locale = 'fr-FR',
+  timezone = 'Europe/Paris',
+  placesLabel = 'places',
+  imageComponent: ImageComp,
+  trackingName = 'Séminaires',
+  className,
+}: SeminarsSectionProps) {
+  if (isLoading) {
+    return <SeminarsSkeleton title={title} />;
+  }
+
+  return (
+    <section
+      id="seminaires"
+      className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}
+      data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
+      data-track-section-name={trackingName}
+    >
+      <div className="mx-auto max-w-6xl space-y-12">
+        <SectionTitle {...title} />
+        <div className="grid gap-10 md:grid-cols-3">
+          {seminars.length > 0 ? (
+            seminars.map(seminar => (
+              <article
+                key={seminar.id}
+                className="border-ivory/10 bg-night/50 shadow-night/60 group flex h-full flex-col overflow-hidden rounded-3xl border shadow-xl"
+              >
+                <div className="from-night/80 to-night/40 relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br">
+                  {seminar.thumbnail && ImageComp ? (
+                    <ImageComp
+                      src={seminar.thumbnail}
+                      alt={seminar.title}
+                      width={640}
+                      height={360}
+                      className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                  ) : seminar.thumbnail ? (
+                    <img
+                      src={seminar.thumbnail}
+                      alt={seminar.title}
+                      className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                  ) : (
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <svg
+                        className="text-ivory/10 h-16 w-16"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={1}
+                          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                        />
+                      </svg>
+                    </div>
+                  )}
+                  {seminar.seminarType && (
+                    <span className="bg-gold/90 text-night absolute left-4 top-4 rounded-full px-3 py-1 text-xs font-semibold backdrop-blur-sm">
+                      {seminar.seminarType}
+                    </span>
+                  )}
+                </div>
+
+                <div className="flex flex-1 flex-col justify-between p-6">
+                  <div>
+                    <h3 className="text-ivory text-xl font-semibold">{seminar.title}</h3>
+                    <p className="text-ivory/70 mt-3 line-clamp-3 text-sm">{seminar.description}</p>
+                  </div>
+
+                  <dl className="text-ivory/60 mt-5 space-y-2 text-sm">
+                    <div className="flex items-center gap-2">
+                      <svg
+                        className="text-gold h-4 w-4 flex-shrink-0"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                        />
+                      </svg>
+                      <span>
+                        {formatSeminarDate(seminar.startAt, seminar.endAt, locale, timezone)}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <svg
+                        className="text-gold h-4 w-4 flex-shrink-0"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                        />
+                      </svg>
+                      <span>
+                        {seminar.capacity} {placesLabel}
+                      </span>
+                    </div>
+                  </dl>
+
+                  <div className="mt-6 flex justify-center">
+                    {ctaComponent ? (
+                      ctaComponent(seminar)
+                    ) : (
+                      <a
+                        href={ctaHref}
+                        className="bg-gold text-night hover:shadow-gold/25 inline-flex items-center justify-center gap-2 rounded-lg px-7 py-3.5 text-sm font-medium tracking-wide shadow-md transition-all duration-300 hover:shadow-lg"
+                      >
+                        {ctaLabel}
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </article>
+            ))
+          ) : (
+            <div className="border-ivory/10 bg-night/40 text-ivory/60 rounded-3xl border p-8 text-center text-sm md:col-span-3">
+              {emptyMessage}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/sections/testimonials-section.tsx
+++ b/packages/ui/src/components/sections/testimonials-section.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { cn } from '../../utils/cn';
+import { Marquee } from '../marquee';
+import { SectionTitle, type SectionTitleProps } from '../section-title';
+
+/**
+ * Testimonial data for the section
+ */
+export interface TestimonialSectionItem {
+  /** Unique identifier */
+  id: string;
+  /** Testimonial quote text */
+  quote: string;
+  /** Author name */
+  author: string;
+}
+
+/**
+ * Props for the TestimonialsSection component
+ */
+export interface TestimonialsSectionProps {
+  /** Testimonial data to display */
+  testimonials: TestimonialSectionItem[];
+  /** Whether data is still loading */
+  isLoading?: boolean;
+  /** Section title configuration */
+  title?: SectionTitleProps;
+  /** Custom card render function */
+  renderCard?: (testimonial: TestimonialSectionItem) => ReactNode;
+  /** Hint text shown below the marquee */
+  hoverHint?: string;
+  /** Empty state message */
+  emptyMessage?: string;
+  /** Analytics tracking section name */
+  trackingName?: string;
+  /** Additional CSS classes for the section */
+  className?: string;
+  /** Top row marquee speed in seconds */
+  topRowSpeed?: number;
+  /** Bottom row marquee speed in seconds */
+  bottomRowSpeed?: number;
+  /** Custom colors */
+  colors?: {
+    /** Card border color */
+    cardBorder?: string;
+    /** Card background */
+    cardBg?: string;
+    /** Card accent color */
+    accent?: string;
+    /** Quote text color */
+    quoteText?: string;
+    /** Author text color */
+    authorText?: string;
+  };
+}
+
+/**
+ * Default compact testimonial card for the marquee
+ */
+function DefaultTestimonialCard({
+  quote,
+  author,
+  colors = {},
+}: {
+  quote: string;
+  author: string;
+  colors?: TestimonialsSectionProps['colors'];
+}) {
+  const {
+    cardBorder = 'border-ivory/[0.08]',
+    cardBg = 'from-ivory/[0.04]',
+    accent = 'from-gold/60',
+    quoteText = 'text-ivory/75 group-hover:text-ivory/90',
+    authorText = 'text-gold/80',
+  } = colors;
+
+  return (
+    <article
+      className={cn(
+        'group relative flex w-[320px] shrink-0 flex-col gap-4 rounded-2xl border bg-gradient-to-br to-transparent p-6 backdrop-blur-sm transition-all duration-300 sm:w-[380px]',
+        cardBorder,
+        cardBg,
+        `hover:bg-ivory/[0.06]`
+      )}
+    >
+      {/* Subtle accent line */}
+      <div
+        className={cn('absolute left-6 top-0 h-px w-12 bg-gradient-to-r to-transparent', accent)}
+      />
+
+      {/* Quote */}
+      <p className={cn('text-[15px] leading-relaxed transition-colors duration-300', quoteText)}>
+        &ldquo;{quote}&rdquo;
+      </p>
+
+      {/* Author with decorative dash */}
+      <div className="flex items-center gap-2">
+        <span className="bg-gold/40 h-px w-4" />
+        <span className={cn('text-sm font-medium', authorText)}>{author}</span>
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Loading skeleton for the testimonials section
+ */
+function TestimonialsSkeleton() {
+  return (
+    <section className="bg-night/60 overflow-hidden py-20">
+      <div className="mx-auto max-w-6xl space-y-10 px-6 sm:px-10 lg:px-16">
+        <div className="space-y-4">
+          <div className="bg-ivory/10 h-4 w-24 animate-pulse rounded" />
+          <div className="bg-ivory/10 h-8 w-80 max-w-full animate-pulse rounded" />
+        </div>
+      </div>
+      <div className="mt-12 space-y-4">
+        {[1, 2].map(row => (
+          <div key={row} className="flex gap-4 overflow-hidden px-4 sm:gap-6">
+            {[1, 2, 3, 4].map(i => (
+              <div
+                key={i}
+                className="border-ivory/[0.08] bg-ivory/[0.02] w-[320px] shrink-0 rounded-2xl border p-6 sm:w-[380px]"
+              >
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <div className="bg-ivory/10 h-4 w-full animate-pulse rounded" />
+                    <div className="bg-ivory/10 h-4 w-4/5 animate-pulse rounded" />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="bg-ivory/10 h-px w-4" />
+                    <div className="bg-ivory/10 h-3 w-16 animate-pulse rounded" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <p className="text-ivory/40 mt-8 text-center text-xs">Survolez pour mettre en pause</p>
+    </section>
+  );
+}
+
+/**
+ * Testimonials section with dual-direction infinite marquee.
+ * Two rows scrolling in opposite directions create visual interest.
+ * Supports reduced motion for accessibility.
+ *
+ * @example
+ * ```tsx
+ * <TestimonialsSection
+ *   testimonials={data}
+ *   title={{
+ *     eyebrow: "Témoignages",
+ *     title: "Ce que disent nos clients",
+ *   }}
+ * />
+ * ```
+ */
+export function TestimonialsSection({
+  testimonials,
+  isLoading = false,
+  title = { eyebrow: 'Témoignages', title: 'Ce que disent nos clients' },
+  renderCard,
+  hoverHint = 'Survolez pour mettre en pause',
+  emptyMessage = 'Aucun témoignage pour le moment.',
+  trackingName = 'Témoignages',
+  className,
+  topRowSpeed = 35,
+  bottomRowSpeed = 30,
+  colors = {},
+}: TestimonialsSectionProps) {
+  if (isLoading) {
+    return <TestimonialsSkeleton />;
+  }
+
+  // Split testimonials into two rows
+  const shouldShowAllOnBothRows = testimonials.length <= 10;
+  const topRow = shouldShowAllOnBothRows
+    ? testimonials
+    : testimonials.slice(0, Math.ceil(testimonials.length / 2));
+  const bottomRow = shouldShowAllOnBothRows
+    ? [...testimonials].reverse()
+    : testimonials.slice(Math.ceil(testimonials.length / 2));
+
+  // Empty state
+  if (testimonials.length === 0) {
+    return (
+      <section className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}>
+        <div className="mx-auto max-w-6xl space-y-12">
+          <SectionTitle {...title} />
+          <div className="border-ivory/10 bg-ivory/[0.02] text-ivory/60 rounded-2xl border p-8 text-center text-sm">
+            {emptyMessage}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const cardRenderer =
+    renderCard ??
+    ((t: TestimonialSectionItem) => (
+      <DefaultTestimonialCard key={t.id} quote={t.quote} author={t.author} colors={colors} />
+    ));
+
+  return (
+    <section
+      className={cn('bg-night/60 overflow-hidden py-20', className)}
+      data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
+      data-track-section-name={trackingName}
+    >
+      {/* Title */}
+      <div className="mx-auto max-w-6xl px-6 sm:px-10 lg:px-16">
+        <SectionTitle {...title} />
+      </div>
+
+      {/* Marquee rows */}
+      <div className="mt-12 space-y-4 sm:space-y-6">
+        <Marquee direction="left" speed={topRowSpeed}>
+          {topRow.map(t => cardRenderer(t))}
+        </Marquee>
+
+        {bottomRow.length > 0 && (
+          <Marquee direction="right" speed={bottomRowSpeed}>
+            {bottomRow.map(t => cardRenderer(t))}
+          </Marquee>
+        )}
+      </div>
+
+      {/* Hover hint */}
+      {hoverHint && <p className="text-ivory/40 mt-8 text-center text-xs">{hoverHint}</p>}
+    </section>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -142,6 +142,26 @@ export {
 
 // Typography Components
 export { PageTitle, type PageTitleProps } from './components/page-title';
+export { SectionTitle, type SectionTitleProps } from './components/section-title';
+
+// Marquee
+export { Marquee, type MarqueeProps } from './components/marquee';
+
+// Page Sections
+export {
+  TestimonialsSection,
+  type TestimonialsSectionProps,
+  type TestimonialSectionItem,
+  BlogSection,
+  type BlogSectionProps,
+  type BlogSectionPost,
+  type BlogCategoryColor,
+  ContactSection,
+  type ContactSectionProps,
+  SeminarsSection,
+  type SeminarsSectionProps,
+  type SeminarSectionItem,
+} from './components/sections';
 
 // Floating Contact Button
 export {


### PR DESCRIPTION
## Résumé

Extrait les sections génériques des pages publiques de Psypnos vers `@kairn/ui` pour permettre leur réutilisation par d'autres sites.

- Crée 6 nouveaux composants dans `@kairn/ui` : `SectionTitle`, `Marquee`, `TestimonialsSection`, `BlogSection`, `ContactSection`, `SeminarsSection`
- Convertit les sections de Psypnos en wrappers minces fournissant données et config spécifiques
- Ajoute 34 tests unitaires couvrant tous les cas

## Validation

| Étape | Statut |
|---|---|
| Lint | OK |
| Type-check | OK |
| Tests UI | 168/168 (34 nouveaux) |
| Tests coverage | 1076/1076 |
| Build | OK |

Fixes #308

https://claude.ai/code/session_01JVsYj9wFSYPUo2s51nLxB2