### PR TITLE
fix(admin): corriger les composants non responsive sur mobile

### DIFF
--- a/apps/psypnos/app/admin/social/_components/SocialInsights.tsx
+++ b/apps/psypnos/app/admin/social/_components/SocialInsights.tsx
@@ -467,7 +467,7 @@ export function SocialInsights({ posts, analytics, isCompact = false }: SocialIn
 
       {/* Analytics Breakdown */}
       {analytics && (
-        <div className="grid grid-cols-3 gap-3 sm:grid-cols-6">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
           <div className="border-gold/10 bg-night/20 rounded-lg border p-3 text-center">
             <Eye className="text-gold/70 mx-auto mb-1 h-4 w-4" />
             <p className="text-ivory text-lg font-semibold">

--- a/apps/psypnos/components/analytics/v2/CommandCenter.tsx
+++ b/apps/psypnos/components/analytics/v2/CommandCenter.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { RefreshCw, Settings, Bell, Download, Beaker, Users, Target, Clock } from "lucide-react";
-import { useState } from "react";
+import { motion } from 'framer-motion';
+import { RefreshCw, Settings, Bell, Download, Beaker, Users, Target, Clock } from 'lucide-react';
+import { useState } from 'react';
 
 interface KPIData {
   visitors: number;
@@ -54,24 +54,24 @@ export function CommandCenter({
   const getHealthConfig = (score: number) => {
     if (score >= 70) {
       return {
-        color: "text-green-400",
-        bgColor: "bg-green-500/20",
-        borderColor: "border-green-500/30",
-        label: "Excellente",
+        color: 'text-green-400',
+        bgColor: 'bg-green-500/20',
+        borderColor: 'border-green-500/30',
+        label: 'Excellente',
       };
     } else if (score >= 40) {
       return {
-        color: "text-yellow-400",
-        bgColor: "bg-yellow-500/20",
-        borderColor: "border-yellow-500/30",
-        label: "Correcte",
+        color: 'text-yellow-400',
+        bgColor: 'bg-yellow-500/20',
+        borderColor: 'border-yellow-500/30',
+        label: 'Correcte',
       };
     } else {
       return {
-        color: "text-red-400",
-        bgColor: "bg-red-500/20",
-        borderColor: "border-red-500/30",
-        label: "Attention",
+        color: 'text-red-400',
+        bgColor: 'bg-red-500/20',
+        borderColor: 'border-red-500/30',
+        label: 'Attention',
       };
     }
   };
@@ -82,28 +82,26 @@ export function CommandCenter({
   const formatDuration = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
-    return `${mins}:${secs.toString().padStart(2, "0")}`;
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="sticky top-0 z-40 -mx-4 px-4 py-3 backdrop-blur-xl bg-night/95 border-b border-gold/10"
+      className="bg-night/95 border-gold/10 sticky top-0 z-40 -mx-4 border-b px-4 py-3 backdrop-blur-xl"
     >
       {/* Row 1: Controls - Period, Simulation, Actions */}
-      <div className="flex items-center justify-between gap-2 mb-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
         {/* Left: Health Score Compact */}
         <div className="flex items-center gap-2">
           <div
-            className={`relative w-10 h-10 ${healthConfig.bgColor} ${healthConfig.borderColor} border rounded-full flex items-center justify-center`}
+            className={`relative h-10 w-10 ${healthConfig.bgColor} ${healthConfig.borderColor} flex items-center justify-center rounded-full border`}
           >
-            <span className={`text-sm font-bold ${healthConfig.color}`}>
-              {healthScore}
-            </span>
+            <span className={`text-sm font-bold ${healthConfig.color}`}>{healthScore}</span>
             {isRealtime && (
               <motion.div
-                className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-green-500 rounded-full"
+                className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-green-500"
                 animate={{ scale: [1, 1.2, 1] }}
                 transition={{ duration: 2, repeat: Infinity }}
               />
@@ -117,31 +115,29 @@ export function CommandCenter({
         {/* Right: All Controls */}
         <div className="flex items-center gap-2">
           {/* Period Selector */}
-          <div className="relative z-50">
-            {children}
-          </div>
+          <div className="relative z-50">{children}</div>
 
           {/* Simulation Toggle */}
           {onSimulationToggle && (
             <motion.button
               onClick={onSimulationToggle}
-              className={`flex items-center gap-1.5 px-2 py-1.5 rounded-lg border transition-all ${
+              className={`flex items-center gap-1.5 rounded-lg border px-2 py-1.5 transition-all ${
                 isSimulationMode
-                  ? "border-purple-500/50 bg-purple-500/20 text-purple-400"
-                  : "border-gold/30 bg-gold/5 text-ivory/60 hover:text-gold"
+                  ? 'border-purple-500/50 bg-purple-500/20 text-purple-400'
+                  : 'border-gold/30 bg-gold/5 text-ivory/60 hover:text-gold'
               }`}
               whileTap={{ scale: 0.95 }}
             >
               <Beaker size={14} />
               <div
-                className={`w-6 h-3 rounded-full transition-colors ${
-                  isSimulationMode ? "bg-purple-500" : "bg-ivory/20"
+                className={`h-3 w-6 rounded-full transition-colors ${
+                  isSimulationMode ? 'bg-purple-500' : 'bg-ivory/20'
                 }`}
               >
                 <motion.div
-                  className="w-2.5 h-2.5 mt-[1px] bg-white rounded-full shadow-sm"
-                  animate={{ marginLeft: isSimulationMode ? "12px" : "1px" }}
-                  transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                  className="mt-[1px] h-2.5 w-2.5 rounded-full bg-white shadow-sm"
+                  animate={{ marginLeft: isSimulationMode ? '12px' : '1px' }}
+                  transition={{ type: 'spring', stiffness: 500, damping: 30 }}
                 />
               </div>
             </motion.button>
@@ -151,23 +147,23 @@ export function CommandCenter({
           <motion.button
             onClick={handleRefresh}
             disabled={isRefreshing}
-            className="p-2 rounded-lg border border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 transition-colors disabled:opacity-50"
+            className="border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 rounded-lg border p-2 transition-colors disabled:opacity-50"
             whileTap={{ scale: 0.95 }}
           >
-            <RefreshCw size={16} className={isRefreshing ? "animate-spin" : ""} />
+            <RefreshCw size={16} className={isRefreshing ? 'animate-spin' : ''} />
           </motion.button>
 
           {/* Alerts */}
           {onAlertsClick && (
             <motion.button
               onClick={onAlertsClick}
-              className="relative p-2 rounded-lg border border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 transition-colors"
+              className="border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 relative rounded-lg border p-2 transition-colors"
               whileTap={{ scale: 0.95 }}
             >
               <Bell size={16} />
               {alertCount > 0 && (
-                <span className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center">
-                  {alertCount > 9 ? "9+" : alertCount}
+                <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
+                  {alertCount > 9 ? '9+' : alertCount}
                 </span>
               )}
             </motion.button>
@@ -177,7 +173,7 @@ export function CommandCenter({
           {onExportClick && (
             <motion.button
               onClick={onExportClick}
-              className="hidden sm:flex items-center gap-1.5 px-2 py-2 rounded-lg border border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 transition-colors"
+              className="border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 hidden items-center gap-1.5 rounded-lg border px-2 py-2 transition-colors sm:flex"
               whileTap={{ scale: 0.95 }}
             >
               <Download size={16} />
@@ -189,7 +185,7 @@ export function CommandCenter({
           {onSettingsClick && (
             <motion.button
               onClick={onSettingsClick}
-              className="p-2 rounded-lg border border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 transition-colors"
+              className="border-gold/30 bg-gold/5 text-gold hover:bg-gold/10 rounded-lg border p-2 transition-colors"
               whileTap={{ scale: 0.95 }}
             >
               <Settings size={16} />
@@ -199,32 +195,34 @@ export function CommandCenter({
       </div>
 
       {/* Row 2: KPIs - Full width, clearly separated */}
-      <div className="grid grid-cols-3 gap-2 sm:gap-3">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3">
         {/* Visitors */}
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.1 }}
-          className="p-2.5 sm:p-3 rounded-xl bg-gradient-to-br from-blue-500/15 to-blue-500/5 border border-blue-500/30"
+          className="rounded-xl border border-blue-500/30 bg-gradient-to-br from-blue-500/15 to-blue-500/5 p-2.5 sm:p-3"
         >
-          <div className="flex items-center gap-1.5 mb-1">
+          <div className="mb-1 flex items-center gap-1.5">
             <Users size={12} className="text-blue-400" />
-            <span className="text-[10px] sm:text-xs text-blue-300 font-medium uppercase tracking-wide">
+            <span className="text-[10px] font-medium uppercase tracking-wide text-blue-300 sm:text-xs">
               Visiteurs
             </span>
           </div>
-          <div className="text-lg sm:text-2xl font-bold text-ivory">
+          <div className="text-ivory text-lg font-bold sm:text-2xl">
             {isLoading ? (
-              <span className="inline-block w-12 h-6 bg-blue-400/20 animate-pulse rounded" />
+              <span className="inline-block h-6 w-12 animate-pulse rounded bg-blue-400/20" />
             ) : (
-              kpis.visitors.toLocaleString("fr-FR")
+              kpis.visitors.toLocaleString('fr-FR')
             )}
           </div>
           {!isLoading && (
-            <div className={`text-[10px] sm:text-xs font-medium ${
-              kpis.visitorsChange >= 0 ? "text-green-400" : "text-red-400"
-            }`}>
-              {kpis.visitorsChange >= 0 ? "↑" : "↓"} {Math.abs(kpis.visitorsChange).toFixed(1)}%
+            <div
+              className={`text-[10px] font-medium sm:text-xs ${
+                kpis.visitorsChange >= 0 ? 'text-green-400' : 'text-red-400'
+              }`}
+            >
+              {kpis.visitorsChange >= 0 ? '↑' : '↓'} {Math.abs(kpis.visitorsChange).toFixed(1)}%
             </div>
           )}
         </motion.div>
@@ -234,26 +232,29 @@ export function CommandCenter({
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2 }}
-          className="p-2.5 sm:p-3 rounded-xl bg-gradient-to-br from-gold/15 to-gold/5 border border-gold/30"
+          className="from-gold/15 to-gold/5 border-gold/30 rounded-xl border bg-gradient-to-br p-2.5 sm:p-3"
         >
-          <div className="flex items-center gap-1.5 mb-1">
+          <div className="mb-1 flex items-center gap-1.5">
             <Target size={12} className="text-gold" />
-            <span className="text-[10px] sm:text-xs text-gold/90 font-medium uppercase tracking-wide">
+            <span className="text-gold/90 text-[10px] font-medium uppercase tracking-wide sm:text-xs">
               Conversion
             </span>
           </div>
-          <div className="text-lg sm:text-2xl font-bold text-ivory">
+          <div className="text-ivory text-lg font-bold sm:text-2xl">
             {isLoading ? (
-              <span className="inline-block w-10 h-6 bg-gold/20 animate-pulse rounded" />
+              <span className="bg-gold/20 inline-block h-6 w-10 animate-pulse rounded" />
             ) : (
               `${kpis.conversionRate.toFixed(1)}%`
             )}
           </div>
           {!isLoading && (
-            <div className={`text-[10px] sm:text-xs font-medium ${
-              kpis.conversionChange >= 0 ? "text-green-400" : "text-red-400"
-            }`}>
-              {kpis.conversionChange >= 0 ? "↑" : "↓"} {Math.abs(kpis.conversionChange).toFixed(1)} pts
+            <div
+              className={`text-[10px] font-medium sm:text-xs ${
+                kpis.conversionChange >= 0 ? 'text-green-400' : 'text-red-400'
+              }`}
+            >
+              {kpis.conversionChange >= 0 ? '↑' : '↓'} {Math.abs(kpis.conversionChange).toFixed(1)}{' '}
+              pts
             </div>
           )}
         </motion.div>
@@ -263,26 +264,28 @@ export function CommandCenter({
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3 }}
-          className="p-2.5 sm:p-3 rounded-xl bg-gradient-to-br from-purple-500/15 to-purple-500/5 border border-purple-500/30"
+          className="rounded-xl border border-purple-500/30 bg-gradient-to-br from-purple-500/15 to-purple-500/5 p-2.5 sm:p-3"
         >
-          <div className="flex items-center gap-1.5 mb-1">
+          <div className="mb-1 flex items-center gap-1.5">
             <Clock size={12} className="text-purple-400" />
-            <span className="text-[10px] sm:text-xs text-purple-300 font-medium uppercase tracking-wide">
+            <span className="text-[10px] font-medium uppercase tracking-wide text-purple-300 sm:text-xs">
               Durée moy.
             </span>
           </div>
-          <div className="text-lg sm:text-2xl font-bold text-ivory">
+          <div className="text-ivory text-lg font-bold sm:text-2xl">
             {isLoading ? (
-              <span className="inline-block w-10 h-6 bg-purple-400/20 animate-pulse rounded" />
+              <span className="inline-block h-6 w-10 animate-pulse rounded bg-purple-400/20" />
             ) : (
               formatDuration(kpis.avgDuration)
             )}
           </div>
           {!isLoading && (
-            <div className={`text-[10px] sm:text-xs font-medium ${
-              kpis.durationChange >= 0 ? "text-green-400" : "text-red-400"
-            }`}>
-              {kpis.durationChange >= 0 ? "↑" : "↓"} {Math.abs(kpis.durationChange)}s
+            <div
+              className={`text-[10px] font-medium sm:text-xs ${
+                kpis.durationChange >= 0 ? 'text-green-400' : 'text-red-400'
+              }`}
+            >
+              {kpis.durationChange >= 0 ? '↑' : '↓'} {Math.abs(kpis.durationChange)}s
             </div>
           )}
         </motion.div>

--- a/apps/psypnos/components/analytics/v2/panels/BlogPanel.tsx
+++ b/apps/psypnos/components/analytics/v2/panels/BlogPanel.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-
 import { motion } from 'framer-motion';
 import {
   Eye,
@@ -17,6 +15,7 @@ import {
   ChevronUp,
   ChevronDown,
 } from 'lucide-react';
+import { useState, useMemo } from 'react';
 
 export interface BlogArticleStats {
   slug: string;
@@ -348,42 +347,44 @@ export function BlogPanel({ data, isLoading = false }: BlogPanelProps) {
           </div>
         ) : (
           <div className="-mx-4 overflow-x-auto sm:mx-0">
-            <table className="w-full min-w-[640px] text-sm">
+            <table className="w-full min-w-[400px] text-sm">
               <thead>
                 <tr className="border-gold/20 border-b">
-                  <th className="text-ivory/70 px-4 py-3 text-left font-semibold">#</th>
+                  <th className="text-ivory/70 px-3 py-3 text-left font-semibold sm:px-4">#</th>
                   <th
-                    className="text-ivory/70 hover:text-gold cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors"
+                    className="text-ivory/70 hover:text-gold cursor-pointer select-none px-3 py-3 text-center font-semibold transition-colors sm:px-4"
                     onClick={() => handleSort('score')}
                   >
                     Score <SortIcon column="score" />
                   </th>
-                  <th className="text-ivory/70 px-4 py-3 text-left font-semibold">Article</th>
+                  <th className="text-ivory/70 px-3 py-3 text-left font-semibold sm:px-4">
+                    Article
+                  </th>
                   <th
-                    className="text-ivory/70 hover:text-gold cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors"
+                    className="text-ivory/70 hover:text-gold cursor-pointer select-none px-3 py-3 text-center font-semibold transition-colors sm:px-4"
                     onClick={() => handleSort('views')}
                   >
                     Vues <SortIcon column="views" />
                   </th>
                   <th
-                    className="text-ivory/70 hover:text-gold cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors"
+                    className="text-ivory/70 hover:text-gold hidden cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors sm:table-cell"
                     onClick={() => handleSort('uniqueVisitors')}
                   >
                     Visiteurs <SortIcon column="uniqueVisitors" />
                   </th>
                   <th
-                    className="text-ivory/70 hover:text-gold cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors"
+                    className="text-ivory/70 hover:text-gold hidden cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors md:table-cell"
                     onClick={() => handleSort('avgTimeOnPage')}
                   >
                     Durée moy. <SortIcon column="avgTimeOnPage" />
                   </th>
                   <th
-                    className="text-ivory/70 hover:text-gold cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors"
+                    className="text-ivory/70 hover:text-gold hidden cursor-pointer select-none px-4 py-3 text-center font-semibold transition-colors md:table-cell"
                     onClick={() => handleSort('avgScrollDepth')}
                   >
                     % Lecture <SortIcon column="avgScrollDepth" />
                   </th>
-                  <th className="text-ivory/70 px-4 py-3 text-left font-semibold">
+                  <th className="text-ivory/70 hidden px-4 py-3 text-left font-semibold lg:table-cell">
                     Dernière visite
                   </th>
                 </tr>
@@ -397,7 +398,7 @@ export function BlogPanel({ data, isLoading = false }: BlogPanelProps) {
                     transition={{ delay: index * 0.03 }}
                     className="border-gold/10 hover:bg-ivory/5 border-b transition-colors"
                   >
-                    <td className="px-4 py-3">
+                    <td className="px-3 py-3 sm:px-4">
                       <span
                         className={`inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold ${
                           index === 0
@@ -412,24 +413,24 @@ export function BlogPanel({ data, isLoading = false }: BlogPanelProps) {
                         {index + 1}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="px-3 py-3 text-center sm:px-4">
                       <div className="flex items-center justify-center gap-1">
                         <Trophy size={14} className="text-gold/60" />
                         <span className="text-gold font-bold">{article.score}</span>
                       </div>
                     </td>
-                    <td className="px-4 py-3">
+                    <td className="px-3 py-3 sm:px-4">
                       <a
                         href={`/blog/${article.slug}`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-ivory hover:text-gold block max-w-[200px] truncate font-medium transition-colors"
+                        className="text-ivory hover:text-gold block max-w-[120px] truncate font-medium transition-colors sm:max-w-[200px]"
                         title={article.title || article.slug}
                       >
                         {article.title || article.slug}
                       </a>
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="px-3 py-3 text-center sm:px-4">
                       <div className="flex items-center justify-center gap-1.5">
                         <Eye size={14} className="text-gold/60" />
                         <span className="text-ivory font-semibold">
@@ -437,7 +438,7 @@ export function BlogPanel({ data, isLoading = false }: BlogPanelProps) {
                         </span>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="hidden px-4 py-3 text-center sm:table-cell">
                       <div className="flex items-center justify-center gap-1.5">
                         <Users size={14} className="text-blue-400/60" />
                         <span className="text-ivory/80">
@@ -445,7 +446,7 @@ export function BlogPanel({ data, isLoading = false }: BlogPanelProps) {
                         </span>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="hidden px-4 py-3 text-center md:table-cell">
                       <div className="flex items-center justify-center gap-1.5">
                         <Clock size={14} className="text-green-400/60" />
                         <span className="text-ivory/80">
@@ -453,7 +454,7 @@ export function BlogPanel({ data, isLoading = false }: BlogPanelProps) {
                         </span>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="hidden px-4 py-3 text-center md:table-cell">
                       {article.avgScrollDepth !== null ? (
                         <div className="flex items-center justify-center gap-2">
                           <div className="bg-night/40 h-1.5 w-12 overflow-hidden rounded-full">
@@ -468,7 +469,7 @@ export function BlogPanel({ data, isLoading = false }: BlogPanelProps) {
                         <span className="text-ivory/40">—</span>
                       )}
                     </td>
-                    <td className="text-ivory/60 px-4 py-3 text-xs">
+                    <td className="text-ivory/60 hidden px-4 py-3 text-xs lg:table-cell">
                       {formatDate(article.lastViewed)}
                     </td>
                   </motion.tr>

--- a/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
+++ b/apps/psypnos/components/analytics/v2/panels/PostsPanel.tsx
@@ -644,25 +644,37 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
           </div>
         ) : (
           <div className="-mx-4 overflow-x-auto sm:mx-0">
-            <table className="w-full min-w-[800px] text-sm">
+            <table className="w-full min-w-[480px] text-sm">
               <thead>
                 <tr className="border-gold/20 border-b">
-                  <th className="text-ivory/70 px-4 py-3 text-left font-semibold">#</th>
-                  <th className="text-ivory/70 px-4 py-3 text-left font-semibold">Plateforme</th>
-                  <th className="text-ivory/70 px-4 py-3 text-left font-semibold">Contenu</th>
-                  <th className="text-ivory/70 px-4 py-3 text-center font-semibold">Type</th>
-                  <th className="text-ivory/70 px-4 py-3 text-center font-semibold">Portée</th>
-                  <th className="text-ivory/70 px-4 py-3 text-center font-semibold">
+                  <th className="text-ivory/70 px-3 py-3 text-left font-semibold sm:px-4">#</th>
+                  <th className="text-ivory/70 px-3 py-3 text-left font-semibold sm:px-4">
+                    Plateforme
+                  </th>
+                  <th className="text-ivory/70 px-3 py-3 text-left font-semibold sm:px-4">
+                    Contenu
+                  </th>
+                  <th className="text-ivory/70 hidden px-4 py-3 text-center font-semibold md:table-cell">
+                    Type
+                  </th>
+                  <th className="text-ivory/70 px-3 py-3 text-center font-semibold sm:px-4">
+                    Portée
+                  </th>
+                  <th className="text-ivory/70 px-3 py-3 text-center font-semibold sm:px-4">
                     <Heart size={14} className="inline text-pink-400" />
                   </th>
-                  <th className="text-ivory/70 px-4 py-3 text-center font-semibold">
+                  <th className="text-ivory/70 hidden px-4 py-3 text-center font-semibold sm:table-cell">
                     <MessageCircle size={14} className="inline text-blue-400" />
                   </th>
-                  <th className="text-ivory/70 px-4 py-3 text-center font-semibold">
+                  <th className="text-ivory/70 hidden px-4 py-3 text-center font-semibold sm:table-cell">
                     <Repeat2 size={14} className="inline text-green-400" />
                   </th>
-                  <th className="text-ivory/70 px-4 py-3 text-center font-semibold">Taux</th>
-                  <th className="text-ivory/70 px-4 py-3 text-left font-semibold">Date</th>
+                  <th className="text-ivory/70 px-3 py-3 text-center font-semibold sm:px-4">
+                    Taux
+                  </th>
+                  <th className="text-ivory/70 hidden px-4 py-3 text-left font-semibold lg:table-cell">
+                    Date
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -697,33 +709,36 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
                         <PlatformIcon platform={post.platform} size={16} className="text-white" />
                       </div>
                     </td>
-                    <td className="px-4 py-3">
-                      <p className="text-ivory max-w-[200px] truncate text-sm" title={post.content}>
+                    <td className="px-3 py-3 sm:px-4">
+                      <p
+                        className="text-ivory max-w-[120px] truncate text-sm sm:max-w-[200px]"
+                        title={post.content}
+                      >
                         {truncateText(post.content, 50)}
                       </p>
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="hidden px-4 py-3 text-center md:table-cell">
                       <div className="flex items-center justify-center gap-1">
                         <PostTypeIcon type={post.type} />
                         <span className="text-ivory/60 text-xs capitalize">{post.type}</span>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="px-3 py-3 text-center sm:px-4">
                       <div className="flex items-center justify-center gap-1">
                         <Eye size={14} className="text-blue-400/60" />
                         <span className="text-ivory font-semibold">{formatNumber(post.reach)}</span>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-center font-medium text-pink-400">
+                    <td className="px-3 py-3 text-center font-medium text-pink-400 sm:px-4">
                       {formatNumber(post.likes)}
                     </td>
-                    <td className="px-4 py-3 text-center font-medium text-blue-400">
+                    <td className="hidden px-4 py-3 text-center font-medium text-blue-400 sm:table-cell">
                       {formatNumber(post.comments)}
                     </td>
-                    <td className="px-4 py-3 text-center font-medium text-green-400">
+                    <td className="hidden px-4 py-3 text-center font-medium text-green-400 sm:table-cell">
                       {formatNumber(post.shares)}
                     </td>
-                    <td className="px-4 py-3 text-center">
+                    <td className="px-3 py-3 text-center sm:px-4">
                       <span
                         className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ${
                           post.engagementRate >= 5
@@ -736,7 +751,7 @@ export function PostsPanel({ data, isLoading = false }: PostsPanelProps) {
                         {post.engagementRate.toFixed(1)}%
                       </span>
                     </td>
-                    <td className="text-ivory/60 px-4 py-3 text-xs">
+                    <td className="text-ivory/60 hidden px-4 py-3 text-xs lg:table-cell">
                       {formatDate(post.publishedAt)}
                     </td>
                   </motion.tr>

--- a/packages/admin/src/components/analytics/ConversionFunnel.tsx
+++ b/packages/admin/src/components/analytics/ConversionFunnel.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { cn } from "@kairn/ui";
+import { cn } from '@kairn/ui';
+import { motion } from 'framer-motion';
 
 export interface ConversionData {
   clicks: number;
@@ -53,14 +53,14 @@ export interface ConversionFunnelProps {
 export function ConversionFunnel({
   data,
   typeLabels = {},
-  title = "Entonnoir de conversion",
+  title = 'Entonnoir de conversion',
   className,
-  accentColor = "gold",
-  clicksLabel = "clics",
-  conversionsLabel = "conversions",
-  totalClicksLabel = "Total clics",
-  totalConversionsLabel = "Conversions totales",
-  averageRateLabel = "Taux moyen",
+  accentColor = 'gold',
+  clicksLabel = 'clics',
+  conversionsLabel = 'conversions',
+  totalClicksLabel = 'Total clics',
+  totalConversionsLabel = 'Conversions totales',
+  averageRateLabel = 'Taux moyen',
 }: ConversionFunnelProps) {
   const entries = Object.entries(data).sort((a, b) => b[1].clicks - a[1].clicks);
 
@@ -73,19 +73,17 @@ export function ConversionFunnel({
   );
 
   const averageRate =
-    entries.length > 0
-      ? entries.reduce((sum, [, item]) => sum + item.rate, 0) / entries.length
-      : 0;
+    entries.length > 0 ? entries.reduce((sum, [, item]) => sum + item.rate, 0) / entries.length : 0;
 
   return (
     <div
       className={cn(
-        "rounded-lg border bg-gradient-to-br from-night/60 to-night/40 p-6 backdrop-blur-sm",
+        'from-night/60 to-night/40 rounded-lg border bg-gradient-to-br p-6 backdrop-blur-sm',
         `border-${accentColor}/20`,
         className
       )}
     >
-      <h3 className={cn("mb-6 text-lg font-semibold", `text-${accentColor}`)}>{title}</h3>
+      <h3 className={cn('mb-6 text-lg font-semibold', `text-${accentColor}`)}>{title}</h3>
       <div className="space-y-4">
         {entries.map(([type, item], index) => (
           <motion.div
@@ -96,31 +94,37 @@ export function ConversionFunnel({
             transition={{ duration: 0.5, delay: index * 0.1 }}
           >
             <div className="mb-2 flex items-center justify-between">
-              <span className="text-sm font-medium text-ivory">
-                {typeLabels[type] || type}
-              </span>
-              <div className="flex gap-4 text-xs text-ivory/70">
+              <span className="text-ivory text-sm font-medium">{typeLabels[type] || type}</span>
+              <div className="text-ivory/70 flex gap-4 text-xs">
                 <span className={`text-${accentColor}`}>
                   {item.clicks} {clicksLabel}
                 </span>
                 <span className="font-semibold text-green-400">
                   {item.completed} {conversionsLabel}
                 </span>
-                <span className={cn("font-semibold", `text-${accentColor}`)}>
+                <span className={cn('font-semibold', `text-${accentColor}`)}>
                   {(item.rate ?? 0).toFixed(1)}%
                 </span>
               </div>
             </div>
 
-            <div className={cn("relative h-8 overflow-hidden rounded-lg border bg-night/40", `border-${accentColor}/10`)}>
+            <div
+              className={cn(
+                'bg-night/40 relative h-8 overflow-hidden rounded-lg border',
+                `border-${accentColor}/10`
+              )}
+            >
               {/* Background bar (clicks) */}
               <motion.div
                 initial={{ scaleX: 0 }}
                 whileInView={{ scaleX: 1 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: index * 0.1 }}
-                className={cn("absolute inset-y-0 left-0 origin-left bg-gradient-to-r", `from-${accentColor}/40 to-${accentColor}/20`)}
-                style={{ width: "100%" }}
+                className={cn(
+                  'absolute inset-y-0 left-0 origin-left bg-gradient-to-r',
+                  `from-${accentColor}/40 to-${accentColor}/20`
+                )}
+                style={{ width: '100%' }}
               />
 
               {/* Conversion bar (rate) */}
@@ -135,7 +139,7 @@ export function ConversionFunnel({
 
               {/* Label */}
               <div className="absolute inset-0 flex items-center px-3">
-                <span className="text-xs font-bold text-ivory/80">
+                <span className="text-ivory/80 text-xs font-bold">
                   {(item.rate ?? 0).toFixed(1)}%
                 </span>
               </div>
@@ -144,20 +148,23 @@ export function ConversionFunnel({
         ))}
       </div>
 
-      <div className={cn("mt-6 grid grid-cols-3 gap-4 border-t pt-6", `border-${accentColor}/10`)}>
+      <div
+        className={cn(
+          'mt-6 grid grid-cols-1 gap-3 border-t pt-6 sm:grid-cols-3 sm:gap-4',
+          `border-${accentColor}/10`
+        )}
+      >
         <div>
-          <p className="text-xs text-ivory/70">{totalClicksLabel}</p>
-          <p className={cn("mt-1 text-2xl font-bold", `text-${accentColor}`)}>
-            {totals.clicks}
-          </p>
+          <p className="text-ivory/70 text-xs">{totalClicksLabel}</p>
+          <p className={cn('mt-1 text-2xl font-bold', `text-${accentColor}`)}>{totals.clicks}</p>
         </div>
         <div>
-          <p className="text-xs text-ivory/70">{totalConversionsLabel}</p>
+          <p className="text-ivory/70 text-xs">{totalConversionsLabel}</p>
           <p className="mt-1 text-2xl font-bold text-green-400">{totals.completed}</p>
         </div>
         <div>
-          <p className="text-xs text-ivory/70">{averageRateLabel}</p>
-          <p className={cn("mt-1 text-2xl font-bold", `text-${accentColor}`)}>
+          <p className="text-ivory/70 text-xs">{averageRateLabel}</p>
+          <p className={cn('mt-1 text-2xl font-bold', `text-${accentColor}`)}>
             {averageRate.toFixed(1)}%
           </p>
         </div>

--- a/packages/admin/src/components/common/DateRangePicker.tsx
+++ b/packages/admin/src/components/common/DateRangePicker.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { useState, useCallback } from "react";
-import { Calendar } from "lucide-react";
-import { cn } from "@kairn/ui";
+import { cn } from '@kairn/ui';
+import { Calendar } from 'lucide-react';
+import { useState, useCallback } from 'react';
 
 export interface DateRangePickerProps {
   /** Start date in YYYY-MM-DD format */
@@ -27,7 +27,7 @@ export interface DateRangePickerProps {
 }
 
 const formatDateString = (date: Date): string => {
-  return date.toISOString().split("T")[0] ?? "";
+  return date.toISOString().split('T')[0] ?? '';
 };
 
 const DEFAULT_PRESETS: Array<{
@@ -35,7 +35,7 @@ const DEFAULT_PRESETS: Array<{
   getValue: () => { startDate: string; endDate: string };
 }> = [
   {
-    label: "7 derniers jours",
+    label: '7 derniers jours',
     getValue: () => {
       const end = new Date();
       const start = new Date();
@@ -47,7 +47,7 @@ const DEFAULT_PRESETS: Array<{
     },
   },
   {
-    label: "30 derniers jours",
+    label: '30 derniers jours',
     getValue: () => {
       const end = new Date();
       const start = new Date();
@@ -59,7 +59,7 @@ const DEFAULT_PRESETS: Array<{
     },
   },
   {
-    label: "Ce mois",
+    label: 'Ce mois',
     getValue: () => {
       const now = new Date();
       const start = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -70,7 +70,7 @@ const DEFAULT_PRESETS: Array<{
     },
   },
   {
-    label: "Mois dernier",
+    label: 'Mois dernier',
     getValue: () => {
       const now = new Date();
       const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
@@ -99,13 +99,13 @@ export function DateRangePicker({
   startDate,
   endDate,
   onDateChange,
-  locale = "fr-FR",
+  locale = 'fr-FR',
   className,
-  accentColor = "gold",
+  accentColor = 'gold',
   dateFormatOptions = {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
   },
   presets = DEFAULT_PRESETS,
 }: DateRangePickerProps) {
@@ -141,11 +141,11 @@ export function DateRangePicker({
   };
 
   return (
-    <div className={cn("relative", className)}>
+    <div className={cn('relative', className)}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
-          "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm text-ivory transition",
+          'text-ivory flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition',
           `border-${accentColor}/30 bg-night/60 hover:bg-${accentColor}/10`
         )}
       >
@@ -163,14 +163,14 @@ export function DateRangePicker({
           {/* Dropdown */}
           <div
             className={cn(
-              "absolute right-0 z-50 mt-2 w-80 rounded-lg border p-4 shadow-xl backdrop-blur-sm",
-              `border-${accentColor}/30 bg-gradient-to-br from-night/95 to-night/90`
+              'absolute right-0 z-50 mt-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border p-4 shadow-xl backdrop-blur-sm',
+              `border-${accentColor}/30 from-night/95 to-night/90 bg-gradient-to-br`
             )}
           >
             {/* Quick Presets */}
             {presets.length > 0 && (
-              <div className="mb-4 border-b border-gold/20 pb-4">
-                <p className={cn("mb-2 text-xs font-semibold", `text-${accentColor}/70`)}>
+              <div className="border-gold/20 mb-4 border-b pb-4">
+                <p className={cn('mb-2 text-xs font-semibold', `text-${accentColor}/70`)}>
                   Raccourcis
                 </p>
                 <div className="grid grid-cols-2 gap-2">
@@ -179,7 +179,7 @@ export function DateRangePicker({
                       key={idx}
                       onClick={() => handlePreset(preset)}
                       className={cn(
-                        "rounded-md px-2 py-1.5 text-xs text-ivory/70 transition",
+                        'text-ivory/70 rounded-md px-2 py-1.5 text-xs transition',
                         `hover:bg-${accentColor}/10 hover:text-ivory`
                       )}
                     >
@@ -190,32 +190,32 @@ export function DateRangePicker({
               </div>
             )}
 
-            <h3 className={cn("mb-3 text-sm font-semibold", `text-${accentColor}`)}>
+            <h3 className={cn('mb-3 text-sm font-semibold', `text-${accentColor}`)}>
               Plage personnalisee
             </h3>
 
             <div className="space-y-3">
               <div>
-                <label className="mb-1 block text-xs text-ivory/70">Date de debut</label>
+                <label className="text-ivory/70 mb-1 block text-xs">Date de debut</label>
                 <input
                   type="date"
                   value={localStartDate}
-                  onChange={(e) => setLocalStartDate(e.target.value)}
+                  onChange={e => setLocalStartDate(e.target.value)}
                   className={cn(
-                    "w-full rounded-lg border bg-night/50 px-3 py-2 text-sm text-ivory",
+                    'bg-night/50 text-ivory w-full rounded-lg border px-3 py-2 text-sm',
                     `border-${accentColor}/30 focus:border-${accentColor} focus:outline-none`
                   )}
                 />
               </div>
 
               <div>
-                <label className="mb-1 block text-xs text-ivory/70">Date de fin</label>
+                <label className="text-ivory/70 mb-1 block text-xs">Date de fin</label>
                 <input
                   type="date"
                   value={localEndDate}
-                  onChange={(e) => setLocalEndDate(e.target.value)}
+                  onChange={e => setLocalEndDate(e.target.value)}
                   className={cn(
-                    "w-full rounded-lg border bg-night/50 px-3 py-2 text-sm text-ivory",
+                    'bg-night/50 text-ivory w-full rounded-lg border px-3 py-2 text-sm',
                     `border-${accentColor}/30 focus:border-${accentColor} focus:outline-none`
                   )}
                 />
@@ -226,7 +226,7 @@ export function DateRangePicker({
               <button
                 onClick={handleCancel}
                 className={cn(
-                  "flex-1 rounded-lg border px-3 py-2 text-sm text-ivory transition",
+                  'text-ivory flex-1 rounded-lg border px-3 py-2 text-sm transition',
                   `border-${accentColor}/30 hover:bg-${accentColor}/10`
                 )}
               >
@@ -235,7 +235,7 @@ export function DateRangePicker({
               <button
                 onClick={handleApply}
                 className={cn(
-                  "flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition",
+                  'flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition',
                   `bg-${accentColor}/20 border-${accentColor}/50 text-${accentColor} hover:bg-${accentColor}/30`
                 )}
               >

--- a/packages/admin/src/components/configuration/AlertFormModal.tsx
+++ b/packages/admin/src/components/configuration/AlertFormModal.tsx
@@ -355,7 +355,7 @@ export function AlertFormModal({
                 <label className="text-ivory mb-2 block text-sm font-medium">
                   Type d&apos;alerte
                 </label>
-                <div className="grid grid-cols-3 gap-3">
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3">
                   {(Object.keys(ALERT_TYPE_LABELS) as AlertType[]).map(type => (
                     <button
                       key={type}

--- a/packages/admin/src/components/configuration/GoalsConfigurationPanel.tsx
+++ b/packages/admin/src/components/configuration/GoalsConfigurationPanel.tsx
@@ -211,7 +211,7 @@ export function GoalsConfigurationPanel({
       </div>
 
       {/* Stats Overview */}
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4">
         <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/20">


### PR DESCRIPTION
## Résumé

Corrige le débordement horizontal sur smartphone pour les pages `/admin/*` en ajoutant les breakpoints Tailwind responsive manquants.

- **Grilles non responsive** : `grid-cols-3` sans breakpoint mobile → `grid-cols-1 sm:grid-cols-3`
- **Tables trop larges** : réduction du `min-w` et masquage des colonnes non-essentielles sur mobile
- **Dropdown DateRangePicker** : ajout de `max-w-[calc(100vw-2rem)]` pour éviter le débordement

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `GoalsConfigurationPanel.tsx` | `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` |
| `ConversionFunnel.tsx` | `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` |
| `AlertFormModal.tsx` | `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` |
| `DateRangePicker.tsx` | Ajout `max-w-[calc(100vw-2rem)]` |
| `SocialInsights.tsx` | `grid-cols-3 sm:grid-cols-6` → `grid-cols-2 sm:grid-cols-3 lg:grid-cols-6` |
| `CommandCenter.tsx` | `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` |
| `PostsPanel.tsx` | `min-w-[800px]` → `min-w-[480px]` + colonnes hidden sur mobile |
| `BlogPanel.tsx` | `min-w-[640px]` → `min-w-[400px]` + colonnes hidden sur mobile |

## Test plan

- [ ] Vérifier chaque page admin sur un viewport mobile (375px)
- [ ] Vérifier qu'aucun contenu ne déborde horizontalement
- [ ] Vérifier que les colonnes masquées réapparaissent sur tablette/desktop
- [ ] Vérifier que les grilles empilent correctement sur petit écran

Fixes #368

https://claude.ai/code/session_01EYWThLxifuCWEPTGLodRxx