### PR TITLE
fix(avv): corriger erreurs de build Vercel

### DIFF
--- a/apps/avv/__tests__/integration/auth-flow.test.ts
+++ b/apps/avv/__tests__/integration/auth-flow.test.ts
@@ -313,7 +313,7 @@ describe('Auth Flow Integration', () => {
 
     it('should normalize email to lowercase', async () => {
       const result = await handleLogin({
-        email: 'ADMIN@AVV.FR',
+        email: 'ADMIN@APPRECIEZVOTREVIE.FR',
         password: 'securePassword123!',
       });
 

--- a/apps/avv/__tests__/unit/blog-jobs-route.test.ts
+++ b/apps/avv/__tests__/unit/blog-jobs-route.test.ts
@@ -67,7 +67,7 @@ const VALID_BODY = {
   category: 'Comprendre',
   targetLength: 'medium',
   preferredTones: ['pédagogique'],
-  useAppréciez Votre VieStyle: true,
+  useAvvStyle: true,
 };
 
 // ─── Tests ────────────────────────────────────────────────────────

--- a/apps/avv/__tests__/unit/blog-jobs-step.test.ts
+++ b/apps/avv/__tests__/unit/blog-jobs-step.test.ts
@@ -108,7 +108,7 @@ const BASE_JOB = {
     category: 'Comprendre',
     targetLength: 'medium',
     preferredTones: ['pédagogique'],
-    useAppréciez Votre VieStyle: true,
+    useAvvStyle: true,
   },
   partialResult: null,
   result: null,

--- a/apps/avv/__tests__/unit/seminar-prompt-builder.test.ts
+++ b/apps/avv/__tests__/unit/seminar-prompt-builder.test.ts
@@ -135,7 +135,7 @@ describe('buildSeminarMultiPlatformPrompt', () => {
     const prompt = buildSeminarMultiPlatformPrompt(BASE_SEMINAR, platforms, DEFAULT_OPTIONS);
 
     expect(prompt).toContain(INSCRIPTION_URL);
-    expect(prompt).toContain(RESPIRATION_URL);
+    expect(prompt).toContain(BREATHWORK_URL);
   });
 
   it('contient le thumbnail quand il est fourni', () => {

--- a/apps/avv/app/admin/blog/_components/ArticleGeneratorModal.tsx
+++ b/apps/avv/app/admin/blog/_components/ArticleGeneratorModal.tsx
@@ -78,7 +78,7 @@ export function ArticleGeneratorModal({
   const [seoQuery, setSeoQuery] = useState('');
   const [searchIntent, setSearchIntent] = useState('');
   const [readerPersona, setReaderPersona] = useState('');
-  const [useAppréciez Votre VieStyle, setUseAppréciez Votre VieStyle] = useState(true);
+  const [useAvvStyle, setUseAvvStyle] = useState(true);
 
   const [error, setError] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -259,7 +259,7 @@ export function ArticleGeneratorModal({
           seoQuery: seoQuery.trim() || undefined,
           searchIntent: searchIntent.trim() || undefined,
           readerPersona: readerPersona.trim() || undefined,
-          useAppréciez Votre VieStyle,
+          useAvvStyle,
         }),
       });
 
@@ -295,7 +295,7 @@ export function ArticleGeneratorModal({
     setSeoQuery('');
     setSearchIntent('');
     setReaderPersona('');
-    setUseAppréciez Votre VieStyle(true);
+    setUseAvvStyle(true);
     setError(null);
     setIsGenerating(false);
     setGenerationProgress(0);
@@ -573,13 +573,13 @@ export function ArticleGeneratorModal({
             <div className="flex items-center gap-3">
               <input
                 type="checkbox"
-                id="useAppréciez Votre VieStyle"
-                checked={useAppréciez Votre VieStyle}
-                onChange={e => setUseAppréciez Votre VieStyle(e.target.checked)}
+                id="useAvvStyle"
+                checked={useAvvStyle}
+                onChange={e => setUseAvvStyle(e.target.checked)}
                 disabled={isGenerating}
                 className="border-gold/20 text-gold focus:ring-gold h-4 w-4 rounded disabled:opacity-50"
               />
-              <label htmlFor="useAppréciez Votre VieStyle" className="text-ivory text-sm font-medium">
+              <label htmlFor="useAvvStyle" className="text-ivory text-sm font-medium">
                 Utiliser le style rédactionnel AVV
               </label>
             </div>

--- a/apps/avv/app/admin/blog/_components/ArticleImprover.tsx
+++ b/apps/avv/app/admin/blog/_components/ArticleImprover.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { motion, AnimatePresence } from "framer-motion";
-import { X, Wand2, Loader } from "lucide-react";
-import { useState } from "react";
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Wand2, Loader } from 'lucide-react';
+import { useState } from 'react';
 
 interface ArticleImproverProps {
   isOpen: boolean;
@@ -17,8 +17,8 @@ export function ArticleImprover({
   currentContent,
   onImprove,
 }: ArticleImproverProps) {
-  const [improvementPrompt, setImprovementPrompt] = useState("");
-  const [useAppréciez Votre VieStyle, setUseAppréciez Votre VieStyle] = useState(true);
+  const [improvementPrompt, setImprovementPrompt] = useState('');
+  const [useAvvStyle, setUseAvvStyle] = useState(true);
   const [isImproving, setIsImproving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -33,21 +33,21 @@ export function ArticleImprover({
 
     try {
       // Récupérer le token CSRF
-      const csrfResponse = await fetch("/api/csrf-token");
+      const csrfResponse = await fetch('/api/csrf-token');
       const { token: csrfToken } = await csrfResponse.json();
 
       // Utiliser /api/blog/improve-text pour améliorer le contenu complet
-      const response = await fetch("/api/blog/improve-text", {
-        method: "POST",
+      const response = await fetch('/api/blog/improve-text', {
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": csrfToken,
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
         },
         body: JSON.stringify({
           selectedText: currentContent,
           improvementInstructions: improvementPrompt.trim(),
-          useAppréciez Votre VieStyle,
-          meta: { honeypot: "" },
+          useAvvStyle,
+          meta: { honeypot: '' },
         }),
       });
 
@@ -59,20 +59,18 @@ export function ArticleImprover({
       const data = await response.json();
 
       if (!data.success || !data.improvedText) {
-        throw new Error("Réponse invalide du serveur");
+        throw new Error('Réponse invalide du serveur');
       }
 
       // Appeler le callback avec le contenu amélioré
       onImprove(data.improvedText);
 
       // Réinitialiser et fermer
-      setImprovementPrompt("");
+      setImprovementPrompt('');
       onClose();
     } catch (err) {
-      console.error("Error improving article:", err);
-      setError(
-        err instanceof Error ? err.message : "Une erreur est survenue"
-      );
+      console.error('Error improving article:', err);
+      setError(err instanceof Error ? err.message : 'Une erreur est survenue');
     } finally {
       setIsImproving(false);
     }
@@ -80,18 +78,18 @@ export function ArticleImprover({
 
   const handleClose = () => {
     if (!isImproving) {
-      setImprovementPrompt("");
+      setImprovementPrompt('');
       setError(null);
       onClose();
     }
   };
 
   const suggestedPrompts = [
-    "Améliorer la clarté et la lisibilité",
+    'Améliorer la clarté et la lisibilité',
     "Renforcer l'approche empathique",
     "Ajouter plus d'exemples concrets",
-    "Optimiser pour le SEO",
-    "Approfondir les conseils pratiques",
+    'Optimiser pour le SEO',
+    'Approfondir les conseils pratiques',
   ];
 
   return (
@@ -104,7 +102,7 @@ export function ArticleImprover({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={handleClose}
-            className="fixed inset-0 z-50 bg-night/80 backdrop-blur-sm"
+            className="bg-night/80 fixed inset-0 z-50 backdrop-blur-sm"
           />
 
           {/* Modal */}
@@ -115,18 +113,18 @@ export function ArticleImprover({
             transition={{ duration: 0.2 }}
             className="fixed inset-0 z-50 flex items-center justify-center p-4"
           >
-            <div className="w-full max-w-2xl rounded-lg border border-gold/20 bg-gradient-to-br from-night/95 to-night/90 p-6 shadow-2xl backdrop-blur-xl">
+            <div className="border-gold/20 from-night/95 to-night/90 w-full max-w-2xl rounded-lg border bg-gradient-to-br p-6 shadow-2xl backdrop-blur-xl">
               {/* Header */}
               <div className="mb-6 flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="rounded-lg bg-gold/20 p-2">
-                    <Wand2 className="h-5 w-5 text-gold" />
+                  <div className="bg-gold/20 rounded-lg p-2">
+                    <Wand2 className="text-gold h-5 w-5" />
                   </div>
                   <div>
-                    <h2 className="text-xl font-semibold text-ivory">
+                    <h2 className="text-ivory text-xl font-semibold">
                       Améliorer l&apos;article avec Claude
                     </h2>
-                    <p className="text-sm text-ivory/60">
+                    <p className="text-ivory/60 text-sm">
                       Décrivez comment vous souhaitez améliorer le contenu
                     </p>
                   </div>
@@ -134,7 +132,7 @@ export function ArticleImprover({
                 <button
                   onClick={handleClose}
                   disabled={isImproving}
-                  className="rounded-lg p-2 text-ivory/70 transition hover:bg-gold/10 hover:text-ivory disabled:opacity-50"
+                  className="text-ivory/70 hover:bg-gold/10 hover:text-ivory rounded-lg p-2 transition disabled:opacity-50"
                 >
                   <X className="h-5 w-5" />
                 </button>
@@ -144,28 +142,26 @@ export function ArticleImprover({
               <div className="space-y-6">
                 {/* Instructions input */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gold">
+                  <label className="text-gold mb-2 block text-sm font-medium">
                     Instructions d&apos;amélioration *
                   </label>
                   <textarea
                     value={improvementPrompt}
-                    onChange={(e) => {
+                    onChange={e => {
                       setImprovementPrompt(e.target.value);
                       setError(null);
                     }}
                     disabled={isImproving}
                     rows={6}
-                    className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory placeholder-ivory/40 transition focus:border-gold focus:outline-none disabled:opacity-50"
+                    className="border-gold/20 bg-night/50 text-ivory placeholder-ivory/40 focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none disabled:opacity-50"
                     placeholder="Ex: Renforcer la dimension empathique et ajouter des exemples concrets de situations vécues par les lecteurs..."
                   />
-                  {error && (
-                    <p className="mt-2 text-sm text-red-400">{error}</p>
-                  )}
+                  {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
                 </div>
 
                 {/* Suggested prompts */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gold">
+                  <label className="text-gold mb-2 block text-sm font-medium">
                     Suggestions rapides
                   </label>
                   <div className="flex flex-wrap gap-2">
@@ -174,7 +170,7 @@ export function ArticleImprover({
                         key={index}
                         onClick={() => setImprovementPrompt(prompt)}
                         disabled={isImproving}
-                        className="rounded-full border border-gold/20 bg-night/50 px-3 py-1 text-sm text-ivory/70 transition hover:border-gold/40 hover:text-ivory disabled:opacity-50"
+                        className="border-gold/20 bg-night/50 text-ivory/70 hover:border-gold/40 hover:text-ivory rounded-full border px-3 py-1 text-sm transition disabled:opacity-50"
                       >
                         {prompt}
                       </button>
@@ -186,39 +182,35 @@ export function ArticleImprover({
                 <div className="flex items-center gap-3">
                   <input
                     type="checkbox"
-                    id="useAppréciez Votre VieStyle"
-                    checked={useAppréciez Votre VieStyle}
-                    onChange={(e) => setUseAppréciez Votre VieStyle(e.target.checked)}
+                    id="useAvvStyle"
+                    checked={useAvvStyle}
+                    onChange={e => setUseAvvStyle(e.target.checked)}
                     disabled={isImproving}
-                    className="h-4 w-4 rounded border-gold/20 text-gold focus:ring-gold disabled:opacity-50"
+                    className="border-gold/20 text-gold focus:ring-gold h-4 w-4 rounded disabled:opacity-50"
                   />
-                  <label
-                    htmlFor="useAppréciez Votre VieStyle"
-                    className="text-sm font-medium text-ivory"
-                  >
+                  <label htmlFor="useAvvStyle" className="text-ivory text-sm font-medium">
                     Utiliser le style rédactionnel AVV
                   </label>
                 </div>
 
                 {/* Info box */}
-                <div className="rounded-lg border border-gold/20 bg-gold/5 p-4">
-                  <p className="text-sm text-ivory/70">
-                    <strong className="text-gold">Note :</strong> Claude va
-                    analyser votre contenu actuel et l&apos;améliorer selon vos
-                    instructions. Le contenu amélioré remplacera le contenu
-                    actuel de l&apos;éditeur. Vous pourrez toujours utiliser
+                <div className="border-gold/20 bg-gold/5 rounded-lg border p-4">
+                  <p className="text-ivory/70 text-sm">
+                    <strong className="text-gold">Note :</strong> Claude va analyser votre contenu
+                    actuel et l&apos;améliorer selon vos instructions. Le contenu amélioré
+                    remplacera le contenu actuel de l&apos;éditeur. Vous pourrez toujours utiliser
                     Ctrl+Z pour annuler.
                   </p>
                 </div>
               </div>
 
               {/* Actions */}
-              <div className="mt-6 flex items-center justify-between gap-3 border-t border-gold/10 pt-4">
+              <div className="border-gold/10 mt-6 flex items-center justify-between gap-3 border-t pt-4">
                 {/* Indicateur de progression */}
                 {isImproving && (
                   <div className="flex items-center gap-2">
-                    <Loader className="h-4 w-4 animate-spin text-gold" />
-                    <span className="text-xs text-ivory/70">Amélioration en cours...</span>
+                    <Loader className="text-gold h-4 w-4 animate-spin" />
+                    <span className="text-ivory/70 text-xs">Amélioration en cours...</span>
                   </div>
                 )}
                 {!isImproving && <div />}
@@ -228,14 +220,14 @@ export function ArticleImprover({
                   <button
                     onClick={handleClose}
                     disabled={isImproving}
-                    className="rounded-lg border border-gold/30 px-6 py-3 font-medium text-gold transition hover:bg-gold/10 disabled:opacity-50"
+                    className="border-gold/30 text-gold hover:bg-gold/10 rounded-lg border px-6 py-3 font-medium transition disabled:opacity-50"
                   >
                     Annuler
                   </button>
                   <button
                     onClick={handleImprove}
                     disabled={isImproving || !improvementPrompt.trim()}
-                    className="flex items-center gap-2 rounded-lg bg-gold/20 px-6 py-3 font-medium text-gold transition hover:bg-gold/30 disabled:opacity-50"
+                    className="bg-gold/20 text-gold hover:bg-gold/30 flex items-center gap-2 rounded-lg px-6 py-3 font-medium transition disabled:opacity-50"
                   >
                     {isImproving ? (
                       <>

--- a/apps/avv/app/admin/blog/_components/TextImprover.tsx
+++ b/apps/avv/app/admin/blog/_components/TextImprover.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { motion, AnimatePresence } from "framer-motion";
-import { X, Sparkles, Loader } from "lucide-react";
-import { useState } from "react";
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Sparkles, Loader } from 'lucide-react';
+import { useState } from 'react';
 
 interface TextImproverProps {
   isOpen: boolean;
@@ -11,14 +11,9 @@ interface TextImproverProps {
   onImprove: (improvedText: string) => void;
 }
 
-export function TextImprover({
-  isOpen,
-  onClose,
-  selectedText,
-  onImprove,
-}: TextImproverProps) {
-  const [improvementInstructions, setImprovementInstructions] = useState("");
-  const [useAppréciez Votre VieStyle, setUseAppréciez Votre VieStyle] = useState(true);
+export function TextImprover({ isOpen, onClose, selectedText, onImprove }: TextImproverProps) {
+  const [improvementInstructions, setImprovementInstructions] = useState('');
+  const [useAvvStyle, setUseAvvStyle] = useState(true);
   const [isImproving, setIsImproving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -33,20 +28,20 @@ export function TextImprover({
 
     try {
       // Récupérer le token CSRF
-      const csrfResponse = await fetch("/api/csrf-token");
+      const csrfResponse = await fetch('/api/csrf-token');
       const { token: csrfToken } = await csrfResponse.json();
 
-      const response = await fetch("/api/blog/improve-text", {
-        method: "POST",
+      const response = await fetch('/api/blog/improve-text', {
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": csrfToken,
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
         },
         body: JSON.stringify({
           selectedText,
           improvementInstructions: improvementInstructions.trim(),
-          useAppréciez Votre VieStyle,
-          meta: { honeypot: "" },
+          useAvvStyle,
+          meta: { honeypot: '' },
         }),
       });
 
@@ -58,20 +53,18 @@ export function TextImprover({
       const data = await response.json();
 
       if (!data.success || !data.improvedText) {
-        throw new Error("Réponse invalide du serveur");
+        throw new Error('Réponse invalide du serveur');
       }
 
       // Appeler le callback avec le texte amélioré
       onImprove(data.improvedText);
 
       // Réinitialiser et fermer
-      setImprovementInstructions("");
+      setImprovementInstructions('');
       onClose();
     } catch (err) {
-      console.error("Error improving text:", err);
-      setError(
-        err instanceof Error ? err.message : "Une erreur est survenue"
-      );
+      console.error('Error improving text:', err);
+      setError(err instanceof Error ? err.message : 'Une erreur est survenue');
     } finally {
       setIsImproving(false);
     }
@@ -79,18 +72,18 @@ export function TextImprover({
 
   const handleClose = () => {
     if (!isImproving) {
-      setImprovementInstructions("");
+      setImprovementInstructions('');
       setError(null);
       onClose();
     }
   };
 
   const suggestedInstructions = [
-    "Améliorer la clarté",
-    "Rendre plus empathique",
-    "Simplifier le vocabulaire",
-    "Ajouter un exemple concret",
-    "Reformuler de manière plus poétique",
+    'Améliorer la clarté',
+    'Rendre plus empathique',
+    'Simplifier le vocabulaire',
+    'Ajouter un exemple concret',
+    'Reformuler de manière plus poétique',
   ];
 
   return (
@@ -103,7 +96,7 @@ export function TextImprover({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={handleClose}
-            className="fixed inset-0 z-50 bg-night/80 backdrop-blur-sm"
+            className="bg-night/80 fixed inset-0 z-50 backdrop-blur-sm"
           />
 
           {/* Modal */}
@@ -114,18 +107,18 @@ export function TextImprover({
             transition={{ duration: 0.2 }}
             className="fixed inset-0 z-50 flex items-center justify-center p-4"
           >
-            <div className="w-full max-w-2xl rounded-lg border border-gold/20 bg-gradient-to-br from-night/95 to-night/90 p-6 shadow-2xl backdrop-blur-xl">
+            <div className="border-gold/20 from-night/95 to-night/90 w-full max-w-2xl rounded-lg border bg-gradient-to-br p-6 shadow-2xl backdrop-blur-xl">
               {/* Header */}
               <div className="mb-6 flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="rounded-lg bg-gold/20 p-2">
-                    <Sparkles className="h-5 w-5 text-gold" />
+                  <div className="bg-gold/20 rounded-lg p-2">
+                    <Sparkles className="text-gold h-5 w-5" />
                   </div>
                   <div>
-                    <h2 className="text-xl font-semibold text-ivory">
+                    <h2 className="text-ivory text-xl font-semibold">
                       Améliorer le texte sélectionné
                     </h2>
-                    <p className="text-sm text-ivory/60">
+                    <p className="text-ivory/60 text-sm">
                       {selectedText.length} caractères sélectionnés
                     </p>
                   </div>
@@ -133,7 +126,7 @@ export function TextImprover({
                 <button
                   onClick={handleClose}
                   disabled={isImproving}
-                  className="rounded-lg p-2 text-ivory/70 transition hover:bg-gold/10 hover:text-ivory disabled:opacity-50"
+                  className="text-ivory/70 hover:bg-gold/10 hover:text-ivory rounded-lg p-2 transition disabled:opacity-50"
                 >
                   <X className="h-5 w-5" />
                 </button>
@@ -143,40 +136,36 @@ export function TextImprover({
               <div className="space-y-6">
                 {/* Selected text preview */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gold">
+                  <label className="text-gold mb-2 block text-sm font-medium">
                     Texte sélectionné
                   </label>
-                  <div className="max-h-32 overflow-y-auto rounded-lg border border-gold/20 bg-night/50 p-3">
-                    <p className="text-sm text-ivory/70 whitespace-pre-wrap">
-                      {selectedText}
-                    </p>
+                  <div className="border-gold/20 bg-night/50 max-h-32 overflow-y-auto rounded-lg border p-3">
+                    <p className="text-ivory/70 whitespace-pre-wrap text-sm">{selectedText}</p>
                   </div>
                 </div>
 
                 {/* Instructions input */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gold">
+                  <label className="text-gold mb-2 block text-sm font-medium">
                     Comment souhaitez-vous améliorer ce texte ? *
                   </label>
                   <textarea
                     value={improvementInstructions}
-                    onChange={(e) => {
+                    onChange={e => {
                       setImprovementInstructions(e.target.value);
                       setError(null);
                     }}
                     disabled={isImproving}
                     rows={4}
-                    className="w-full rounded-lg border border-gold/20 bg-night/50 px-4 py-3 text-ivory placeholder-ivory/40 transition focus:border-gold focus:outline-none disabled:opacity-50"
+                    className="border-gold/20 bg-night/50 text-ivory placeholder-ivory/40 focus:border-gold w-full rounded-lg border px-4 py-3 transition focus:outline-none disabled:opacity-50"
                     placeholder="Ex: Rendre ce passage plus empathique et ajouter une métaphore..."
                   />
-                  {error && (
-                    <p className="mt-2 text-sm text-red-400">{error}</p>
-                  )}
+                  {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
                 </div>
 
                 {/* Suggested instructions */}
                 <div>
-                  <label className="mb-2 block text-sm font-medium text-gold">
+                  <label className="text-gold mb-2 block text-sm font-medium">
                     Suggestions rapides
                   </label>
                   <div className="flex flex-wrap gap-2">
@@ -185,7 +174,7 @@ export function TextImprover({
                         key={index}
                         onClick={() => setImprovementInstructions(instruction)}
                         disabled={isImproving}
-                        className="rounded-full border border-gold/20 bg-night/50 px-3 py-1 text-sm text-ivory/70 transition hover:border-gold/40 hover:text-ivory disabled:opacity-50"
+                        className="border-gold/20 bg-night/50 text-ivory/70 hover:border-gold/40 hover:text-ivory rounded-full border px-3 py-1 text-sm transition disabled:opacity-50"
                       >
                         {instruction}
                       </button>
@@ -197,39 +186,34 @@ export function TextImprover({
                 <div className="flex items-center gap-3">
                   <input
                     type="checkbox"
-                    id="useAppréciez Votre VieStyle"
-                    checked={useAppréciez Votre VieStyle}
-                    onChange={(e) => setUseAppréciez Votre VieStyle(e.target.checked)}
+                    id="useAvvStyle"
+                    checked={useAvvStyle}
+                    onChange={e => setUseAvvStyle(e.target.checked)}
                     disabled={isImproving}
-                    className="h-4 w-4 rounded border-gold/20 text-gold focus:ring-gold disabled:opacity-50"
+                    className="border-gold/20 text-gold focus:ring-gold h-4 w-4 rounded disabled:opacity-50"
                   />
-                  <label
-                    htmlFor="useAppréciez Votre VieStyle"
-                    className="text-sm font-medium text-ivory"
-                  >
+                  <label htmlFor="useAvvStyle" className="text-ivory text-sm font-medium">
                     Utiliser le style rédactionnel AVV
                   </label>
                 </div>
 
                 {/* Info box */}
-                <div className="rounded-lg border border-gold/20 bg-gold/5 p-4">
-                  <p className="text-sm text-ivory/70">
-                    <strong className="text-gold">Note :</strong> Claude va
-                    améliorer uniquement le texte sélectionné selon vos
-                    instructions. Le texte amélioré remplacera la sélection
-                    actuelle. Vous pourrez toujours utiliser Ctrl+Z pour
-                    annuler.
+                <div className="border-gold/20 bg-gold/5 rounded-lg border p-4">
+                  <p className="text-ivory/70 text-sm">
+                    <strong className="text-gold">Note :</strong> Claude va améliorer uniquement le
+                    texte sélectionné selon vos instructions. Le texte amélioré remplacera la
+                    sélection actuelle. Vous pourrez toujours utiliser Ctrl+Z pour annuler.
                   </p>
                 </div>
               </div>
 
               {/* Actions */}
-              <div className="mt-6 flex items-center justify-between gap-3 border-t border-gold/10 pt-4">
+              <div className="border-gold/10 mt-6 flex items-center justify-between gap-3 border-t pt-4">
                 {/* Indicateur de progression */}
                 {isImproving && (
                   <div className="flex items-center gap-2">
-                    <Loader className="h-4 w-4 animate-spin text-gold" />
-                    <span className="text-xs text-ivory/70">Amélioration en cours...</span>
+                    <Loader className="text-gold h-4 w-4 animate-spin" />
+                    <span className="text-ivory/70 text-xs">Amélioration en cours...</span>
                   </div>
                 )}
                 {!isImproving && <div />}
@@ -239,14 +223,14 @@ export function TextImprover({
                   <button
                     onClick={handleClose}
                     disabled={isImproving}
-                    className="rounded-lg border border-gold/30 px-6 py-3 font-medium text-gold transition hover:bg-gold/10 disabled:opacity-50"
+                    className="border-gold/30 text-gold hover:bg-gold/10 rounded-lg border px-6 py-3 font-medium transition disabled:opacity-50"
                   >
                     Annuler
                   </button>
                   <button
                     onClick={handleImprove}
                     disabled={isImproving || !improvementInstructions.trim()}
-                    className="flex items-center gap-2 rounded-lg bg-gold/20 px-6 py-3 font-medium text-gold transition hover:bg-gold/30 disabled:opacity-50"
+                    className="bg-gold/20 text-gold hover:bg-gold/30 flex items-center gap-2 rounded-lg px-6 py-3 font-medium transition disabled:opacity-50"
                   >
                     {isImproving ? (
                       <>

--- a/apps/avv/app/api/blog/generate-multi-step/route.ts
+++ b/apps/avv/app/api/blog/generate-multi-step/route.ts
@@ -43,7 +43,7 @@ const generateArticleSchema = z.object({
   seoQuery: z.string().trim().optional(),
   searchIntent: z.string().trim().optional(),
   readerPersona: z.string().optional(),
-  useAppréciez Votre VieStyle: z.boolean().optional().default(true),
+  useAvvStyle: z.boolean().optional().default(true),
   // Pour rétrocompatibilité
   subject: z.string().trim().optional(),
   seoKeyword: z.string().trim().optional(),
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
     searchIntent: payload.searchIntent || payload.searchIntention || '',
     readerPersona: payload.readerPersona || payload.persona || '',
     preferredTones: allTones,
-    useAppréciez Votre VieStyle: payload.useAppréciez Votre VieStyle,
+    useAvvStyle: payload.useAvvStyle,
   };
 
   // Mode streaming avec SSE

--- a/apps/avv/app/api/blog/generate-sectional/route.ts
+++ b/apps/avv/app/api/blog/generate-sectional/route.ts
@@ -46,7 +46,7 @@ const generateArticleSchema = z.object({
   seoQuery: z.string().trim().optional(),
   searchIntent: z.string().trim().optional(),
   readerPersona: z.string().optional(),
-  useAppréciez Votre VieStyle: z.boolean().optional().default(true),
+  useAvvStyle: z.boolean().optional().default(true),
   // Pour rétrocompatibilité
   subject: z.string().trim().optional(),
   seoKeyword: z.string().trim().optional(),
@@ -121,7 +121,7 @@ export async function POST(request: NextRequest) {
     searchIntent: payload.searchIntent || payload.searchIntention || '',
     readerPersona: payload.readerPersona || payload.persona || '',
     preferredTones: allTones,
-    useAppréciez Votre VieStyle: payload.useAppréciez Votre VieStyle,
+    useAvvStyle: payload.useAvvStyle,
   };
 
   // Mode streaming avec SSE

--- a/apps/avv/app/api/blog/generate/route.ts
+++ b/apps/avv/app/api/blog/generate/route.ts
@@ -47,7 +47,7 @@ const generateArticleSchema = z.object({
   seoQuery: z.string().trim().optional(),
   searchIntent: z.string().trim().optional(),
   readerPersona: z.string().optional(),
-  useAppréciez Votre VieStyle: z.boolean().optional(),
+  useAvvStyle: z.boolean().optional(),
   meta: z.object({ honeypot: z.string() }).optional(),
 
   // Ancien schema pour rétrocompatibilité
@@ -135,7 +135,7 @@ export async function POST(request: Request) {
       searchIntent: payload.searchIntent || payload.searchIntention || '',
       readerPersona: payload.readerPersona || payload.persona || '',
       specificTone: singleTone as ArticleGenerationOptions['specificTone'],
-      useAppréciez Votre VieStyle: payload.useAppréciez Votre VieStyle !== false,
+      useAvvStyle: payload.useAvvStyle !== false,
       targetLength: (payload.targetLength || 'long') as 'short' | 'medium' | 'long',
       preferredTones: allTones, // Utiliser les tons fusionnés
     };

--- a/apps/avv/app/api/blog/improve-text/route.ts
+++ b/apps/avv/app/api/blog/improve-text/route.ts
@@ -2,8 +2,8 @@ import Anthropic from '@anthropic-ai/sdk';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
-import { validateCSRFMiddleware } from '../../common/csrf-middleware';
 import { AVV_STYLE_SYSTEM_PROMPT } from '../../common/avv-system-prompt';
+import { validateCSRFMiddleware } from '../../common/csrf-middleware';
 import { recordAttemptAsync, getClientIP } from '../../common/rate-limiter';
 
 // Vercel serverless function timeout — single Claude API call
@@ -12,7 +12,7 @@ export const maxDuration = 60;
 const improveTextSchema = z.object({
   selectedText: z.string().trim().min(1).max(10000),
   improvementInstructions: z.string().trim().min(1).max(1000),
-  useAppréciez Votre VieStyle: z.boolean().optional().default(true),
+  useAvvStyle: z.boolean().optional().default(true),
   meta: z
     .object({
       honeypot: z
@@ -85,7 +85,7 @@ export async function POST(request: Request) {
       apiKey: apiKey,
     });
 
-    const prompt = payload.useAppréciez Votre VieStyle
+    const prompt = payload.useAvvStyle
       ? `## TEXTE SÉLECTIONNÉ
 
 ${payload.selectedText}
@@ -127,7 +127,7 @@ Retourne uniquement le texte amélioré, sans balises additionnelles, sans préa
       model: 'claude-sonnet-4-5-20250929',
       max_tokens: 8000,
       temperature: 0.7,
-      ...(payload.useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+      ...(payload.useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
       messages: [
         {
           role: 'user',

--- a/apps/avv/app/api/blog/jobs/route.ts
+++ b/apps/avv/app/api/blog/jobs/route.ts
@@ -30,7 +30,7 @@ const createJobSchema = z.object({
   seoQuery: z.string().trim().optional(),
   searchIntent: z.string().trim().optional(),
   readerPersona: z.string().optional(),
-  useAppréciez Votre VieStyle: z.boolean().optional().default(true),
+  useAvvStyle: z.boolean().optional().default(true),
   // Rétrocompatibilité
   subject: z.string().trim().optional(),
   seoKeyword: z.string().trim().optional(),

--- a/apps/avv/app/api/blog/jobs/step-executor.ts
+++ b/apps/avv/app/api/blog/jobs/step-executor.ts
@@ -170,11 +170,11 @@ export async function executeNextStep(jobId: string): Promise<StepExecutionResul
     searchIntent: input.searchIntent || input.searchIntention || '',
     readerPersona: input.readerPersona || input.persona || '',
     preferredTones: input.preferredTones || input.tones || [],
-    useAppréciez Votre VieStyle: input.useAppréciez Votre VieStyle,
+    useAvvStyle: input.useAvvStyle,
   };
 
   const anthropic = new Anthropic({ apiKey });
-  const useAppréciez Votre VieStyle = options.useAppréciez Votre VieStyle !== false;
+  const useAvvStyle = options.useAvvStyle !== false;
 
   try {
     const stepName = STEP_NAMES[stepIndex] || `Étape ${stepIndex + 1}`;
@@ -194,7 +194,7 @@ export async function executeNextStep(jobId: string): Promise<StepExecutionResul
     const updatedPartial = await executeSingleStep(
       anthropic,
       options,
-      useAppréciez Votre VieStyle,
+      useAvvStyle,
       stepIndex,
       partialResult
     );
@@ -278,7 +278,7 @@ export async function executeNextStep(jobId: string): Promise<StepExecutionResul
 async function executeSingleStep(
   anthropic: Anthropic,
   options: SectionalGenerationOptions,
-  useAppréciez Votre VieStyle: boolean,
+  useAvvStyle: boolean,
   stepIndex: number,
   partial: PartialResult
 ): Promise<PartialResult> {
@@ -305,21 +305,21 @@ async function executeSingleStep(
   switch (stepIndex) {
     case 0: {
       // Étape 1: Générer le plan détaillé
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 0, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 0, updated);
       updated.outline = result.outline;
       break;
     }
     case 1: {
       // Étape 2: Générer l'introduction
       if (!updated.outline) throw new Error('Plan détaillé manquant');
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 1, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 1, updated);
       updated.introduction = result.introduction;
       break;
     }
     case 2: {
       // Étape 3: Générer les sections
       if (!updated.outline) throw new Error('Plan détaillé manquant');
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 2, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 2, updated);
       updated.sections = result.sections;
       // Assembler le contenu partiel
       updated.assembledContent = [updated.introduction || '', ...(updated.sections || [])]
@@ -330,7 +330,7 @@ async function executeSingleStep(
     case 3: {
       // Étape 4: Générer la conclusion
       if (!updated.outline) throw new Error('Plan détaillé manquant');
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 3, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 3, updated);
       updated.conclusion = result.conclusion;
       // Mettre à jour le contenu assemblé
       updated.assembledContent = [
@@ -345,7 +345,7 @@ async function executeSingleStep(
     case 4: {
       // Étape 5: Révision de cohérence
       if (!updated.outline) throw new Error('Plan détaillé manquant');
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 4, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 4, updated);
       updated.revisedContent = result.revisedContent;
       updated.coherenceScore = result.coherenceScore;
       break;
@@ -353,26 +353,26 @@ async function executeSingleStep(
     case 5: {
       // Étape 6: Titre et description SEO
       if (!updated.outline) throw new Error('Plan détaillé manquant');
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 5, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 5, updated);
       updated.title = result.title;
       updated.description = result.description;
       break;
     }
     case 6: {
       // Étape 7: Tags
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 6, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 6, updated);
       updated.tags = result.tags;
       break;
     }
     case 7: {
       // Étape 8: FAQ
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 7, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 7, updated);
       updated.faq = result.faq;
       break;
     }
     case 8: {
       // Étape 9: Prompt image
-      const result = await runStepWithGenerator(anthropic, options, useAppréciez Votre VieStyle, 8, updated);
+      const result = await runStepWithGenerator(anthropic, options, useAvvStyle, 8, updated);
       updated.imagePrompt = result.imagePrompt;
       break;
     }
@@ -396,7 +396,7 @@ async function executeSingleStep(
 async function runStepWithGenerator(
   anthropic: Anthropic,
   options: SectionalGenerationOptions,
-  useAppréciez Votre VieStyle: boolean,
+  useAvvStyle: boolean,
   stepIndex: number,
   partial: PartialResult
 ): Promise<Partial<PartialResult>> {
@@ -443,7 +443,7 @@ async function runStepWithGenerator(
 
   // Import du style prompt si nécessaire
   let AVV_STYLE_SYSTEM_PROMPT: string | undefined;
-  if (useAppréciez Votre VieStyle) {
+  if (useAvvStyle) {
     const styleModule = await import('../../common/avv-system-prompt');
     AVV_STYLE_SYSTEM_PROMPT = styleModule.AVV_STYLE_SYSTEM_PROMPT;
   }

--- a/apps/avv/app/api/blog/jobs/worker.ts
+++ b/apps/avv/app/api/blog/jobs/worker.ts
@@ -138,7 +138,7 @@ export async function runBlogGenerationWorker(jobId: string, apiKey: string): Pr
       searchIntent: input.searchIntent || input.searchIntention || '',
       readerPersona: input.readerPersona || input.persona || '',
       preferredTones: allTones,
-      useAppréciez Votre VieStyle: input.useAppréciez Votre VieStyle,
+      useAvvStyle: input.useAvvStyle,
       // Callback de progression pour mettre à jour le job
       onProgress: async (progress: GenerationProgress) => {
         const progressPercent = Math.round((progress.step / progress.totalSteps) * 100);

--- a/apps/avv/app/api/common/claude-article-generator-multi-step.ts
+++ b/apps/avv/app/api/common/claude-article-generator-multi-step.ts
@@ -16,19 +16,15 @@
  * 6. Générer le prompt image
  */
 
-import Anthropic from "@anthropic-ai/sdk";
+import Anthropic from '@anthropic-ai/sdk';
 
-import {
-  parseJsonFromText,
-  withRetryAndTimeout,
-  type RetryOptions,
-} from "./ai-utils";
+import { parseJsonFromText, withRetryAndTimeout, type RetryOptions } from './ai-utils';
 import {
   AVV_IMAGE_GENERATION_PROMPT,
   enrichImagePromptWithThematics,
   validatePromptForMandatoryElements,
-} from "./avv-image-prompt-generator";
-import { AVV_STYLE_SYSTEM_PROMPT } from "./avv-system-prompt";
+} from './avv-image-prompt-generator';
+import { AVV_STYLE_SYSTEM_PROMPT } from './avv-system-prompt';
 
 // Configuration des timeouts et retries
 const API_TIMEOUT_MS = 90000; // 90 secondes par étape
@@ -38,7 +34,8 @@ const RETRY_OPTIONS: RetryOptions = {
   backoffMultiplier: 2,
   maxDelayMs: 15000,
   onRetry: (attempt, error, delayMs) => {
-    console.warn(`🔄 Multi-step retry ${attempt} après erreur, attente ${delayMs}ms:`,
+    console.warn(
+      `🔄 Multi-step retry ${attempt} après erreur, attente ${delayMs}ms:`,
       error instanceof Error ? error.message : error
     );
   },
@@ -48,13 +45,13 @@ const RETRY_OPTIONS: RetryOptions = {
 export interface MultiStepGenerationOptions {
   topic: string;
   category: string;
-  targetLength?: "short" | "medium" | "long";
+  targetLength?: 'short' | 'medium' | 'long';
   seoQuery?: string;
   searchIntent?: string;
-  editorialCategory?: "Comprendre" | "Traverser" | "Découvrir" | "Cheminer";
+  editorialCategory?: 'Comprendre' | 'Traverser' | 'Découvrir' | 'Cheminer';
   readerPersona?: string;
   preferredTones?: string[];
-  useAppréciez Votre VieStyle?: boolean;
+  useAvvStyle?: boolean;
   // Callback pour le suivi de progression
   onProgress?: (step: GenerationStep) => void;
 }
@@ -63,7 +60,7 @@ export interface GenerationStep {
   step: number;
   totalSteps: number;
   name: string;
-  status: "pending" | "in_progress" | "completed" | "error";
+  status: 'pending' | 'in_progress' | 'completed' | 'error';
   message?: string;
 }
 
@@ -98,27 +95,27 @@ export interface GeneratedArticleMultiStep {
 
 // Constantes
 const LENGTH_CONFIG = {
-  short: { words: "800-1000", sections: 2, maxContentTokens: 4000 },
-  medium: { words: "1000-1500", sections: 3, maxContentTokens: 6000 },
-  long: { words: "1500-2000", sections: 4, maxContentTokens: 8000 },
+  short: { words: '800-1000', sections: 2, maxContentTokens: 4000 },
+  medium: { words: '1000-1500', sections: 3, maxContentTokens: 6000 },
+  long: { words: '1500-2000', sections: 4, maxContentTokens: 8000 },
 } as const;
 
 const SPECIFIC_TONE_GUIDE: Record<string, string> = {
-  informatif: "Présente les faits et informations avec clarté et objectivité.",
-  pédagogique: "Approche pédagogique progressive, guidant pas à pas vers la compréhension.",
-  inspirant: "Motivant et porteur, incitant à croire en ses capacités de transformation.",
-  narratif: "Raconte des histoires engageantes, utilisant des anecdotes.",
-  conversationnel: "Ton amical et accessible, comme une conversation entre amis.",
-  professionnel: "Formel et expert, avec vocabulaire spécialisé.",
-  provocateur: "Défi les conventions, provoque la réflexion critique.",
+  informatif: 'Présente les faits et informations avec clarté et objectivité.',
+  pédagogique: 'Approche pédagogique progressive, guidant pas à pas vers la compréhension.',
+  inspirant: 'Motivant et porteur, incitant à croire en ses capacités de transformation.',
+  narratif: 'Raconte des histoires engageantes, utilisant des anecdotes.',
+  conversationnel: 'Ton amical et accessible, comme une conversation entre amis.',
+  professionnel: 'Formel et expert, avec vocabulaire spécialisé.',
+  provocateur: 'Défi les conventions, provoque la réflexion critique.',
   humoristique: "Léger et amusant, utilise l'humour.",
-  poétique: "Approche poétique et métaphorique, beauté du langage.",
-  introspectif: "Approche introspective et contemplative, exploration intérieure.",
+  poétique: 'Approche poétique et métaphorique, beauté du langage.',
+  introspectif: 'Approche introspective et contemplative, exploration intérieure.',
   engagé: "Prend position, appelle à l'action avec passion.",
-  scientifique: "Base sur les données et recherches, ton neutre et basé sur preuves.",
+  scientifique: 'Base sur les données et recherches, ton neutre et basé sur preuves.',
   pragmatique: "Focalisé sur l'utilité pratique et les résultats concrets.",
-  analytique: "Approche analytique et structurée, décortiquant avec précision.",
-  apaisant: "Calme, rassurant, comme une voix intérieure qui guide.",
+  analytique: 'Approche analytique et structurée, décortiquant avec précision.',
+  apaisant: 'Calme, rassurant, comme une voix intérieure qui guide.',
 } as const;
 
 const TOTAL_STEPS = 6;
@@ -151,11 +148,11 @@ function buildEditorialContext(options: MultiStepGenerationOptions): string {
   if (options.preferredTones && options.preferredTones.length > 0) {
     const tonesDesc = options.preferredTones
       .map(t => `- **${t}** : ${SPECIFIC_TONE_GUIDE[t] || t}`)
-      .join("\n");
+      .join('\n');
     parts.push(`**Tons préférés** :\n${tonesDesc}`);
   }
 
-  return parts.join("\n");
+  return parts.join('\n');
 }
 
 /**
@@ -164,9 +161,9 @@ function buildEditorialContext(options: MultiStepGenerationOptions): string {
 async function generateOutline(
   anthropic: Anthropic,
   options: MultiStepGenerationOptions,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<ArticleOutline> {
-  const lengthConfig = LENGTH_CONFIG[options.targetLength || "medium"];
+  const lengthConfig = LENGTH_CONFIG[options.targetLength || 'medium'];
   const editorialContext = buildEditorialContext(options);
 
   const prompt = `Tu dois planifier un article de blog sur le sujet suivant.
@@ -208,25 +205,28 @@ IMPORTANT:
 
   // Appel API avec retry et timeout
   const message = await withRetryAndTimeout(
-    () => anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
-      max_tokens: 1500,
-      temperature: 0.7,
-      ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
-      messages: [{ role: "user", content: prompt }],
-    }),
+    () =>
+      anthropic.messages.create({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 1500,
+        temperature: 0.7,
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        messages: [{ role: 'user', content: prompt }],
+      }),
     API_TIMEOUT_MS,
     RETRY_OPTIONS
   );
 
-  const responseText = message.content[0].type === "text" ? message.content[0].text : "";
+  const responseText = message.content[0].type === 'text' ? message.content[0].text : '';
 
   // Parser le JSON avec l'utilitaire robuste
   try {
     return parseJsonFromText<ArticleOutline>(responseText);
   } catch (error) {
-    console.error("Erreur parsing outline JSON:", responseText.slice(0, 1000));
-    throw new Error(`Impossible de parser le plan de l'article: ${error instanceof Error ? error.message : "Erreur"}`);
+    console.error('Erreur parsing outline JSON:', responseText.slice(0, 1000));
+    throw new Error(
+      `Impossible de parser le plan de l'article: ${error instanceof Error ? error.message : 'Erreur'}`
+    );
   }
 }
 
@@ -237,15 +237,18 @@ async function generateContent(
   anthropic: Anthropic,
   options: MultiStepGenerationOptions,
   outline: ArticleOutline,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<string> {
-  const lengthConfig = LENGTH_CONFIG[options.targetLength || "medium"];
+  const lengthConfig = LENGTH_CONFIG[options.targetLength || 'medium'];
   const editorialContext = buildEditorialContext(options);
 
   // Formater les sections du plan
   const sectionsGuide = outline.sections
-    .map((s, i) => `### Section ${i + 1}: ${s.title}\n- Points clés : ${s.keyPoints.join(", ")}\n- Longueur : ~${s.estimatedWords} mots`)
-    .join("\n\n");
+    .map(
+      (s, i) =>
+        `### Section ${i + 1}: ${s.title}\n- Points clés : ${s.keyPoints.join(', ')}\n- Longueur : ~${s.estimatedWords} mots`
+    )
+    .join('\n\n');
 
   const prompt = `Tu dois rédiger le contenu complet d'un article de blog.
 
@@ -268,7 +271,7 @@ ${outline.targetAudience}
 ${sectionsGuide}
 
 ## MESSAGES CLÉS À TRANSMETTRE
-${outline.keyMessages.map(m => `- ${m}`).join("\n")}
+${outline.keyMessages.map(m => `- ${m}`).join('\n')}
 
 ## INSTRUCTIONS DE RÉDACTION
 
@@ -303,21 +306,22 @@ IMPORTANT: Rédige UNIQUEMENT le contenu Markdown de l'article. Pas de balises X
 
   // Appel API avec retry et timeout (timeout plus long pour le contenu)
   const message = await withRetryAndTimeout(
-    () => anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
-      max_tokens: lengthConfig.maxContentTokens,
-      temperature: 0.7,
-      ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
-      messages: [{ role: "user", content: prompt }],
-    }),
+    () =>
+      anthropic.messages.create({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: lengthConfig.maxContentTokens,
+        temperature: 0.7,
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        messages: [{ role: 'user', content: prompt }],
+      }),
     API_TIMEOUT_MS * 1.5, // Timeout plus long pour le contenu principal
     RETRY_OPTIONS
   );
 
-  const content = message.content[0].type === "text" ? message.content[0].text : "";
+  const content = message.content[0].type === 'text' ? message.content[0].text : '';
 
   if (!content || content.trim().length < 500) {
-    throw new Error("Contenu généré trop court ou vide");
+    throw new Error('Contenu généré trop court ou vide');
   }
 
   return content.trim();
@@ -331,7 +335,7 @@ async function generateTitleAndDescription(
   options: MultiStepGenerationOptions,
   content: string,
   outline: ArticleOutline,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<{ title: string; description: string }> {
   // Extraire les premiers 2000 caractères du contenu pour le contexte
   const contentPreview = content.slice(0, 2000);
@@ -348,7 +352,7 @@ ${options.category}
 ${outline.mainThesis}
 
 ## REQUÊTE SEO
-${options.seoQuery || "Non spécifiée"}
+${options.seoQuery || 'Non spécifiée'}
 
 ## DÉBUT DU CONTENU
 ${contentPreview}...
@@ -375,27 +379,28 @@ Réponds UNIQUEMENT avec le JSON, sans texte avant ou après.`;
 
   // Appel API avec retry et timeout
   const message = await withRetryAndTimeout(
-    () => anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
-      max_tokens: 500,
-      temperature: 0.7,
-      ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
-      messages: [{ role: "user", content: prompt }],
-    }),
+    () =>
+      anthropic.messages.create({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 500,
+        temperature: 0.7,
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        messages: [{ role: 'user', content: prompt }],
+      }),
     API_TIMEOUT_MS,
     RETRY_OPTIONS
   );
 
-  const responseText = message.content[0].type === "text" ? message.content[0].text : "";
+  const responseText = message.content[0].type === 'text' ? message.content[0].text : '';
 
   try {
     // Utiliser le parsing JSON robuste avec fallback
-    return parseJsonFromText<{ title: string; description: string }>(
-      responseText,
-      { title: options.topic, description: `Découvrez notre article sur ${options.topic}` }
-    );
+    return parseJsonFromText<{ title: string; description: string }>(responseText, {
+      title: options.topic,
+      description: `Découvrez notre article sur ${options.topic}`,
+    });
   } catch (error) {
-    console.error("Erreur parsing title/description JSON:", responseText.slice(0, 500));
+    console.error('Erreur parsing title/description JSON:', responseText.slice(0, 500));
     // Retourner des valeurs par défaut au lieu de throw
     return {
       title: options.topic,
@@ -412,7 +417,7 @@ async function generateTags(
   options: MultiStepGenerationOptions,
   content: string,
   title: string,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<string[]> {
   const contentPreview = content.slice(0, 1500);
 
@@ -428,7 +433,7 @@ ${options.topic}
 ${options.category}
 
 ## REQUÊTE SEO
-${options.seoQuery || "Non spécifiée"}
+${options.seoQuery || 'Non spécifiée'}
 
 ## EXTRAIT DU CONTENU
 ${contentPreview}...
@@ -451,24 +456,25 @@ Réponds UNIQUEMENT avec le JSON.`;
 
   // Appel API avec retry et timeout
   const message = await withRetryAndTimeout(
-    () => anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
-      max_tokens: 300,
-      temperature: 0.7,
-      messages: [{ role: "user", content: prompt }],
-    }),
+    () =>
+      anthropic.messages.create({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 300,
+        temperature: 0.7,
+        messages: [{ role: 'user', content: prompt }],
+      }),
     API_TIMEOUT_MS,
     RETRY_OPTIONS
   );
 
-  const responseText = message.content[0].type === "text" ? message.content[0].text : "";
+  const responseText = message.content[0].type === 'text' ? message.content[0].text : '';
 
   try {
     // Utiliser le parsing JSON robuste avec fallback
     const parsed = parseJsonFromText<{ tags?: string[] }>(responseText, { tags: [] });
     return parsed.tags || [];
   } catch (error) {
-    console.error("Erreur parsing tags JSON (non-bloquant):", responseText.slice(0, 300));
+    console.error('Erreur parsing tags JSON (non-bloquant):', responseText.slice(0, 300));
     return [];
   }
 }
@@ -481,7 +487,7 @@ async function generateFAQ(
   options: MultiStepGenerationOptions,
   content: string,
   title: string,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<Array<{ question: string; answer: string }>> {
   const contentPreview = content.slice(0, 2000);
 
@@ -494,10 +500,10 @@ ${title}
 ${options.topic}
 
 ## REQUÊTE SEO
-${options.seoQuery || "Non spécifiée"}
+${options.seoQuery || 'Non spécifiée'}
 
 ## INTENTION DE RECHERCHE
-${options.searchIntent || "Non spécifiée"}
+${options.searchIntent || 'Non spécifiée'}
 
 ## EXTRAIT DU CONTENU
 ${contentPreview}...
@@ -525,18 +531,19 @@ Réponds UNIQUEMENT avec le JSON.`;
 
   // Appel API avec retry et timeout
   const message = await withRetryAndTimeout(
-    () => anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
-      max_tokens: 1500,
-      temperature: 0.7,
-      ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
-      messages: [{ role: "user", content: prompt }],
-    }),
+    () =>
+      anthropic.messages.create({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 1500,
+        temperature: 0.7,
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        messages: [{ role: 'user', content: prompt }],
+      }),
     API_TIMEOUT_MS,
     RETRY_OPTIONS
   );
 
-  const responseText = message.content[0].type === "text" ? message.content[0].text : "";
+  const responseText = message.content[0].type === 'text' ? message.content[0].text : '';
 
   try {
     // Utiliser le parsing JSON robuste avec fallback
@@ -546,7 +553,7 @@ Réponds UNIQUEMENT avec le JSON.`;
     );
     return parsed.faq || [];
   } catch (error) {
-    console.error("Erreur parsing FAQ JSON (non-bloquant):", responseText.slice(0, 500));
+    console.error('Erreur parsing FAQ JSON (non-bloquant):', responseText.slice(0, 500));
     return [];
   }
 }
@@ -559,7 +566,7 @@ async function generateImagePrompt(
   options: MultiStepGenerationOptions,
   content: string,
   title: string,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<string> {
   const contentPreview = content.slice(0, 1500);
 
@@ -625,18 +632,19 @@ Réponds UNIQUEMENT avec le prompt image, sans JSON ni balises.`;
 
   // Appel API avec le system prompt spécialisé et retry/timeout
   const message = await withRetryAndTimeout(
-    () => anthropic.messages.create({
-      model: "claude-sonnet-4-5-20250929",
-      max_tokens: 1000,
-      temperature: 0.7,
-      system: AVV_IMAGE_GENERATION_PROMPT,
-      messages: [{ role: "user", content: prompt }],
-    }),
+    () =>
+      anthropic.messages.create({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 1000,
+        temperature: 0.7,
+        system: AVV_IMAGE_GENERATION_PROMPT,
+        messages: [{ role: 'user', content: prompt }],
+      }),
     API_TIMEOUT_MS,
     RETRY_OPTIONS
   );
 
-  const rawImagePrompt = message.content[0].type === "text" ? message.content[0].text : "";
+  const rawImagePrompt = message.content[0].type === 'text' ? message.content[0].text : '';
 
   // Enrichir avec les données thématiques et la catégorie
   const enrichedPrompt = enrichImagePromptWithThematics(
@@ -650,7 +658,7 @@ Réponds UNIQUEMENT avec le prompt image, sans JSON ni balises.`;
 
   if (!validation.isValid) {
     console.warn(
-      `⚠️ IMAGE_PROMPT (multi-step) manque des éléments obligatoires: ${validation.missingElements.join(", ")}`
+      `⚠️ IMAGE_PROMPT (multi-step) manque des éléments obligatoires: ${validation.missingElements.join(', ')}`
     );
   }
 
@@ -665,9 +673,14 @@ export async function generateArticleMultiStep(
   apiKey: string
 ): Promise<GeneratedArticleMultiStep> {
   const anthropic = createAnthropicClient(apiKey);
-  const useAppréciez Votre VieStyle = options.useAppréciez Votre VieStyle !== false;
+  const useAvvStyle = options.useAvvStyle !== false;
 
-  const notifyProgress = (step: number, name: string, status: GenerationStep["status"], message?: string) => {
+  const notifyProgress = (
+    step: number,
+    name: string,
+    status: GenerationStep['status'],
+    message?: string
+  ) => {
     if (options.onProgress) {
       options.onProgress({ step, totalSteps: TOTAL_STEPS, name, status, message });
     }
@@ -684,40 +697,55 @@ export async function generateArticleMultiStep(
 
   try {
     // ÉTAPE 1: Générer le plan
-    notifyProgress(1, "Génération du plan", "in_progress", "Création de la structure de l'article...");
+    notifyProgress(
+      1,
+      'Génération du plan',
+      'in_progress',
+      "Création de la structure de l'article..."
+    );
     try {
-      outline = await generateOutline(anthropic, options, useAppréciez Votre VieStyle);
+      outline = await generateOutline(anthropic, options, useAvvStyle);
       stepsCompleted = 1;
-      notifyProgress(1, "Génération du plan", "completed");
+      notifyProgress(1, 'Génération du plan', 'completed');
     } catch (error) {
-      console.error("Erreur étape 1 (outline):", error);
-      notifyProgress(1, "Génération du plan", "error", "Échec de la génération du plan");
-      throw new Error(`Échec de la génération du plan: ${error instanceof Error ? error.message : "Erreur inconnue"}`);
+      console.error('Erreur étape 1 (outline):', error);
+      notifyProgress(1, 'Génération du plan', 'error', 'Échec de la génération du plan');
+      throw new Error(
+        `Échec de la génération du plan: ${error instanceof Error ? error.message : 'Erreur inconnue'}`
+      );
     }
 
     // ÉTAPE 2: Générer le contenu
-    notifyProgress(2, "Rédaction du contenu", "in_progress", "Rédaction de l'article...");
+    notifyProgress(2, 'Rédaction du contenu', 'in_progress', "Rédaction de l'article...");
     try {
-      content = await generateContent(anthropic, options, outline, useAppréciez Votre VieStyle);
+      content = await generateContent(anthropic, options, outline, useAvvStyle);
       stepsCompleted = 2;
-      notifyProgress(2, "Rédaction du contenu", "completed");
+      notifyProgress(2, 'Rédaction du contenu', 'completed');
     } catch (error) {
-      console.error("Erreur étape 2 (content):", error);
-      notifyProgress(2, "Rédaction du contenu", "error", "Échec de la rédaction");
-      throw new Error(`Échec de la rédaction du contenu: ${error instanceof Error ? error.message : "Erreur inconnue"}`);
+      console.error('Erreur étape 2 (content):', error);
+      notifyProgress(2, 'Rédaction du contenu', 'error', 'Échec de la rédaction');
+      throw new Error(
+        `Échec de la rédaction du contenu: ${error instanceof Error ? error.message : 'Erreur inconnue'}`
+      );
     }
 
     // ÉTAPE 3: Générer titre et description
-    notifyProgress(3, "Optimisation SEO", "in_progress", "Génération du titre et description...");
+    notifyProgress(3, 'Optimisation SEO', 'in_progress', 'Génération du titre et description...');
     try {
-      const titleDesc = await generateTitleAndDescription(anthropic, options, content, outline, useAppréciez Votre VieStyle);
+      const titleDesc = await generateTitleAndDescription(
+        anthropic,
+        options,
+        content,
+        outline,
+        useAvvStyle
+      );
       title = titleDesc.title;
       description = titleDesc.description;
       stepsCompleted = 3;
-      notifyProgress(3, "Optimisation SEO", "completed");
+      notifyProgress(3, 'Optimisation SEO', 'completed');
     } catch (error) {
-      console.error("Erreur étape 3 (title/desc):", error);
-      notifyProgress(3, "Optimisation SEO", "error", "Échec de l'optimisation SEO");
+      console.error('Erreur étape 3 (title/desc):', error);
+      notifyProgress(3, 'Optimisation SEO', 'error', "Échec de l'optimisation SEO");
       // Continuer avec des valeurs par défaut
       title = options.topic;
       description = `Découvrez notre article sur ${options.topic}`;
@@ -725,40 +753,55 @@ export async function generateArticleMultiStep(
     }
 
     // ÉTAPE 4: Générer les tags
-    notifyProgress(4, "Génération des tags", "in_progress", "Création des tags SEO...");
+    notifyProgress(4, 'Génération des tags', 'in_progress', 'Création des tags SEO...');
     try {
-      tags = await generateTags(anthropic, options, content, title, useAppréciez Votre VieStyle);
+      tags = await generateTags(anthropic, options, content, title, useAvvStyle);
       stepsCompleted = 4;
-      notifyProgress(4, "Génération des tags", "completed");
+      notifyProgress(4, 'Génération des tags', 'completed');
     } catch (error) {
-      console.error("Erreur étape 4 (tags):", error);
-      notifyProgress(4, "Génération des tags", "error", "Échec de la génération des tags");
+      console.error('Erreur étape 4 (tags):', error);
+      notifyProgress(4, 'Génération des tags', 'error', 'Échec de la génération des tags');
       // Continuer sans tags
       stepsCompleted = 4;
     }
 
     // ÉTAPE 5: Générer la FAQ
-    notifyProgress(5, "Création de la FAQ", "in_progress", "Génération des questions fréquentes...");
+    notifyProgress(
+      5,
+      'Création de la FAQ',
+      'in_progress',
+      'Génération des questions fréquentes...'
+    );
     try {
-      faq = await generateFAQ(anthropic, options, content, title, useAppréciez Votre VieStyle);
+      faq = await generateFAQ(anthropic, options, content, title, useAvvStyle);
       stepsCompleted = 5;
-      notifyProgress(5, "Création de la FAQ", "completed");
+      notifyProgress(5, 'Création de la FAQ', 'completed');
     } catch (error) {
-      console.error("Erreur étape 5 (FAQ):", error);
-      notifyProgress(5, "Création de la FAQ", "error", "Échec de la génération de la FAQ");
+      console.error('Erreur étape 5 (FAQ):', error);
+      notifyProgress(5, 'Création de la FAQ', 'error', 'Échec de la génération de la FAQ');
       // Continuer sans FAQ
       stepsCompleted = 5;
     }
 
     // ÉTAPE 6: Générer le prompt image
-    notifyProgress(6, "Création du prompt image", "in_progress", "Génération du prompt pour l'illustration...");
+    notifyProgress(
+      6,
+      'Création du prompt image',
+      'in_progress',
+      "Génération du prompt pour l'illustration..."
+    );
     try {
-      imagePrompt = await generateImagePrompt(anthropic, options, content, title, useAppréciez Votre VieStyle);
+      imagePrompt = await generateImagePrompt(anthropic, options, content, title, useAvvStyle);
       stepsCompleted = 6;
-      notifyProgress(6, "Création du prompt image", "completed");
+      notifyProgress(6, 'Création du prompt image', 'completed');
     } catch (error) {
-      console.error("Erreur étape 6 (image prompt):", error);
-      notifyProgress(6, "Création du prompt image", "error", "Échec de la génération du prompt image");
+      console.error('Erreur étape 6 (image prompt):', error);
+      notifyProgress(
+        6,
+        'Création du prompt image',
+        'error',
+        'Échec de la génération du prompt image'
+      );
       // Continuer sans prompt image
       stepsCompleted = 6;
     }
@@ -781,12 +824,11 @@ export async function generateArticleMultiStep(
         totalSteps: TOTAL_STEPS,
       },
     };
-
   } catch (error) {
-    console.error("Erreur lors de la génération multi-étapes:", error);
+    console.error('Erreur lors de la génération multi-étapes:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : "Erreur inconnue lors de la génération",
+      error: error instanceof Error ? error.message : 'Erreur inconnue lors de la génération',
       // Retourner les données partielles si disponibles
       title,
       description,

--- a/apps/avv/app/api/common/claude-article-generator-sectional.ts
+++ b/apps/avv/app/api/common/claude-article-generator-sectional.ts
@@ -54,7 +54,7 @@ export interface SectionalGenerationOptions {
   editorialCategory?: 'Comprendre' | 'Traverser' | 'Découvrir' | 'Cheminer';
   readerPersona?: string;
   preferredTones?: string[];
-  useAppréciez Votre VieStyle?: boolean;
+  useAvvStyle?: boolean;
   onProgress?: (step: GenerationProgress) => void | Promise<void>;
 }
 
@@ -214,7 +214,7 @@ function buildEditorialContext(options: SectionalGenerationOptions): string {
 async function generateDetailedOutline(
   anthropic: Anthropic,
   options: SectionalGenerationOptions,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<DetailedOutline> {
   const lengthConfig = LENGTH_CONFIG[options.targetLength || 'medium'];
   const editorialContext = buildEditorialContext(options);
@@ -279,7 +279,7 @@ IMPORTANT:
         model: 'claude-sonnet-4-5-20250929',
         max_tokens: 5000, // Augmenté de 2000 à 5000 pour éviter la troncature du JSON
         temperature: 0.7,
-        ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
         messages: [{ role: 'user', content: prompt }],
       }),
     API_TIMEOUT_MS,
@@ -306,7 +306,7 @@ async function generateIntroduction(
   anthropic: Anthropic,
   options: SectionalGenerationOptions,
   outline: DetailedOutline,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<string> {
   const lengthConfig = LENGTH_CONFIG[options.targetLength || 'medium'];
   const editorialContext = buildEditorialContext(options);
@@ -352,7 +352,7 @@ IMPORTANT: Rédige UNIQUEMENT l'introduction en Markdown, sans balises ni commen
         model: 'claude-sonnet-4-5-20250929',
         max_tokens: 1000,
         temperature: 0.7,
-        ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
         messages: [{ role: 'user', content: prompt }],
       }),
     API_TIMEOUT_MS,
@@ -372,7 +372,7 @@ async function generateSection(
   outline: DetailedOutline,
   sectionIndex: number,
   previousSectionsContent: string,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<string> {
   const lengthConfig = LENGTH_CONFIG[options.targetLength || 'medium'];
   const section = outline.sections[sectionIndex];
@@ -436,7 +436,7 @@ IMPORTANT: Rédige UNIQUEMENT cette section en Markdown (titre H2 inclus), sans 
         model: 'claude-sonnet-4-5-20250929',
         max_tokens: lengthConfig.maxTokensPerSection,
         temperature: 0.7,
-        ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
         messages: [{ role: 'user', content: prompt }],
       }),
     API_TIMEOUT_MS,
@@ -455,7 +455,7 @@ async function generateConclusion(
   options: SectionalGenerationOptions,
   outline: DetailedOutline,
   fullContentSoFar: string,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<string> {
   const lengthConfig = LENGTH_CONFIG[options.targetLength || 'medium'];
   const editorialContext = buildEditorialContext(options);
@@ -498,7 +498,7 @@ IMPORTANT: Rédige UNIQUEMENT la conclusion en Markdown (titre H2 inclus), sans 
         model: 'claude-sonnet-4-5-20250929',
         max_tokens: 1000,
         temperature: 0.7,
-        ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
         messages: [{ role: 'user', content: prompt }],
       }),
     API_TIMEOUT_MS,
@@ -517,7 +517,7 @@ async function reviseForCoherence(
   options: SectionalGenerationOptions,
   fullContent: string,
   outline: DetailedOutline,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<{ revisedContent: string; coherenceScore: number }> {
   const editorialContext = buildEditorialContext(options);
 
@@ -569,7 +569,7 @@ Le coherenceScore est une note de 0 à 100 évaluant la cohérence de l'article.
         model: 'claude-sonnet-4-5-20250929',
         max_tokens: 8000,
         temperature: 0.3, // Température basse pour la révision
-        ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
         messages: [{ role: 'user', content: prompt }],
       }),
     COHERENCE_TIMEOUT_MS,
@@ -605,7 +605,7 @@ async function generateTitleAndDescription(
   options: SectionalGenerationOptions,
   content: string,
   outline: DetailedOutline,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<{ title: string; description: string }> {
   const contentPreview = content.slice(0, 2000);
 
@@ -648,7 +648,7 @@ Réponds UNIQUEMENT avec le JSON.`;
         model: 'claude-sonnet-4-5-20250929',
         max_tokens: 500,
         temperature: 0.7,
-        ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
         messages: [{ role: 'user', content: prompt }],
       }),
     API_TIMEOUT_MS,
@@ -743,7 +743,7 @@ async function generateFAQ(
   options: SectionalGenerationOptions,
   content: string,
   title: string,
-  useAppréciez Votre VieStyle: boolean
+  useAvvStyle: boolean
 ): Promise<Array<{ question: string; answer: string }>> {
   const contentPreview = content.slice(0, 2000);
 
@@ -784,7 +784,7 @@ Réponds UNIQUEMENT avec le JSON.`;
         model: 'claude-sonnet-4-5-20250929',
         max_tokens: 1500,
         temperature: 0.7,
-        ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+        ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
         messages: [{ role: 'user', content: prompt }],
       }),
     API_TIMEOUT_MS,
@@ -920,7 +920,7 @@ export async function generateArticleSectional(
   apiKey: string
 ): Promise<GeneratedSectionalArticle> {
   const anthropic = createAnthropicClient(apiKey);
-  const useAppréciez Votre VieStyle = options.useAppréciez Votre VieStyle !== false;
+  const useAvvStyle = options.useAvvStyle !== false;
   const lengthConfig = LENGTH_CONFIG[options.targetLength || 'medium'];
 
   // Calcul du nombre total d'étapes
@@ -983,7 +983,7 @@ export async function generateArticleSectional(
       "Création de la structure de l'article..."
     );
     try {
-      outline = await generateDetailedOutline(anthropic, options, useAppréciez Votre VieStyle);
+      outline = await generateDetailedOutline(anthropic, options, useAvvStyle);
       await safeNotifyProgress('Génération du plan détaillé', 'completed');
     } catch (error) {
       console.error('Erreur étape 1 (outline):', error);
@@ -999,7 +999,7 @@ export async function generateArticleSectional(
       'Création du chapo introductif...'
     );
     try {
-      const intro = await generateIntroduction(anthropic, options, outline, useAppréciez Votre VieStyle);
+      const intro = await generateIntroduction(anthropic, options, outline, useAvvStyle);
       content = intro;
       await safeNotifyProgress("Rédaction de l'introduction", 'completed');
     } catch (error) {
@@ -1027,7 +1027,7 @@ export async function generateArticleSectional(
           outline,
           i,
           content,
-          useAppréciez Votre VieStyle
+          useAvvStyle
         );
         content += '\n\n' + sectionContent;
         sectionsGenerated++;
@@ -1055,7 +1055,7 @@ export async function generateArticleSectional(
         options,
         outline,
         content,
-        useAppréciez Votre VieStyle
+        useAvvStyle
       );
       content += '\n\n' + conclusion;
       await safeNotifyProgress('Rédaction de la conclusion', 'completed');
@@ -1073,13 +1073,7 @@ export async function generateArticleSectional(
       'Amélioration des transitions...'
     );
     try {
-      const revision = await reviseForCoherence(
-        anthropic,
-        options,
-        content,
-        outline,
-        useAppréciez Votre VieStyle
-      );
+      const revision = await reviseForCoherence(anthropic, options, content, outline, useAvvStyle);
       // Seulement utiliser le contenu révisé s'il est non vide et de longueur raisonnable
       if (revision.revisedContent && revision.revisedContent.length > content.length * 0.5) {
         content = revision.revisedContent;
@@ -1111,7 +1105,7 @@ export async function generateArticleSectional(
         options,
         content,
         outline,
-        useAppréciez Votre VieStyle
+        useAvvStyle
       );
       title = titleDesc.title;
       description = titleDesc.description;
@@ -1142,7 +1136,7 @@ export async function generateArticleSectional(
       'Génération des questions fréquentes...'
     );
     try {
-      faq = await generateFAQ(anthropic, options, content, title, useAppréciez Votre VieStyle);
+      faq = await generateFAQ(anthropic, options, content, title, useAvvStyle);
       await safeNotifyProgress('Création de la FAQ', 'completed', `${faq.length} questions`);
     } catch (error) {
       console.error('Erreur FAQ:', error);

--- a/apps/avv/app/api/common/claude-article-generator.ts
+++ b/apps/avv/app/api/common/claude-article-generator.ts
@@ -53,7 +53,7 @@ export interface ArticleGenerationOptions {
     | 'pragmatique';
   // Nouveaux tons préférés (multi-sélection)
   preferredTones?: string[];
-  useAppréciez Votre VieStyle?: boolean; // Activer le style rédactionnel AVV complet (default: true)
+  useAvvStyle?: boolean; // Activer le style rédactionnel AVV complet (default: true)
 }
 
 export interface GeneratedArticle {
@@ -301,7 +301,7 @@ export async function generateArticleWithClaude(
     });
 
     // Utiliser le style AVV par défaut (sauf désactivation explicite)
-    const useAppréciez Votre VieStyle = options.useAppréciez Votre VieStyle !== false;
+    const useAvvStyle = options.useAvvStyle !== false;
 
     // Construire le prompt selon les options
     const targetLength = options.targetLength || 'medium';
@@ -312,7 +312,7 @@ export async function generateArticleWithClaude(
     let editorialContext = '';
     let tonInstructions = '';
 
-    if (useAppréciez Votre VieStyle) {
+    if (useAvvStyle) {
       // Formater les tons préférés et créer les instructions
       if (options.preferredTones && options.preferredTones.length > 0) {
         // Créer un contexte riche pour les tons multiples
@@ -375,7 +375,7 @@ ${options.readerPersona ? `**Persona lecteur** : ${options.readerPersona}` : ''}
     }
 
     // Construire le prompt utilisateur
-    const prompt = useAppréciez Votre VieStyle
+    const prompt = useAvvStyle
       ? `${AVV_TECHNICAL_INSTRUCTIONS}
 
 ${editorialContext}
@@ -537,7 +537,7 @@ Génère maintenant l'article complet.`;
           max_tokens: maxTokensByLength[targetLength],
           temperature: 0.7,
           // ✨ Utiliser le system prompt AVV si activé
-          ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+          ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
           messages: [
             {
               role: 'user',
@@ -558,7 +558,7 @@ Génère maintenant l'article complet.`;
     }
 
     // Vérifier si la réponse a été tronquée (toutes les balises XML requises)
-    const requiredTags = useAppréciez Votre VieStyle
+    const requiredTags = useAvvStyle
       ? ['TITLE', 'DESCRIPTION', 'CONTENT', 'TAGS', 'FAQ', 'IMAGE_PROMPT']
       : ['TITLE', 'DESCRIPTION', 'CONTENT', 'TAGS'];
 
@@ -723,21 +723,21 @@ Génère maintenant l'article complet.`;
  * @param existingContent - Contenu existant de l'article
  * @param improvementPrompt - Instructions spécifiques pour l'amélioration
  * @param apiKey - Clé API Anthropic
- * @param useAppréciez Votre VieStyle - Utiliser le style AVV complet (default: true)
+ * @param useAvvStyle - Utiliser le style AVV complet (default: true)
  * @returns L'article amélioré
  */
 export async function improveArticleWithClaude(
   existingContent: string,
   improvementPrompt: string,
   apiKey: string,
-  useAppréciez Votre VieStyle = true
+  useAvvStyle = true
 ): Promise<GeneratedArticle> {
   try {
     const anthropic = new Anthropic({
       apiKey: apiKey,
     });
 
-    const prompt = useAppréciez Votre VieStyle
+    const prompt = useAvvStyle
       ? `${AVV_TECHNICAL_INSTRUCTIONS}
 
 ## CONTENU ACTUEL DE L'ARTICLE
@@ -781,7 +781,7 @@ Retourne uniquement le contenu amélioré en Markdown, sans balises additionnell
           max_tokens: 6000, // Même limite que la génération
           temperature: 0.7,
           // ✨ Utiliser le system prompt AVV si activé
-          ...(useAppréciez Votre VieStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
+          ...(useAvvStyle && { system: AVV_STYLE_SYSTEM_PROMPT }),
           messages: [
             {
               role: 'user',

--- a/apps/avv/components/ErrorBoundary.tsx
+++ b/apps/avv/components/ErrorBoundary.tsx
@@ -13,7 +13,7 @@ import { ErrorBoundary as SharedErrorBoundary } from '@kairn/ui';
 import type { ErrorInfo, ReactNode } from 'react';
 
 /** Props du wrapper ErrorBoundary Appréciez Votre Vie */
-interface Appréciez Votre VieErrorBoundaryProps {
+interface AvvErrorBoundaryProps {
   /** Contenu enfant */
   children: ReactNode;
   /** Composant fallback personnalisé */
@@ -57,14 +57,9 @@ function handleError(error: Error, errorInfo: ErrorInfo, context?: Record<string
  * </ErrorBoundary>
  * ```
  */
-export function ErrorBoundary({ children, fallback }: Appréciez Votre VieErrorBoundaryProps) {
+export function ErrorBoundary({ children, fallback }: AvvErrorBoundaryProps) {
   return (
-    <SharedErrorBoundary
-      fallback={fallback}
-      onError={handleError}
-      colors={AVV_COLORS}
-      homeUrl="/"
-    >
+    <SharedErrorBoundary fallback={fallback} onError={handleError} colors={AVV_COLORS} homeUrl="/">
       {children}
     </SharedErrorBoundary>
   );

--- a/apps/avv/components/GeoPage.tsx
+++ b/apps/avv/components/GeoPage.tsx
@@ -23,7 +23,13 @@ export interface GeoPageProps {
   title: string;
   subtitle: string;
   description: string;
-  service: 'psychotherapie' | 'somatothérapie' | 'respiration';
+  service:
+    | 'psychotherapie'
+    | 'somatothérapie'
+    | 'respiration'
+    | 'sophrologie'
+    | 'somatotherapie'
+    | 'breathwork';
   location: {
     city: string;
     department?: string;
@@ -59,14 +65,20 @@ export interface GeoPageProps {
 // Service labels and links
 const serviceLabels: Record<GeoPageProps['service'], string> = {
   psychotherapie: 'Sophrologie',
+  sophrologie: 'Sophrologie',
   somatothérapie: 'Somatothérapie',
+  somatotherapie: 'Somatothérapie',
   respiration: 'Breathwork & rebirth',
+  breathwork: 'Breathwork & rebirth',
 };
 
 const serviceLinks: Record<GeoPageProps['service'], string> = {
   psychotherapie: '/sophrologie',
+  sophrologie: '/sophrologie',
   somatothérapie: '/somatotherapie',
+  somatotherapie: '/somatotherapie',
   respiration: '/breathwork',
+  breathwork: '/breathwork',
 };
 
 // Default pricing for Appréciez Votre Vie

--- a/apps/avv/config/site.config.ts
+++ b/apps/avv/config/site.config.ts
@@ -112,8 +112,7 @@ j'accompagne désormais les adultes dans une démarche de ré-enchantement de le
       id: 'breathwork',
       name: 'Breathwork & Rebirth',
       slug: 'breathwork',
-      shortDescription:
-        'Techniques de respiration pour un voyage intérieur profond et libérateur.',
+      shortDescription: 'Techniques de respiration pour un voyage intérieur profond et libérateur.',
       icon: 'Wind',
       enabled: true,
       order: 3,
@@ -123,7 +122,7 @@ j'accompagne désormais les adultes dans une démarche de ré-enchantement de le
       name: 'Cohérence Cardiaque',
       slug: 'coherence-cardiaque',
       shortDescription:
-        'Exercices de respiration rythmée pour réguler le stress et harmoniser le corps et l\'esprit.',
+        "Exercices de respiration rythmée pour réguler le stress et harmoniser le corps et l'esprit.",
       icon: 'HeartPulse',
       enabled: true,
       order: 4,
@@ -158,7 +157,7 @@ j'accompagne désormais les adultes dans une démarche de ré-enchantement de le
       'Appréciez Votre Vie - Sophrologie, Relaxation & Somatothérapie | Saint-Julien-du-Sault, Yonne',
     titleTemplate: '%s | Appréciez Votre Vie',
     description:
-      'Nathalie Duquenne, sophrologue et somatothérapeute à Saint-Julien-du-Sault (89). Sophrologie, relaxation, somatothérapie, breathwork, cohérence cardiaque et reiki.',
+      'Nathalie Duquenne, sophrologue et somatothérapeute à Saint-Julien-du-Sault (89). Sophrologie, relaxation, somatothérapie, breathwork et reiki.',
     keywords: [
       'sophrologie',
       'relaxation',

--- a/apps/avv/lib/categoryColors.ts
+++ b/apps/avv/lib/categoryColors.ts
@@ -23,15 +23,15 @@ export const CATEGORY_COLORS = defineCategoryColors({
   Comprendre: COLOR_PRESETS.blue,
   Traverser: COLOR_PRESETS.green,
   Découvrir: COLOR_PRESETS.purple,
-  Cheminer: COLOR_PRESETS.mauve,
+  Cheminer: COLOR_PRESETS.pink,
 });
 
 export type Category = keyof typeof CATEGORY_COLORS;
 
 /**
- * Get colors for a category, falling back to mauve (Cheminer)
+ * Get colors for a category, falling back to pink (Cheminer)
  */
 export const getCategoryColors = createCategoryColorGetter(
   CATEGORY_COLORS,
-  COLOR_PRESETS.mauve // Default fallback for AVV
+  COLOR_PRESETS.pink // Default fallback for AVV
 );

--- a/apps/avv/scripts/migrate-blog-from-json.ts
+++ b/apps/avv/scripts/migrate-blog-from-json.ts
@@ -41,7 +41,7 @@ const AVV_BASE_URL = 'https://appreciezvotrevie.fr';
 // Types
 // ============================================
 
-interface Appréciez Votre VieBlogPost {
+interface AvvBlogPost {
   id: string;
   slug: string;
   title: string;
@@ -103,7 +103,7 @@ const kairnSupabase = createKairnSupabase();
 /**
  * Load articles from JSON file
  */
-async function loadArticlesFromJson(): Promise<Appréciez Votre VieBlogPost[]> {
+async function loadArticlesFromJson(): Promise<AvvBlogPost[]> {
   try {
     const content = await fs.readFile(DATA_FILE, 'utf-8');
     const data = JSON.parse(content);
@@ -270,7 +270,7 @@ function parseJsonField(value: string | unknown): unknown {
  * Create article in KAIRN database
  */
 async function createKairnArticle(
-  article: Appréciez Votre VieBlogPost,
+  article: AvvBlogPost,
   newImageUrl: string | null
 ): Promise<boolean> {
   try {

--- a/apps/avv/scripts/migrate-blog-from-psypnos.ts
+++ b/apps/avv/scripts/migrate-blog-from-psypnos.ts
@@ -41,7 +41,7 @@ const AVV_DEFAULT_URL = `https://${AVV_PROJECT_REF}.supabase.co`;
 // Types
 // ============================================
 
-interface Appréciez Votre VieBlogPost {
+interface AvvBlogPost {
   id: string;
   slug: string;
   title: string;
@@ -88,7 +88,7 @@ let avvPool: Pool | null = null;
 let avvSupabase: SupabaseClient | null = null;
 let dataSource: DataSource = 'postgres';
 
-function initAppréciez Votre VieConnection(): DataSource {
+function initAvvConnection(): DataSource {
   // Try PostgreSQL direct connection first
   if (process.env.AVV_DATABASE_URL) {
     avvPool = new Pool({
@@ -142,7 +142,7 @@ let kairnSupabase: SupabaseClient | null = null;
 /**
  * Fetch all articles from AVV database via PostgreSQL
  */
-async function fetchAppréciez Votre VieArticlesPostgres(): Promise<Appréciez Votre VieBlogPost[]> {
+async function fetchAvvArticlesPostgres(): Promise<AvvBlogPost[]> {
   if (!avvPool) {
     throw new Error('PostgreSQL pool not initialized');
   }
@@ -163,7 +163,7 @@ async function fetchAppréciez Votre VieArticlesPostgres(): Promise<Appréciez V
 /**
  * Fetch all articles from AVV via Supabase REST API
  */
-async function fetchAppréciez Votre VieArticlesSupabase(): Promise<Appréciez Votre VieBlogPost[]> {
+async function fetchAvvArticlesSupabase(): Promise<AvvBlogPost[]> {
   if (!avvSupabase) {
     throw new Error('Supabase client not initialized');
   }
@@ -183,11 +183,11 @@ async function fetchAppréciez Votre VieArticlesSupabase(): Promise<Appréciez V
 /**
  * Fetch articles from AVV using the configured data source
  */
-async function fetchAppréciez Votre VieArticles(): Promise<Appréciez Votre VieBlogPost[]> {
+async function fetchAvvArticles(): Promise<AvvBlogPost[]> {
   if (dataSource === 'postgres') {
-    return fetchAppréciez Votre VieArticlesPostgres();
+    return fetchAvvArticlesPostgres();
   }
-  return fetchAppréciez Votre VieArticlesSupabase();
+  return fetchAvvArticlesSupabase();
 }
 
 /**
@@ -336,7 +336,7 @@ function validateUtf8(text: string, field: string, slug: string): void {
  * Create article in KAIRN database
  */
 async function createKairnArticle(
-  article: Appréciez Votre VieBlogPost,
+  article: AvvBlogPost,
   newImageUrl: string | null
 ): Promise<boolean> {
   try {
@@ -397,11 +397,11 @@ async function migrate() {
     console.log('📋 ÉTAPE 1: Analyse préalable\n');
 
     // Initialize connections
-    dataSource = initAppréciez Votre VieConnection();
+    dataSource = initAvvConnection();
     kairnSupabase = createKairnSupabase();
 
     console.log('\nConnexion à AVV...');
-    const avvArticles = await fetchAppréciez Votre VieArticles();
+    const avvArticles = await fetchAvvArticles();
     console.log(`✅ ${avvArticles.length} articles trouvés dans AVV\n`);
 
     report.totalArticles = avvArticles.length;
@@ -565,9 +565,7 @@ function printReport(report: MigrationReport) {
   console.log('┌─────────────────────────────────────┬──────────┐');
   console.log('│ Métrique                            │ Valeur   │');
   console.log('├─────────────────────────────────────┼──────────┤');
-  console.log(
-    `│ Articles source (AVV)           │ ${String(report.totalArticles).padStart(8)} │`
-  );
+  console.log(`│ Articles source (AVV)           │ ${String(report.totalArticles).padStart(8)} │`);
   console.log(
     `│ Articles migrés                     │ ${String(report.migratedArticles).padStart(8)} │`
   );
@@ -617,7 +615,7 @@ async function main() {
     process.exit(1);
   }
 
-  // AVV source will be checked in initAppréciez Votre VieConnection()
+  // AVV source will be checked in initAvvConnection()
 
   try {
     const report = await migrate();

--- a/apps/avv/scripts/migrate-blog-standalone.ts
+++ b/apps/avv/scripts/migrate-blog-standalone.ts
@@ -120,7 +120,7 @@ function generateCuid(): string {
   return `c${timestamp}${random}`;
 }
 
-async function fetchAppréciez Votre VieArticles(): Promise<BlogPost[]> {
+async function fetchAvvArticles(): Promise<BlogPost[]> {
   if (!avvPool) throw new Error('AVV pool not initialized');
   const query = `
     SELECT
@@ -282,7 +282,7 @@ async function migrate(): Promise<MigrationReport> {
     console.log('📋 ÉTAPE 1: Analyse préalable\n');
 
     console.log('Connexion à AVV...');
-    const avvArticles = await fetchAppréciez Votre VieArticles();
+    const avvArticles = await fetchAvvArticles();
     console.log(`✅ ${avvArticles.length} articles trouvés dans AVV\n`);
     report.totalArticles = avvArticles.length;
 
@@ -381,9 +381,7 @@ function printReport(report: MigrationReport): void {
   console.log('┌─────────────────────────────────────┬──────────┐');
   console.log('│ Métrique                            │ Valeur   │');
   console.log('├─────────────────────────────────────┼──────────┤');
-  console.log(
-    `│ Articles source (AVV)           │ ${String(report.totalArticles).padStart(8)} │`
-  );
+  console.log(`│ Articles source (AVV)           │ ${String(report.totalArticles).padStart(8)} │`);
   console.log(
     `│ Articles migrés                     │ ${String(report.migratedArticles).padStart(8)} │`
   );


### PR DESCRIPTION
## Résumé

- Renommer les identifiants TS invalides contenant des espaces (ex: `useAppréciez Votre VieStyle` → `useAvvStyle`)
- Ajouter `sophrologie`, `somatotherapie` et `breathwork` au type union GeoPageProps.service
- Remplacer `COLOR_PRESETS.mauve` (inexistant) par `COLOR_PRESETS.pink`
- Raccourcir la description SEO (167→145 car, max 160)
- Corriger les références de test cassées (`RESPIRATION_URL`, email login)

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `app/api/common/claude-article-generator*.ts` | Renommage identifiants `useAvvStyle` |
| `app/api/blog/*/route.ts` + `step-executor.ts` + `worker.ts` | Renommage identifiants Zod + options |
| `app/admin/blog/_components/*.tsx` | Renommage state/props `useAvvStyle` |
| `components/ErrorBoundary.tsx` | `AvvErrorBoundaryProps` |
| `components/GeoPage.tsx` | Extension du type union service |
| `config/site.config.ts` | Description SEO raccourcie |
| `lib/categoryColors.ts` | `COLOR_PRESETS.pink` au lieu de `mauve` |
| `scripts/migrate-blog-*.ts` | Renommage interfaces/fonctions |
| `__tests__/**` | Corrections références cassées |

## Validation

| Étape | Statut |
|---|---|
| Lint | ✅ 0 erreurs |
| Type-check | ✅ |
| Tests (coverage) | ✅ 1431/1431 |
| Tests (UI) | ✅ 192/192 |
| Build | ✅ |

Fixes #385

https://claude.ai/code/session_01HmFzk2vox3CsDkP16uZKqK