### PR TITLE
fix(blog): corriger blog vide, délai SSR, marquee et couleurs catégories

### DIFF
--- a/apps/psypnos/app/(pages)/sections/blog.tsx
+++ b/apps/psypnos/app/(pages)/sections/blog.tsx
@@ -8,22 +8,22 @@ import { CTAButton } from '../../../components/CTAButton';
 import type { BlogPostData } from '../../../lib/server/data-fetchers';
 
 const CATEGORY_COLORS: Record<string, { bg: string; text: string; gradient: string }> = {
-  Psychothérapie: {
+  Comprendre: {
     bg: 'bg-blue-500/20',
     text: 'text-blue-300',
     gradient: 'from-blue-500 to-blue-600',
   },
-  Hypnose: {
-    bg: 'bg-purple-500/20',
-    text: 'text-purple-300',
-    gradient: 'from-purple-500 to-purple-600',
-  },
-  Respiration: {
+  Traverser: {
     bg: 'bg-emerald-500/20',
     text: 'text-emerald-300',
     gradient: 'from-emerald-500 to-emerald-600',
   },
   Découvrir: {
+    bg: 'bg-purple-500/20',
+    text: 'text-purple-300',
+    gradient: 'from-purple-500 to-purple-600',
+  },
+  Cheminer: {
     bg: 'bg-amber-500/20',
     text: 'text-amber-300',
     gradient: 'from-amber-500 to-amber-600',

--- a/apps/psypnos/app/blog/page.tsx
+++ b/apps/psypnos/app/blog/page.tsx
@@ -27,8 +27,7 @@ const breadcrumbs = [
 ];
 
 export default async function BlogPage() {
-  const allPosts = await getAllPostsAsync();
-  const categories = await getAllCategoriesAsync();
+  const [allPosts, categories] = await Promise.all([getAllPostsAsync(), getAllCategoriesAsync()]);
 
   return (
     <>

--- a/packages/db/prisma/migrations/20260312000000_add_blog_post_compound_index/migration.sql
+++ b/packages/db/prisma/migrations/20260312000000_add_blog_post_compound_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "BlogPost_siteId_status_publishedAt_idx" ON "BlogPost"("siteId", "status", "publishedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -239,6 +239,7 @@ model BlogPost {
 
   @@unique([slug, siteId])
   @@index([siteId, status])
+  @@index([siteId, status, publishedAt])
   @@index([publishedAt])
   @@index([siteId, featured])
   @@index([category])

--- a/packages/ui/src/components/marquee.tsx
+++ b/packages/ui/src/components/marquee.tsx
@@ -73,12 +73,18 @@ export function Marquee({
       onMouseEnter={() => pauseOnHover && setIsPaused(true)}
       onMouseLeave={() => pauseOnHover && setIsPaused(false)}
     >
-      {/* Gradient fade edges */}
+      {/* Gradient fade edges — use inline styles because dynamic Tailwind classes are purged in production */}
       <div
-        className={`from-${fadeColor}/80 pointer-events-none absolute left-0 top-0 z-10 h-full w-16 bg-gradient-to-r to-transparent sm:w-24`}
+        className="pointer-events-none absolute left-0 top-0 z-10 h-full w-16 sm:w-24"
+        style={{
+          background: `linear-gradient(to right, var(--marquee-fade, var(--color-${fadeColor}, #0d0d1a)) 0%, transparent 100%)`,
+        }}
       />
       <div
-        className={`from-${fadeColor}/80 pointer-events-none absolute right-0 top-0 z-10 h-full w-16 bg-gradient-to-l to-transparent sm:w-24`}
+        className="pointer-events-none absolute right-0 top-0 z-10 h-full w-16 sm:w-24"
+        style={{
+          background: `linear-gradient(to left, var(--marquee-fade, var(--color-${fadeColor}, #0d0d1a)) 0%, transparent 100%)`,
+        }}
       />
 
       {/* Animated wrapper containing two copies */}

--- a/packages/ui/src/components/sections/blog-section.tsx
+++ b/packages/ui/src/components/sections/blog-section.tsx
@@ -157,7 +157,21 @@ export function BlogSection({
   }
 
   if (posts.length === 0) {
-    return null;
+    return (
+      <section
+        id="blog"
+        className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}
+        data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
+        data-track-section-name={trackingName}
+      >
+        <div className="mx-auto max-w-6xl space-y-12">
+          <SectionTitle {...title} />
+          <p className="text-ivory/50 text-center text-lg">
+            Les premiers articles seront publiés prochainement.
+          </p>
+        </div>
+      </section>
+    );
   }
 
   const Link =


### PR DESCRIPTION
- Paralléliser les requêtes SSR (getAllPostsAsync + getAllCategoriesAsync) via Promise.all
- Corriger les gradients du marquee qui disparaissent en prod (classes Tailwind dynamiques → styles inline)
- Afficher un empty state au lieu de null quand la section blog n'a pas d'articles
- Aligner les couleurs catégories du blog homepage avec les catégories réelles (Comprendre, Traverser, Découvrir, Cheminer)
- Ajouter un index composé [siteId, status, publishedAt] sur BlogPost pour optimiser la requête principale

https://claude.ai/code/session_01FMxfGQ6aWCiTfWzcpvG7GQ