### PR TITLE
fix(blog): corriger affichage blog, navigation et gestion erreurs

### DIFF
--- a/apps/psypnos/app/(pages)/sections/blog.tsx
+++ b/apps/psypnos/app/(pages)/sections/blog.tsx
@@ -37,27 +37,27 @@ interface BlogSectionProps {
 /**
  * Psypnos blog section wrapper.
  * Provides site-specific data fetching, category colors, and CTA to the shared @kairn/ui component.
+ *
+ * Si initialData contient des articles, ils sont affichés immédiatement.
+ * Sinon, un fetch client est lancé avec un loading state visible.
  */
 export function BlogSection({ initialData }: BlogSectionProps) {
+  const hasInitialPosts = initialData && initialData.length > 0;
   const [blogPosts, setBlogPosts] = useState<BlogPostData[]>(initialData ?? []);
-  const [loading, setLoading] = useState(!initialData);
-  const [hasMounted, setHasMounted] = useState(false);
+  const [loading, setLoading] = useState(!hasInitialPosts);
 
   useEffect(() => {
-    setHasMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (initialData && initialData.length > 0) {
+    if (hasInitialPosts) {
       return;
     }
 
     async function fetchPosts() {
+      setLoading(true);
       try {
         const response = await fetch('/api/blog/posts?limit=3&featuredFirst=true');
         if (response.ok) {
           const data = await response.json();
-          setBlogPosts(data);
+          setBlogPosts(Array.isArray(data) ? data : []);
         }
       } catch (error) {
         console.error('Erreur lors du chargement des articles:', error);
@@ -66,14 +66,12 @@ export function BlogSection({ initialData }: BlogSectionProps) {
       }
     }
     fetchPosts();
-  }, [initialData]);
-
-  const showLoading = !initialData && (!hasMounted || loading);
+  }, [hasInitialPosts]);
 
   return (
     <BlogSectionUI
       posts={blogPosts}
-      isLoading={showLoading}
+      isLoading={loading}
       title={{
         eyebrow: 'Ressources & Articles',
         title: 'Découvrez nos derniers contenus',

--- a/apps/psypnos/app/api/blog/posts/[slug]/route.ts
+++ b/apps/psypnos/app/api/blog/posts/[slug]/route.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
 import { revalidatePath } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -12,12 +9,14 @@ import {
   validateSlug,
 } from '../../prisma-store';
 
-// GET - Retrieve a specific post
-export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+type RouteContext = { params: Promise<{ slug: string }> };
+
+/**
+ * GET /api/blog/posts/[slug] - Récupérer un article par slug
+ */
+export async function GET(request: NextRequest, { params }: RouteContext) {
   try {
     const { slug } = await params;
-
-    // Check for admin access (to see unpublished posts)
     const searchParams = request.nextUrl.searchParams;
     const includeUnpublished = searchParams.get('includeUnpublished') === 'true';
 
@@ -27,13 +26,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
-    // Disable cache for admin requests to ensure fresh data after edits
     const cacheHeaders = includeUnpublished
       ? { 'Cache-Control': 'private, no-store' }
       : { 'Cache-Control': 'public, s-maxage=3600, max-age=3600, stale-while-revalidate=86400' };
 
     return NextResponse.json(post, { headers: cacheHeaders });
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error fetching post:', error);
     return NextResponse.json(
       { error: "Erreur lors de la récupération de l'article" },
@@ -42,16 +41,15 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   }
 }
 
-// PUT - Update a post (protected by authentication)
-export async function PUT(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
-  // Verify authentication
+/**
+ * PUT /api/blog/posts/[slug] - Mettre à jour un article (auth admin requise)
+ */
+export async function PUT(request: NextRequest, { params }: RouteContext) {
   const authResult = await withAdminAuth();
   if (authResult.error) return authResult.error;
 
   try {
     const { slug } = await params;
-
-    // Validate slug
     const slugValidation = validateSlug(slug);
     if (!slugValidation.valid) {
       return NextResponse.json({ error: slugValidation.error }, { status: 400 });
@@ -59,7 +57,6 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
     const body = await request.json();
 
-    // If changing slug, validate new slug
     if (body.slug && body.slug !== slug) {
       const newSlugValidation = validateSlug(body.slug);
       if (!newSlugValidation.valid) {
@@ -67,16 +64,13 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       }
     }
 
-    // Use oldSlug if provided (for slug change)
     const actualOldSlug = body.oldSlug || slug;
-
     const updated = await updateBlogPost(actualOldSlug, body);
 
     if (!updated) {
       return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
-    // Invalidate cache - include homepage for featured articles
     revalidatePath('/api/blog/posts');
     revalidatePath('/blog');
     revalidatePath(`/blog/${actualOldSlug}`);
@@ -88,9 +82,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json(updated);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Erreur lors de la mise à jour';
+    // eslint-disable-next-line no-console
     console.error('Error updating post:', error);
 
-    // Check for duplicate slug error
     if (message.includes('existe déjà')) {
       return NextResponse.json({ error: message }, { status: 400 });
     }
@@ -99,19 +93,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   }
 }
 
-// DELETE - Delete a post (protected by authentication)
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ slug: string }> }
-) {
-  // Verify authentication
+/**
+ * DELETE /api/blog/posts/[slug] - Supprimer un article (auth admin requise)
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteContext) {
   const authResult = await withAdminAuth();
   if (authResult.error) return authResult.error;
 
   try {
     const { slug } = await params;
-
-    // Validate slug
     const slugValidation = validateSlug(slug);
     if (!slugValidation.valid) {
       return NextResponse.json({ error: slugValidation.error }, { status: 400 });
@@ -123,7 +113,6 @@ export async function DELETE(
       return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
-    // Invalidate cache - include homepage for featured articles
     revalidatePath('/api/blog/posts');
     revalidatePath('/blog');
     revalidatePath(`/blog/${slug}`);
@@ -131,17 +120,11 @@ export async function DELETE(
     revalidatePath('/');
 
     return NextResponse.json(
-      {
-        message: 'Article supprimé avec succès',
-        slug: slug,
-      },
-      {
-        headers: {
-          'Cache-Control': 'no-cache, no-store, must-revalidate',
-        },
-      }
+      { message: 'Article supprimé avec succès', slug },
+      { headers: { 'Cache-Control': 'no-cache, no-store, must-revalidate' } }
     );
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error deleting post:', error);
     return NextResponse.json(
       { error: "Erreur lors de la suppression de l'article" },
@@ -150,12 +133,10 @@ export async function DELETE(
   }
 }
 
-// PATCH - Partial update (e.g., published/featured status)
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ slug: string }> }
-) {
-  // Verify authentication
+/**
+ * PATCH /api/blog/posts/[slug] - Mise à jour partielle (published/featured)
+ */
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
   const authResult = await withAdminAuth();
   if (authResult.error) return authResult.error;
 
@@ -163,7 +144,6 @@ export async function PATCH(
     const { slug } = await params;
     const body = await request.json();
 
-    // Only allow specific fields for PATCH
     const allowedFields: Record<string, boolean> = {};
     if ('published' in body) {
       allowedFields.published = Boolean(body.published);
@@ -182,7 +162,6 @@ export async function PATCH(
       return NextResponse.json({ error: 'Article introuvable' }, { status: 404 });
     }
 
-    // Invalidate cache - include homepage for featured changes
     revalidatePath('/api/blog/posts');
     revalidatePath('/blog');
     revalidatePath(`/blog/${slug}`);
@@ -190,11 +169,12 @@ export async function PATCH(
 
     return NextResponse.json({
       message: 'Article mis à jour avec succès',
-      slug: slug,
+      slug,
       published: updated.published,
       featured: updated.featured,
     });
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error patching post:', error);
     return NextResponse.json(
       { error: "Erreur lors de la mise à jour de l'article" },

--- a/apps/psypnos/app/api/blog/posts/route.ts
+++ b/apps/psypnos/app/api/blog/posts/route.ts
@@ -1,28 +1,29 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - Type incompatibilities to fix
-import { revalidatePath } from "next/cache";
-import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
 
-import { withAdminAuth } from "../../auth/middleware";
+import { withAdminAuth } from '../../auth/middleware';
 import {
   getAllBlogPosts,
   createBlogPost,
   blogPostPayloadSchema,
   validateSlug,
-} from "../prisma-store";
+} from '../prisma-store';
 
-// GET - Retrieve all posts or filter
+/**
+ * GET /api/blog/posts - Récupérer les articles de blog
+ * Supporte les filtres : includeUnpublished, category, limit, featured, featuredFirst
+ */
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const includeUnpublished = searchParams.get("includeUnpublished") === "true";
-    const category = searchParams.get("category") || undefined;
-    const limitParam = searchParams.get("limit");
+    const includeUnpublished = searchParams.get('includeUnpublished') === 'true';
+    const category = searchParams.get('category') || undefined;
+    const limitParam = searchParams.get('limit');
     const limit = limitParam ? parseInt(limitParam, 10) : undefined;
-    const featuredParam = searchParams.get("featured");
-    const featured = featuredParam === "true" ? true : featuredParam === "false" ? false : undefined;
-    const featuredFirst = searchParams.get("featuredFirst") === "true";
+    const featuredParam = searchParams.get('featured');
+    const featured =
+      featuredParam === 'true' ? true : featuredParam === 'false' ? false : undefined;
+    const featuredFirst = searchParams.get('featuredFirst') === 'true';
 
     const posts = await getAllBlogPosts({
       includeUnpublished,
@@ -32,70 +33,62 @@ export async function GET(request: NextRequest) {
       featuredFirst,
     });
 
-    // Cache strategy based on context
-    // If includeUnpublished=true (admin), no cache to see changes immediately
-    // Otherwise cache public posts for 5 minutes
     const cacheControl = includeUnpublished
-      ? "private, no-cache, no-store, must-revalidate"
-      : "public, max-age=300, stale-while-revalidate=3600";
+      ? 'private, no-cache, no-store, must-revalidate'
+      : 'public, max-age=300, stale-while-revalidate=3600';
 
     return NextResponse.json(posts, {
       headers: {
-        "Cache-Control": cacheControl,
+        'Cache-Control': cacheControl,
       },
     });
   } catch (error) {
-    console.error("Error fetching posts:", error);
+    // eslint-disable-next-line no-console
+    console.error('Error fetching posts:', error);
     return NextResponse.json(
-      { error: "Erreur lors de la récupération des articles" },
+      { error: 'Erreur lors de la récupération des articles' },
       { status: 500 }
     );
   }
 }
 
-// POST - Create a new post (protected by authentication)
+/**
+ * POST /api/blog/posts - Créer un nouvel article (protégé par auth admin)
+ */
 export async function POST(request: NextRequest) {
-  // Verify authentication
   const authResult = await withAdminAuth();
   if (authResult.error) return authResult.error;
 
   try {
     const body = await request.json();
 
-    // Validate slug format first
     if (body.slug) {
       const slugValidation = validateSlug(body.slug);
       if (!slugValidation.valid) {
-        return NextResponse.json(
-          { error: slugValidation.error },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: slugValidation.error }, { status: 400 });
       }
     }
 
-    // Validate payload with Zod
     const parsed = blogPostPayloadSchema.safeParse(body);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];
-      return NextResponse.json({ error: issue?.message ?? "Validation error" }, { status: 400 });
+      return NextResponse.json({ error: issue?.message ?? 'Validation error' }, { status: 400 });
     }
 
     const post = await createBlogPost(parsed.data);
 
-    // Invalidate cache after creation - include homepage for featured articles
-    revalidatePath("/api/blog/posts");
-    revalidatePath("/blog");
+    revalidatePath('/api/blog/posts');
+    revalidatePath('/blog');
     revalidatePath(`/blog/${post.slug}`);
-    revalidatePath("/");
+    revalidatePath('/');
 
     return NextResponse.json(post, { status: 201 });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Erreur lors de la création";
-    console.error("Error creating post:", error);
+    const message = error instanceof Error ? error.message : 'Erreur lors de la création';
+    // eslint-disable-next-line no-console
+    console.error('Error creating post:', error);
 
-    // Check for duplicate slug error
-    if (message.includes("existe déjà")) {
+    if (message.includes('existe déjà')) {
       return NextResponse.json({ error: message }, { status: 409 });
     }
 

--- a/apps/psypnos/app/api/blog/prisma-store.ts
+++ b/apps/psypnos/app/api/blog/prisma-store.ts
@@ -117,10 +117,18 @@ export async function getAllBlogPosts(
   try {
     const siteId = await getSiteId();
 
+    const now = new Date();
+    now.setHours(23, 59, 59, 999);
+
     const posts = await prisma.blogPost.findMany({
       where: {
         siteId,
-        ...(includeUnpublished ? {} : { status: 'PUBLISHED' }),
+        ...(includeUnpublished
+          ? {}
+          : {
+              status: 'PUBLISHED',
+              OR: [{ publishedAt: { lte: now } }, { publishedAt: null }],
+            }),
         ...(category ? { category } : {}),
         ...(featured !== undefined ? { featured } : {}),
       },

--- a/apps/psypnos/app/blog/[slug]/page.tsx
+++ b/apps/psypnos/app/blog/[slug]/page.tsx
@@ -80,14 +80,14 @@ export default async function BlogPostPage({ params }: PageProps) {
     notFound();
   }
 
-  // Vérifier que la date de publication est <= aujourd'hui
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const postDate = new Date(post.date);
-  postDate.setHours(0, 0, 0, 0);
-
-  if (postDate > today) {
-    notFound();
+  // Vérifier que la date de publication est <= aujourd'hui (si définie)
+  if (post.date) {
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+    const postDate = new Date(post.date);
+    if (postDate > today) {
+      notFound();
+    }
   }
 
   // Conversion du Markdown en HTML

--- a/apps/psypnos/app/page.tsx
+++ b/apps/psypnos/app/page.tsx
@@ -37,35 +37,60 @@ import {
 } from './api/seminars/prisma-store';
 import { getAllTestimonials as getAPITestimonials } from './api/testimonials/prisma-store';
 
-export default async function HomePage() {
-  // Fetch data using the same functions as the API routes
-  let seminarsData: SeminarData[] = [];
-  let blogPostsData: BlogPostData[] = [];
-  let testimonialsData: TestimonialData[] = [];
+/**
+ * Fetch data with isolated error handling per section.
+ * Each section fetches independently so one failure doesn't break the others.
+ */
+async function fetchHomePageData(): Promise<{
+  seminars: SeminarData[];
+  blogPosts: BlogPostData[];
+  testimonials: TestimonialData[];
+}> {
+  const [seminarsResult, blogResult, testimonialsResult] = await Promise.allSettled([
+    (async () => {
+      let seminarsRaw = await getAPISeminars(3);
+      if (seminarsRaw.length === 0) {
+        const allSeminars = await getAllAPISeminars();
+        seminarsRaw = allSeminars.slice(0, 3);
+      }
+      return seminarsRaw as unknown as SeminarData[];
+    })(),
+    (async () => {
+      const posts = await getAPIBlogPosts({ limit: 3, featuredFirst: true });
+      return posts as unknown as BlogPostData[];
+    })(),
+    (async () => {
+      const testimonials = await getAPITestimonials(10);
+      return testimonials as unknown as TestimonialData[];
+    })(),
+  ]);
 
-  try {
-    // Get upcoming seminars, fallback to all if none upcoming
-    let seminarsRaw = await getAPISeminars(3);
-    if (seminarsRaw.length === 0) {
-      const allSeminars = await getAllAPISeminars();
-      seminarsRaw = allSeminars.slice(0, 3);
-    }
-
-    // Get blog posts with featured first
-    const blogPostsRaw = await getAPIBlogPosts({ limit: 3, featuredFirst: true });
-
-    // Get testimonials
-    const testimonialsRaw = await getAPITestimonials(10);
-
-    // The API store functions already return properly formatted data
-    seminarsData = seminarsRaw as unknown as SeminarData[];
-    blogPostsData = blogPostsRaw as unknown as BlogPostData[];
-    testimonialsData = testimonialsRaw as unknown as TestimonialData[];
-  } catch (error) {
-    // Log error but don't break the page - sections will show loading state
+  if (seminarsResult.status === 'rejected') {
     // eslint-disable-next-line no-console
-    console.error('[HomePage SSR] Error fetching data:', error);
+    console.error('[HomePage SSR] Erreur fetch séminaires:', seminarsResult.reason);
   }
+  if (blogResult.status === 'rejected') {
+    // eslint-disable-next-line no-console
+    console.error('[HomePage SSR] Erreur fetch blog:', blogResult.reason);
+  }
+  if (testimonialsResult.status === 'rejected') {
+    // eslint-disable-next-line no-console
+    console.error('[HomePage SSR] Erreur fetch témoignages:', testimonialsResult.reason);
+  }
+
+  return {
+    seminars: seminarsResult.status === 'fulfilled' ? seminarsResult.value : [],
+    blogPosts: blogResult.status === 'fulfilled' ? blogResult.value : [],
+    testimonials: testimonialsResult.status === 'fulfilled' ? testimonialsResult.value : [],
+  };
+}
+
+export default async function HomePage() {
+  const {
+    seminars: seminarsData,
+    blogPosts: blogPostsData,
+    testimonials: testimonialsData,
+  } = await fetchHomePageData();
 
   return (
     <div className="from-night via-night/95 to-night text-ivory min-h-screen bg-gradient-to-b">

--- a/apps/psypnos/components/NavigationMenu.tsx
+++ b/apps/psypnos/components/NavigationMenu.tsx
@@ -185,15 +185,14 @@ export function NavigationMenu({ forceVisible = false }: NavigationMenuProps) {
   }, [isMobileMenuOpen, closeMenu]);
 
   const showBackground = hasMounted && (isScrolled || forceVisible);
-  const isVisible = showBackground;
 
   return (
     <>
       <nav
-        className={`fixed left-0 right-0 top-0 z-50 transition-all duration-300 ${
-          isVisible
-            ? 'border-gold/20 bg-night/90 shadow-night/50 translate-y-0 border-b opacity-100 shadow-lg backdrop-blur-md'
-            : '-translate-y-full bg-transparent opacity-0'
+        className={`fixed left-0 right-0 top-0 z-50 translate-y-0 opacity-100 transition-all duration-300 ${
+          showBackground
+            ? 'border-gold/20 bg-night/90 shadow-night/50 border-b shadow-lg backdrop-blur-md'
+            : 'border-transparent bg-transparent'
         }`}
         suppressHydrationWarning
       >

--- a/apps/psypnos/lib/blog.ts
+++ b/apps/psypnos/lib/blog.ts
@@ -233,7 +233,7 @@ export async function getAllPostsAsync(includeUnpublished = false): Promise<Blog
           ? {}
           : {
               status: 'PUBLISHED',
-              publishedAt: { lte: today },
+              OR: [{ publishedAt: { lte: today } }, { publishedAt: null }],
             }),
       },
       include: {

--- a/packages/ui/src/components/sections/__tests__/BlogSection.test.tsx
+++ b/packages/ui/src/components/sections/__tests__/BlogSection.test.tsx
@@ -39,9 +39,11 @@ describe('BlogSection', () => {
     expect(screen.getByText('Blog')).toBeInTheDocument();
   });
 
-  it('renders nothing when posts array is empty', () => {
-    const { container } = render(<BlogSection posts={[]} />);
-    expect(container.firstChild).toBeNull();
+  it('renders empty state message when posts array is empty', () => {
+    render(<BlogSection posts={[]} />);
+    expect(
+      screen.getByText('Les premiers articles seront publiés prochainement.')
+    ).toBeInTheDocument();
   });
 
   it('renders loading skeleton when isLoading is true', () => {


### PR DESCRIPTION
## Résumé

Correction définitive des problèmes de blog et d'affichage sur le site Psypnos :

- **Filtrage publishedAt harmonisé** : les deux chemins de données (prisma-store + lib/blog) incluent désormais les posts avec `publishedAt` null via une condition OR
- **Loading state corrigé** : le wrapper blog de la homepage affiche le skeleton pendant le fetch client au lieu de l'état vide immédiat
- **Navigation toujours visible** : la barre de navigation est désormais visible dès le chargement (fond transparent → opaque au scroll)
- **Gestion d'erreurs isolée** : chaque section SSR (séminaires, blog, témoignages) gère ses erreurs indépendamment via `Promise.allSettled`
- **@ts-nocheck supprimé** : routes API blog proprement typées
- **Test mis à jour** : BlogSection empty state

## Fichiers modifiés

| Fichier | Modification |
|---------|-------------|
| `prisma-store.ts` | Ajout filtre `publishedAt` (OR null/lte today) |
| `lib/blog.ts` | Idem — cohérence avec prisma-store |
| `blog/[slug]/page.tsx` | Gestion `publishedAt` null |
| `(pages)/sections/blog.tsx` | Loading state correct |
| `page.tsx` | Promise.allSettled pour fetch SSR isolé |
| `NavigationMenu.tsx` | Nav toujours visible |
| `posts/route.ts` | Suppression @ts-nocheck |
| `posts/[slug]/route.ts` | Suppression @ts-nocheck |
| `BlogSection.test.tsx` | Test empty state mis à jour |

## Validation

- ✅ Lint (0 erreurs)
- ✅ Type-check
- ✅ Tests unitaires (1431 passed)
- ✅ Tests UI (192 passed)
- ✅ Build

Fixes #391