### PR TITLE
fix(blog): propager les erreurs et ajouter diagnostic blog

### DIFF
--- a/apps/psypnos/app/(pages)/sections/blog.tsx
+++ b/apps/psypnos/app/(pages)/sections/blog.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+/* eslint-disable no-console */
+
 import { BlogSection as BlogSectionUI } from '@kairn/ui';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
@@ -32,6 +34,8 @@ const CATEGORY_COLORS: Record<string, { bg: string; text: string; gradient: stri
 
 interface BlogSectionProps {
   initialData?: BlogPostData[];
+  /** Whether the SSR fetch failed */
+  ssrError?: boolean;
 }
 
 /**
@@ -40,11 +44,13 @@ interface BlogSectionProps {
  *
  * Si initialData contient des articles, ils sont affichés immédiatement.
  * Sinon, un fetch client est lancé avec un loading state visible.
+ * Si le fetch échoue, un état d'erreur est affiché.
  */
-export function BlogSection({ initialData }: BlogSectionProps) {
+export function BlogSection({ initialData, ssrError = false }: BlogSectionProps) {
   const hasInitialPosts = initialData && initialData.length > 0;
   const [blogPosts, setBlogPosts] = useState<BlogPostData[]>(initialData ?? []);
   const [loading, setLoading] = useState(!hasInitialPosts);
+  const [fetchError, setFetchError] = useState(ssrError);
 
   useEffect(() => {
     if (hasInitialPosts) {
@@ -53,20 +59,64 @@ export function BlogSection({ initialData }: BlogSectionProps) {
 
     async function fetchPosts() {
       setLoading(true);
+      setFetchError(false);
       try {
         const response = await fetch('/api/blog/posts?limit=3&featuredFirst=true');
         if (response.ok) {
           const data = await response.json();
-          setBlogPosts(Array.isArray(data) ? data : []);
+          const posts = Array.isArray(data) ? data : [];
+          setBlogPosts(posts);
+          console.log('[BlogSection] Client fetch: received', posts.length, 'posts');
+        } else {
+          const errorData = await response.json().catch(() => ({}));
+          console.error('[BlogSection] Client fetch error:', response.status, errorData);
+          setFetchError(true);
         }
       } catch (error) {
-        console.error('Erreur lors du chargement des articles:', error);
+        console.error('[BlogSection] Client fetch exception:', error);
+        setFetchError(true);
       } finally {
         setLoading(false);
       }
     }
     fetchPosts();
   }, [hasInitialPosts]);
+
+  // Show error state if fetch failed and no posts available
+  if (fetchError && blogPosts.length === 0 && !loading) {
+    return (
+      <section id="blog" className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+        <div className="mx-auto max-w-6xl space-y-12">
+          <div className="space-y-4 text-center">
+            <p className="text-gold text-sm font-medium uppercase tracking-widest">
+              Ressources & Articles
+            </p>
+            <h2 className="text-ivory text-3xl font-bold sm:text-4xl">
+              Découvrez nos derniers contenus
+            </h2>
+          </div>
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-8 text-center">
+            <p className="text-ivory/70 text-lg">
+              Les articles sont temporairement indisponibles. Veuillez réessayer dans quelques
+              instants.
+            </p>
+            <p className="text-ivory/40 mt-2 text-sm">
+              Si le problème persiste, consultez{' '}
+              <a href="/api/debug/blog-status" className="text-gold underline">
+                le diagnostic
+              </a>{' '}
+              pour plus d&apos;informations.
+            </p>
+          </div>
+          <div className="flex justify-center">
+            <CTAButton variant="secondary" href="/blog">
+              Accéder au blog
+            </CTAButton>
+          </div>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <BlogSectionUI

--- a/apps/psypnos/app/api/blog/prisma-store.ts
+++ b/apps/psypnos/app/api/blog/prisma-store.ts
@@ -101,7 +101,8 @@ export interface BlogPostSummary {
 // ============================================
 
 /**
- * Get all blog posts from database
+ * Get all blog posts from database.
+ * Throws on error so callers can handle failures explicitly.
  */
 export async function getAllBlogPosts(
   options: {
@@ -114,40 +115,42 @@ export async function getAllBlogPosts(
 ): Promise<BlogPostSummary[]> {
   const { includeUnpublished = false, limit, category, featured, featuredFirst = false } = options;
 
-  try {
-    const siteId = await getSiteId();
+  const siteId = await getSiteId();
+  console.log(
+    '[prisma-store] getAllBlogPosts: siteId =',
+    siteId,
+    ', options =',
+    JSON.stringify(options)
+  );
 
-    const now = new Date();
-    now.setHours(23, 59, 59, 999);
+  const now = new Date();
+  now.setHours(23, 59, 59, 999);
 
-    const posts = await prisma.blogPost.findMany({
-      where: {
-        siteId,
-        ...(includeUnpublished
-          ? {}
-          : {
-              status: 'PUBLISHED',
-              OR: [{ publishedAt: { lte: now } }, { publishedAt: null }],
-            }),
-        ...(category ? { category } : {}),
-        ...(featured !== undefined ? { featured } : {}),
+  const posts = await prisma.blogPost.findMany({
+    where: {
+      siteId,
+      ...(includeUnpublished
+        ? {}
+        : {
+            status: 'PUBLISHED',
+            OR: [{ publishedAt: { lte: now } }, { publishedAt: null }],
+          }),
+      ...(category ? { category } : {}),
+      ...(featured !== undefined ? { featured } : {}),
+    },
+    include: {
+      tags: {
+        include: { tag: true },
       },
-      include: {
-        tags: {
-          include: { tag: true },
-        },
-      },
-      orderBy: featuredFirst
-        ? [{ featured: 'desc' }, { publishedAt: 'desc' }]
-        : { publishedAt: 'desc' },
-      ...(limit ? { take: limit } : {}),
-    });
+    },
+    orderBy: featuredFirst
+      ? [{ featured: 'desc' }, { publishedAt: 'desc' }]
+      : { publishedAt: 'desc' },
+    ...(limit ? { take: limit } : {}),
+  });
 
-    return posts.map(formatBlogPostSummary);
-  } catch (error) {
-    console.error('Error fetching blog posts:', error);
-    return [];
-  }
+  console.log('[prisma-store] getAllBlogPosts: found', posts.length, 'posts');
+  return posts.map(formatBlogPostSummary);
 }
 
 /**

--- a/apps/psypnos/app/api/debug/blog-status/route.ts
+++ b/apps/psypnos/app/api/debug/blog-status/route.ts
@@ -1,0 +1,174 @@
+/* eslint-disable no-console */
+/**
+ * GET /api/debug/blog-status — Diagnostic endpoint for blog system
+ *
+ * Returns the actual state of the blog data pipeline:
+ * - Database connectivity
+ * - Site record existence
+ * - Blog post counts by status
+ * - Sample post data
+ * - Any errors encountered
+ *
+ * This endpoint is intentionally public (no auth) for debugging deployment issues.
+ * It does NOT expose sensitive data (no content, no auth tokens).
+ */
+
+import { NextResponse } from 'next/server';
+
+import prisma from '@/lib/db/prisma';
+
+interface DiagnosticResult {
+  timestamp: string;
+  checks: {
+    databaseUrl: boolean;
+    databaseConnected: boolean;
+    siteRecord: { found: boolean; id?: string; slug?: string; isActive?: boolean } | null;
+    blogPosts: {
+      total: number;
+      published: number;
+      draft: number;
+      withPublishedAt: number;
+      withoutPublishedAt: number;
+      futurePublishedAt: number;
+    } | null;
+    samplePosts: Array<{
+      slug: string;
+      title: string;
+      status: string;
+      publishedAt: string | null;
+      category: string | null;
+      featured: boolean | null;
+    }>;
+  };
+  errors: string[];
+}
+
+export async function GET() {
+  const result: DiagnosticResult = {
+    timestamp: new Date().toISOString(),
+    checks: {
+      databaseUrl: false,
+      databaseConnected: false,
+      siteRecord: null,
+      blogPosts: null,
+      samplePosts: [],
+    },
+    errors: [],
+  };
+
+  // 1. Check DATABASE_URL
+  result.checks.databaseUrl = !!process.env.DATABASE_URL;
+  if (!result.checks.databaseUrl) {
+    result.errors.push('DATABASE_URL is not set');
+    return NextResponse.json(result, { status: 503 });
+  }
+
+  // 2. Check database connectivity
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    result.checks.databaseConnected = true;
+  } catch (error) {
+    result.checks.databaseConnected = false;
+    result.errors.push(
+      `Database connection failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return NextResponse.json(result, { status: 503 });
+  }
+
+  // 3. Check Site record
+  try {
+    const site = await prisma.site.findUnique({
+      where: { slug: 'psypnos' },
+      select: { id: true, slug: true, isActive: true },
+    });
+
+    if (site) {
+      result.checks.siteRecord = {
+        found: true,
+        id: site.id,
+        slug: site.slug,
+        isActive: site.isActive,
+      };
+    } else {
+      result.checks.siteRecord = { found: false };
+      result.errors.push('Site record with slug "psypnos" not found in database');
+
+      // List all sites for debugging
+      const allSites = await prisma.site.findMany({ select: { slug: true, isActive: true } });
+      result.errors.push(`Available sites: ${JSON.stringify(allSites)}`);
+    }
+  } catch (error) {
+    result.errors.push(
+      `Site query failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  // 4. Check BlogPost records
+  if (result.checks.siteRecord?.found && result.checks.siteRecord.id) {
+    const siteId = result.checks.siteRecord.id;
+    const now = new Date();
+
+    try {
+      const [total, published, draft, withPublishedAt, futurePublishedAt] = await Promise.all([
+        prisma.blogPost.count({ where: { siteId } }),
+        prisma.blogPost.count({ where: { siteId, status: 'PUBLISHED' } }),
+        prisma.blogPost.count({ where: { siteId, status: 'DRAFT' } }),
+        prisma.blogPost.count({ where: { siteId, publishedAt: { not: null } } }),
+        prisma.blogPost.count({ where: { siteId, publishedAt: { gt: now } } }),
+      ]);
+
+      result.checks.blogPosts = {
+        total,
+        published,
+        draft,
+        withPublishedAt,
+        withoutPublishedAt: total - withPublishedAt,
+        futurePublishedAt,
+      };
+
+      if (total === 0) {
+        result.errors.push(
+          'No blog posts found in database for this site. Run seed or create posts via admin.'
+        );
+      } else if (published === 0) {
+        result.errors.push(
+          `Found ${total} blog post(s) but none have status PUBLISHED. All posts are in DRAFT.`
+        );
+      }
+
+      // 5. Sample posts (first 5, no content)
+      const samplePosts = await prisma.blogPost.findMany({
+        where: { siteId },
+        select: {
+          slug: true,
+          title: true,
+          status: true,
+          publishedAt: true,
+          category: true,
+          featured: true,
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+      });
+
+      result.checks.samplePosts = samplePosts.map(p => ({
+        slug: p.slug,
+        title: p.title,
+        status: p.status,
+        publishedAt: p.publishedAt?.toISOString() ?? null,
+        category: p.category,
+        featured: p.featured,
+      }));
+    } catch (error) {
+      result.errors.push(
+        `BlogPost query failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  const status = result.errors.length > 0 ? 500 : 200;
+  return NextResponse.json(result, {
+    status,
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/apps/psypnos/app/api/seminars/prisma-store.ts
+++ b/apps/psypnos/app/api/seminars/prisma-store.ts
@@ -88,45 +88,37 @@ export interface SeminarOutput {
 // ============================================
 
 /**
- * Get all seminars from database
+ * Get all seminars from database.
+ * Throws on error so callers can handle failures explicitly.
  */
 export async function getAllSeminars(): Promise<SeminarOutput[]> {
-  try {
-    const siteId = await getSiteId();
-    const seminars = await prisma.seminar.findMany({
-      where: { siteId },
-      orderBy: { startAt: 'asc' },
-    });
+  const siteId = await getSiteId();
+  const seminars = await prisma.seminar.findMany({
+    where: { siteId },
+    orderBy: { startAt: 'asc' },
+  });
 
-    return seminars.map(formatSeminarOutput);
-  } catch (error) {
-    console.error('Error fetching seminars:', error);
-    return [];
-  }
+  return seminars.map(formatSeminarOutput);
 }
 
 /**
- * Get upcoming seminars (startAt >= now)
+ * Get upcoming seminars (startAt >= now).
+ * Throws on error so callers can handle failures explicitly.
  */
 export async function getUpcomingSeminars(limit?: number): Promise<SeminarOutput[]> {
-  try {
-    const siteId = await getSiteId();
-    const now = new Date();
+  const siteId = await getSiteId();
+  const now = new Date();
 
-    const seminars = await prisma.seminar.findMany({
-      where: {
-        siteId,
-        startAt: { gte: now },
-      },
-      orderBy: { startAt: 'asc' },
-      ...(limit ? { take: limit } : {}),
-    });
+  const seminars = await prisma.seminar.findMany({
+    where: {
+      siteId,
+      startAt: { gte: now },
+    },
+    orderBy: { startAt: 'asc' },
+    ...(limit ? { take: limit } : {}),
+  });
 
-    return seminars.map(formatSeminarOutput);
-  } catch (error) {
-    console.error('Error fetching upcoming seminars:', error);
-    return [];
-  }
+  return seminars.map(formatSeminarOutput);
 }
 
 /**

--- a/apps/psypnos/app/api/testimonials/prisma-store.ts
+++ b/apps/psypnos/app/api/testimonials/prisma-store.ts
@@ -54,25 +54,21 @@ export interface TestimonialOutput {
 // ============================================
 
 /**
- * Get all approved testimonials from database
+ * Get all approved testimonials from database.
+ * Throws on error so callers can handle failures explicitly.
  */
 export async function getAllTestimonials(limit?: number): Promise<TestimonialOutput[]> {
-  try {
-    const siteId = await getSiteId();
-    const testimonials = await prisma.testimonial.findMany({
-      where: {
-        siteId,
-        isApproved: true,
-      },
-      orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
-      ...(limit ? { take: limit } : {}),
-    });
+  const siteId = await getSiteId();
+  const testimonials = await prisma.testimonial.findMany({
+    where: {
+      siteId,
+      isApproved: true,
+    },
+    orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
+    ...(limit ? { take: limit } : {}),
+  });
 
-    return testimonials.map(formatTestimonialOutput);
-  } catch (error) {
-    console.error('Error fetching testimonials:', error);
-    return [];
-  }
+  return testimonials.map(formatTestimonialOutput);
 }
 
 /**

--- a/apps/psypnos/app/blog/[slug]/page.tsx
+++ b/apps/psypnos/app/blog/[slug]/page.tsx
@@ -63,13 +63,19 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-// Génération statique des pages uniquement pour les articles publiés
-// Évite de générer des routes 404 pour les articles non publiés
+/**
+ * Génération statique des pages uniquement pour les articles publiés.
+ * Graceful fallback: retourne [] si la DB n'est pas accessible (build sans DATABASE_URL).
+ */
 export async function generateStaticParams() {
-  const posts = await getAllPostsAsync();
-  return posts.map(post => ({
-    slug: post.slug,
-  }));
+  try {
+    const posts = await getAllPostsAsync();
+    return posts.map(post => ({
+      slug: post.slug,
+    }));
+  } catch {
+    return [];
+  }
 }
 
 export default async function BlogPostPage({ params }: PageProps) {

--- a/apps/psypnos/app/blog/_components/BlogPageClient.tsx
+++ b/apps/psypnos/app/blog/_components/BlogPageClient.tsx
@@ -16,15 +16,16 @@ import { FeaturedCarousel } from './FeaturedCarousel';
 import { Pagination } from './Pagination';
 import { SearchBar } from './SearchBar';
 
-
 interface BlogPageClientProps {
   allPosts: BlogPostSummary[];
   categories: string[];
+  /** Whether the server-side fetch failed */
+  fetchError?: boolean;
 }
 
 const POSTS_PER_PAGE = 10;
 
-export function BlogPageClient({ allPosts, categories }: BlogPageClientProps) {
+export function BlogPageClient({ allPosts, categories, fetchError = false }: BlogPageClientProps) {
   const heroRef = useRef<HTMLDivElement>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [searchFilteredPosts, setSearchFilteredPosts] = useState<BlogPostSummary[]>(allPosts);
@@ -223,8 +224,26 @@ export function BlogPageClient({ allPosts, categories }: BlogPageClientProps) {
           </motion.div>
         )}
 
-        {/* Message si aucun article */}
-        {allPosts.length === 0 && (
+        {/* Error state */}
+        {fetchError && allPosts.length === 0 && (
+          <motion.div
+            initial={hasMounted ? { opacity: 0 } : { opacity: 1 }}
+            animate={{ opacity: 1 }}
+            transition={hasMounted ? { duration: 0.4 } : { duration: 0 }}
+            className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-12 text-center"
+          >
+            <BookOpen className="mx-auto mb-4 h-12 w-12 text-amber-400/50" />
+            <h2 className="text-ivory mb-2 text-xl font-semibold">
+              Articles temporairement indisponibles
+            </h2>
+            <p className="text-ivory/60">
+              Une erreur est survenue lors du chargement. Veuillez réessayer dans quelques instants.
+            </p>
+          </motion.div>
+        )}
+
+        {/* Message si aucun article (pas d'erreur) */}
+        {!fetchError && allPosts.length === 0 && (
           <motion.div
             initial={hasMounted ? { opacity: 0 } : { opacity: 1 }}
             animate={{ opacity: 1 }}

--- a/apps/psypnos/app/blog/page.tsx
+++ b/apps/psypnos/app/blog/page.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable no-console */
 import { BreadcrumbSchema } from '@/components/BreadcrumbSchema';
+import type { BlogPostSummary } from '@/lib/blog';
 import { getAllPostsAsync, getAllCategoriesAsync } from '@/lib/blog';
 
 import { BlogPageClient } from './_components/BlogPageClient';
@@ -26,13 +28,26 @@ const breadcrumbs = [
   { name: 'Blog', url: 'https://psypnos.fr/blog' },
 ];
 
+/**
+ * Blog listing page - fetches all posts with error handling
+ */
 export default async function BlogPage() {
-  const [allPosts, categories] = await Promise.all([getAllPostsAsync(), getAllCategoriesAsync()]);
+  let allPosts: BlogPostSummary[] = [];
+  let categories: string[] = [];
+  let fetchError = false;
+
+  try {
+    [allPosts, categories] = await Promise.all([getAllPostsAsync(), getAllCategoriesAsync()]);
+    console.log(`[BlogPage] Fetched ${allPosts.length} posts, ${categories.length} categories`);
+  } catch (error) {
+    console.error('[BlogPage] Error fetching blog data:', error);
+    fetchError = true;
+  }
 
   return (
     <>
       <BreadcrumbSchema items={breadcrumbs} />
-      <BlogPageClient allPosts={allPosts} categories={categories} />
+      <BlogPageClient allPosts={allPosts} categories={categories} fetchError={fetchError} />
     </>
   );
 }

--- a/apps/psypnos/app/page.tsx
+++ b/apps/psypnos/app/page.tsx
@@ -45,6 +45,7 @@ async function fetchHomePageData(): Promise<{
   seminars: SeminarData[];
   blogPosts: BlogPostData[];
   testimonials: TestimonialData[];
+  blogError: boolean;
 }> {
   const [seminarsResult, blogResult, testimonialsResult] = await Promise.allSettled([
     (async () => {
@@ -82,6 +83,7 @@ async function fetchHomePageData(): Promise<{
     seminars: seminarsResult.status === 'fulfilled' ? seminarsResult.value : [],
     blogPosts: blogResult.status === 'fulfilled' ? blogResult.value : [],
     testimonials: testimonialsResult.status === 'fulfilled' ? testimonialsResult.value : [],
+    blogError: blogResult.status === 'rejected',
   };
 }
 
@@ -90,6 +92,7 @@ export default async function HomePage() {
     seminars: seminarsData,
     blogPosts: blogPostsData,
     testimonials: testimonialsData,
+    blogError: blogFetchError,
   } = await fetchHomePageData();
 
   return (
@@ -110,7 +113,7 @@ export default async function HomePage() {
         <RespirationSection />
         {/* Sections avec données préchargées via API routes */}
         <SeminarsSection initialData={seminarsData} />
-        <BlogSection initialData={blogPostsData} />
+        <BlogSection initialData={blogPostsData} ssrError={blogFetchError} />
         <TestimonialsSection initialData={testimonialsData} />
         <ContactSection />
       </main>

--- a/apps/psypnos/app/sitemap.ts
+++ b/apps/psypnos/app/sitemap.ts
@@ -84,14 +84,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  // Articles de blog
-  const posts = await getAllPostsAsync();
-  const blogPosts: MetadataRoute.Sitemap = posts.map(post => ({
-    url: `${baseUrl}/blog/${post.slug}`,
-    lastModified: new Date(post.date),
-    changeFrequency: 'monthly' as const,
-    priority: 0.7,
-  }));
+  // Articles de blog — graceful fallback si DB non disponible (build sans DATABASE_URL)
+  let blogPosts: MetadataRoute.Sitemap = [];
+  try {
+    const posts = await getAllPostsAsync();
+    blogPosts = posts.map(post => ({
+      url: `${baseUrl}/blog/${post.slug}`,
+      lastModified: new Date(post.date),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    }));
+  } catch {
+    // DB not available during build — blog posts will be added at runtime via ISR
+  }
 
   return [...routes, ...geoPages, ...legalPages, ...blogPosts];
 }

--- a/apps/psypnos/lib/blog.ts
+++ b/apps/psypnos/lib/blog.ts
@@ -215,75 +215,70 @@ export function getPostBySlug(slug: string): BlogPost | null {
 }
 
 /**
- * Get all blog posts (async version - recommended)
+ * Get all blog posts (async version - recommended).
+ * Throws on error so callers can handle failures explicitly.
  */
 export async function getAllPostsAsync(includeUnpublished = false): Promise<BlogPostSummary[]> {
   const startTime = Date.now();
   console.log(`[blog] getAllPostsAsync appelé (includeUnpublished: ${includeUnpublished})`);
 
-  try {
-    const siteId = await getSiteId();
-    const today = new Date();
-    today.setHours(23, 59, 59, 999);
+  const siteId = await getSiteId();
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
 
-    const posts = await prisma.blogPost.findMany({
-      where: {
-        siteId,
-        ...(includeUnpublished
-          ? {}
-          : {
-              status: 'PUBLISHED',
-              OR: [{ publishedAt: { lte: today } }, { publishedAt: null }],
-            }),
+  const posts = await prisma.blogPost.findMany({
+    where: {
+      siteId,
+      ...(includeUnpublished
+        ? {}
+        : {
+            status: 'PUBLISHED',
+            OR: [{ publishedAt: { lte: today } }, { publishedAt: null }],
+          }),
+    },
+    include: {
+      tags: {
+        include: { tag: true },
       },
-      include: {
-        tags: {
-          include: { tag: true },
-        },
-      },
-      orderBy: { publishedAt: 'desc' },
-    });
+    },
+    orderBy: { publishedAt: 'desc' },
+  });
 
+  console.log(
+    `[blog] ${posts.length} articles récupérés de la base de données en ${Date.now() - startTime}ms`
+  );
+
+  const formattedPosts = posts.map(formatPrismaPost);
+
+  // Update cache for sync functions
+  postsCache = formattedPosts;
+  postsCacheTimestamp = Date.now();
+
+  const summaries = formattedPosts.map(
+    (post: BlogPost): BlogPostSummary => ({
+      slug: post.slug,
+      title: post.title,
+      description: post.description,
+      date: post.date,
+      author: post.author,
+      category: post.category,
+      tags: post.tags,
+      image: post.image,
+      published: post.published,
+      featured: post.featured,
+      readingTime: post.readingTime,
+      excerpt: post.excerpt,
+    })
+  );
+
+  if (summaries.length > 0) {
+    const first = summaries[0]!;
     console.log(
-      `[blog] ${posts.length} articles récupérés de la base de données en ${Date.now() - startTime}ms`
+      `[blog] Premier article: "${first.title}" - Tags: [${first.tags?.join(', ') || 'aucun'}]`
     );
-
-    const formattedPosts = posts.map(formatPrismaPost);
-
-    // Update cache for sync functions
-    postsCache = formattedPosts;
-    postsCacheTimestamp = Date.now();
-
-    const summaries = formattedPosts.map(
-      (post: BlogPost): BlogPostSummary => ({
-        slug: post.slug,
-        title: post.title,
-        description: post.description,
-        date: post.date,
-        author: post.author,
-        category: post.category,
-        tags: post.tags,
-        image: post.image,
-        published: post.published,
-        featured: post.featured,
-        readingTime: post.readingTime,
-        excerpt: post.excerpt,
-      })
-    );
-
-    if (summaries.length > 0) {
-      const first = summaries[0]!;
-      console.log(
-        `[blog] Premier article: "${first.title}" - Tags: [${first.tags?.join(', ') || 'aucun'}]`
-      );
-    }
-
-    return summaries;
-  } catch (error) {
-    console.error('[blog] ERREUR lors de la récupération des articles:', error);
-    console.error('[blog] Stack trace:', error instanceof Error ? error.stack : 'N/A');
-    return [];
   }
+
+  return summaries;
 }
 
 /**
@@ -382,28 +377,24 @@ export function getPostsByTag(tag: string, includeUnpublished = false): BlogPost
 }
 
 /**
- * Get all unique categories (async version)
+ * Get all unique categories (async version).
+ * Throws on error so callers can handle failures explicitly.
  */
 export async function getAllCategoriesAsync(): Promise<string[]> {
-  try {
-    const siteId = await getSiteId();
-    const posts = await prisma.blogPost.findMany({
-      where: {
-        siteId,
-        status: 'PUBLISHED',
-        category: { not: null },
-      },
-      select: { category: true },
-      distinct: ['category'],
-    });
-    return posts
-      .map(p => p.category)
-      .filter((c): c is string => c !== null)
-      .sort();
-  } catch (error) {
-    console.error('Error fetching categories:', error);
-    return [];
-  }
+  const siteId = await getSiteId();
+  const posts = await prisma.blogPost.findMany({
+    where: {
+      siteId,
+      status: 'PUBLISHED',
+      category: { not: null },
+    },
+    select: { category: true },
+    distinct: ['category'],
+  });
+  return posts
+    .map(p => p.category)
+    .filter((c): c is string => c !== null)
+    .sort();
 }
 
 /**


### PR DESCRIPTION
## Résumé

Les fonctions de récupération de données (blog, séminaires, témoignages) avalaient **silencieusement TOUTES les erreurs** et retournaient des tableaux vides `[]`. Il était impossible de distinguer « aucun article publié » de « erreur de connexion DB » ou « enregistrement Site manquant ».

### Changements

- **Propagation des erreurs** : `getAllBlogPosts`, `getAllPostsAsync`, `getAllCategoriesAsync`, `getUpcomingSeminars`, `getAllSeminars`, `getAllTestimonials` propagent maintenant les erreurs au lieu de les attraper
- **Endpoint diagnostic** : `GET /api/debug/blog-status` — vérifie connectivité DB, enregistrement Site, comptage articles par statut, échantillon de posts
- **État d'erreur frontend** : la section blog homepage et la page /blog affichent un message d'erreur explicite (distinct de « aucun article ») avec lien vers le diagnostic
- **Build résilient** : sitemap et generateStaticParams ont un try/catch gracieux pour le build sans DATABASE_URL

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `app/api/debug/blog-status/route.ts` | Nouveau — endpoint diagnostic complet |
| `app/api/blog/prisma-store.ts` | Erreurs propagées + logging |
| `app/api/seminars/prisma-store.ts` | Erreurs propagées |
| `app/api/testimonials/prisma-store.ts` | Erreurs propagées |
| `lib/blog.ts` | Erreurs propagées dans getAllPostsAsync + getAllCategoriesAsync |
| `app/(pages)/sections/blog.tsx` | État d'erreur avec message et lien diagnostic |
| `app/blog/page.tsx` | try/catch + prop fetchError |
| `app/blog/_components/BlogPageClient.tsx` | Affichage état erreur vs état vide |
| `app/page.tsx` | Flag blogError via Promise.allSettled |
| `app/blog/[slug]/page.tsx` | try/catch dans generateStaticParams |
| `app/sitemap.ts` | try/catch pour build sans DB |

## Diagnostic

Après déploiement, **visitez immédiatement** :
```
https://psypnos.fr/api/debug/blog-status
```

Cet endpoint révélera la cause racine exacte :
- ❌ `databaseUrl: false` → DATABASE_URL non configuré sur Vercel
- ❌ `databaseConnected: false` → Problème de connexion PostgreSQL
- ❌ `siteRecord.found: false` → Enregistrement Site "psypnos" absent → exécuter le seed
- ❌ `blogPosts.published: 0` → Aucun article publié → créer via admin ou seed
- ✅ `blogPosts.published > 0` → Les articles existent et devraient s'afficher

Fixes #391

https://claude.ai/code/session_01B7ycT9jh1Uj1MmKipTyzmG