### PR TITLE
fix(analytics): corriger collecte et affichage des données analytics

### DIFF
--- a/apps/psypnos/app/api/analytics/blog/stats/route.ts
+++ b/apps/psypnos/app/api/analytics/blog/stats/route.ts
@@ -1,12 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-// TODO: Migration - BlogAnalytics model not available in Kairn schema
-import { PrismaClient } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { prisma } from '@/lib/db/prisma';
+import { getSiteId } from '@/lib/db/site';
 import { isMockMode, logDataMode } from '@/lib/pwaDataMode';
-
-const prisma = new PrismaClient();
 
 export const dynamic = 'force-dynamic';
 
@@ -20,17 +16,18 @@ interface ArticleWithTitle {
 }
 
 /**
- * Récupère les titres des articles depuis la base de données
+ * Récupère les titres des articles depuis la base de données, filtrés par siteId.
  */
-async function getArticleTitles(): Promise<Map<string, string>> {
+async function getArticleTitles(siteId: string): Promise<Map<string, string>> {
   const articlesMap = new Map<string, string>();
 
   try {
     const posts = await prisma.blogPost.findMany({
+      where: { siteId },
       select: {
         slug: true,
-        title: true
-      }
+        title: true,
+      },
     });
 
     for (const post of posts) {
@@ -44,56 +41,49 @@ async function getArticleTitles(): Promise<Map<string, string>> {
 }
 
 /**
- * Génère des données mockées pour les statistiques blog PWA
+ * Génère des données mockées pour les statistiques blog PWA.
  */
-async function generateMockBlogStats(timeRange: string) {
-  const articlesMap = await getArticleTitles();
+async function generateMockBlogStats(siteId: string) {
+  const articlesMap = await getArticleTitles(siteId);
   const articleSlugs = Array.from(articlesMap.keys());
 
-  // Générer des vues aléatoires pour chaque article
   const articlesWithViews = articleSlugs.map(slug => ({
     slug,
     title: articlesMap.get(slug) || slug,
-    views: Math.floor(Math.random() * 450) + 50 // Entre 50 et 500 vues
+    views: Math.floor(Math.random() * 450) + 50,
   }));
 
-  // Trier par vues décroissantes
   articlesWithViews.sort((a, b) => b.views - a.views);
 
   const totalArticles = articlesWithViews.length;
   const totalViews = articlesWithViews.reduce((sum, a) => sum + a.views, 0);
-  const avgReadTime = Math.floor(Math.random() * 240) + 180; // 3-7 minutes en secondes
+  const avgReadTime = Math.floor(Math.random() * 240) + 180;
 
   return {
     totalArticles,
     totalViews,
     avgReadTime,
-    topArticles: articlesWithViews.slice(0, 10)
+    topArticles: articlesWithViews.slice(0, 10),
   };
 }
 
 /**
  * GET /api/analytics/blog/stats
- * Récupère les statistiques blog pour la PWA
+ * Récupère les statistiques blog pour la PWA.
  */
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const timeRange = searchParams.get('range') || '7d';
+    const siteId = await getSiteId();
 
     logDataMode();
 
-    // Si en mode mock, retourner des données simulées
     if (isMockMode()) {
-      console.log('📊 [Blog Stats PWA] Using MOCK data');
-      const mockData = await generateMockBlogStats(timeRange);
+      const mockData = await generateMockBlogStats(siteId);
       return NextResponse.json(mockData, { status: 200 });
     }
 
-    // Mode réel - récupérer les vraies données
-    console.log('📊 [Blog Stats PWA] Using REAL data');
-
-    // Calculer la date de début en fonction du timeRange
     const now = new Date();
     const startDate = new Date();
 
@@ -114,65 +104,51 @@ export async function GET(request: NextRequest) {
         startDate.setDate(now.getDate() - 7);
     }
 
-    // Récupérer toutes les vues d'articles dans la période
     const blogViews = await prisma.blogAnalytics.findMany({
       where: {
+        siteId,
         timestamp: {
           gte: startDate,
-          lte: now
-        }
+          lte: now,
+        },
       },
       select: {
         articleSlug: true,
         sessionId: true,
-        timestamp: true
-      }
+        timestamp: true,
+      },
     });
 
-    // Grouper par article et compter les vues
-    const viewsByArticle = blogViews.reduce(
-      (acc: Record<string, number>, view: { articleSlug: string; sessionId: string; timestamp: Date }) => {
-        if (!acc[view.articleSlug]) {
-          acc[view.articleSlug] = 0;
-        }
-        acc[view.articleSlug]++;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
+    const viewsByArticle: Record<string, number> = {};
+    for (const view of blogViews) {
+      viewsByArticle[view.articleSlug] = (viewsByArticle[view.articleSlug] ?? 0) + 1;
+    }
 
-    // Récupérer les titres des articles depuis la base de données
-    const articlesMap = await getArticleTitles();
+    const articlesMap = await getArticleTitles(siteId);
     const totalArticles = articlesMap.size;
 
-    // Créer le tableau des top articles avec titres
     const articlesWithViews: ArticleWithTitle[] = Object.entries(viewsByArticle)
       .map(([slug, views]) => ({
         slug,
         title: articlesMap.get(slug) || slug,
-        views: views as number
+        views,
       }))
       .sort((a, b) => b.views - a.views);
 
     const totalViews = articlesWithViews.reduce((sum, a) => sum + a.views, 0);
-
-    // Calculer le temps de lecture moyen (estimation: 250 secondes en moyenne)
     const avgReadTime = 250;
 
-    return NextResponse.json({
-      totalArticles,
-      totalViews,
-      avgReadTime,
-      topArticles: articlesWithViews.slice(0, 10)
-    }, { status: 200 });
-
+    return NextResponse.json(
+      {
+        totalArticles,
+        totalViews,
+        avgReadTime,
+        topArticles: articlesWithViews.slice(0, 10),
+      },
+      { status: 200 }
+    );
   } catch (error) {
     console.error('Error fetching blog stats:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch blog stats' },
-      { status: 500 }
-    );
-  } finally {
-    await prisma.$disconnect();
+    return NextResponse.json({ error: 'Failed to fetch blog stats' }, { status: 500 });
   }
 }

--- a/apps/psypnos/app/api/analytics/dashboard/route.ts
+++ b/apps/psypnos/app/api/analytics/dashboard/route.ts
@@ -367,8 +367,9 @@ async function fetchGeoData(startDate: Date, endDate: Date) {
  */
 async function fetchBlogAnalytics(startDate: Date, endDate: Date) {
   try {
+    const siteId = await getCurrentSiteId();
     const allAnalytics = await prisma.blogAnalytics.findMany({
-      where: { timestamp: { gte: startDate, lte: endDate } },
+      where: { siteId, timestamp: { gte: startDate, lte: endDate } },
       select: {
         articleSlug: true,
         sessionId: true,
@@ -458,8 +459,9 @@ async function fetchBlogAnalytics(startDate: Date, endDate: Date) {
 
 async function fetchBlogCtaClicks(startDate: Date, endDate: Date) {
   try {
+    const siteId = await getCurrentSiteId();
     const clicks = await prisma.blogCtaClick.findMany({
-      where: { timestamp: { gte: startDate, lte: endDate } },
+      where: { siteId, timestamp: { gte: startDate, lte: endDate } },
       select: { ctaType: true },
     });
 
@@ -477,8 +479,9 @@ async function fetchBlogCtaClicks(startDate: Date, endDate: Date) {
 
 async function fetchBlogFaqClicks(startDate: Date, endDate: Date) {
   try {
+    const siteId = await getCurrentSiteId();
     const clicks = await prisma.blogFaqClick.findMany({
-      where: { timestamp: { gte: startDate, lte: endDate } },
+      where: { siteId, timestamp: { gte: startDate, lte: endDate } },
       orderBy: { timestamp: 'desc' },
       take: 10000,
     });

--- a/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
+++ b/apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts
@@ -464,30 +464,12 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
       // included in the dashboard response. Only bots (requires admin auth)
       // is fetched separately.
       const postsUrl = `/api/analytics/dashboard/posts?${params}`;
-      console.log('[PostsPanel:Debug][Client] ══════════════════════════════════════');
-      console.log('[PostsPanel:Debug][Client] Fetch démarré pour 3 endpoints');
-      console.log('[PostsPanel:Debug][Client] Posts URL:', postsUrl);
-      console.log('[PostsPanel:Debug][Client] Params:', { timeRange, startDate, endDate });
-      const clientFetchStart = Date.now();
 
       const [dashboardRes, botsRes, postsRes] = await Promise.all([
         fetch(`/api/analytics/dashboard?${params}`, { cache: 'no-store' }),
         fetch(`/api/analytics/bots?${params}`).catch(() => null),
-        fetch(postsUrl).catch(err => {
-          console.error(
-            '[PostsPanel:Debug][Client] ❌ Erreur RÉSEAU fetch posts:',
-            err?.message ?? err
-          );
-          return null;
-        }),
+        fetch(postsUrl).catch(() => null),
       ]);
-
-      console.log(`[PostsPanel:Debug][Client] Fetch terminé en ${Date.now() - clientFetchStart}ms`);
-      console.log('[PostsPanel:Debug][Client] Statuts HTTP:', {
-        dashboard: dashboardRes.status,
-        bots: botsRes?.status ?? 'null (erreur réseau)',
-        posts: postsRes?.status ?? 'null (erreur réseau)',
-      });
 
       if (!dashboardRes.ok) {
         throw new Error('Erreur lors de la récupération des données');
@@ -512,44 +494,8 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
 
       // Social media posts data — null if API fails (graceful degradation)
       let postsData: PostsPanelData | null = null;
-      if (!postsRes) {
-        console.error('[PostsPanel:Debug][Client] ❌ postsRes est null — fetch réseau échoué');
-      } else if (!postsRes.ok) {
-        let errorBody = '';
-        try {
-          errorBody = await postsRes.text();
-        } catch {
-          errorBody = '(impossible de lire le body)';
-        }
-        console.error(
-          `[PostsPanel:Debug][Client] ❌ API posts: HTTP ${postsRes.status} ${postsRes.statusText}`
-        );
-        console.error('[PostsPanel:Debug][Client] ❌ Body erreur:', errorBody);
-      } else {
+      if (postsRes && postsRes.ok) {
         postsData = await postsRes.json();
-        console.log('[PostsPanel:Debug][Client] ✅ Posts data reçue:', {
-          totalPosts: postsData?.totalPosts,
-          totalReach: postsData?.totalReach,
-          totalEngagement: postsData?.totalEngagement,
-          avgEngagementRate: postsData?.avgEngagementRate,
-          totalFollowers: postsData?.totalFollowers,
-          platformsCount: postsData?.platforms?.length ?? 0,
-          topPostsCount: postsData?.topPosts?.length ?? 0,
-          postTypesCount: postsData?.postTypes?.length ?? 0,
-          engagementTrendsCount: postsData?.engagementTrends?.length ?? 0,
-          bestPostingTimesCount: postsData?.bestPostingTimes?.length ?? 0,
-        });
-        // Vérifier si toutes les données sont à zéro
-        if (
-          postsData &&
-          postsData.totalPosts === 0 &&
-          postsData.totalReach === 0 &&
-          postsData.totalEngagement === 0
-        ) {
-          console.warn(
-            '[PostsPanel:Debug][Client] ⚠️ ATTENTION: toutes les valeurs sont à 0 — vérifier les données en base ou les filtres de dates'
-          );
-        }
       }
 
       // Insights are NOT loaded here — they are lazy-loaded on demand
@@ -905,17 +851,10 @@ export function useAnalytics(options: UseAnalyticsOptions): UseAnalyticsReturn {
         postsData,
       };
 
-      console.log(
-        '[PostsPanel:Debug][Client] postsData assigné au state:',
-        postsData ? 'objet non-null' : 'NULL'
-      );
-      console.log('[PostsPanel:Debug][Client] ══════════════════════════════════════');
-
       setData(analyticsData);
       setLastUpdated(new Date());
       setError(null);
     } catch (err) {
-      console.error('[PostsPanel:Debug][Client] ❌ ERREUR CATCH GLOBAL fetchData:', err);
       setError(err instanceof Error ? err.message : 'Erreur inconnue');
     }
   }, [period, customStartDate, customEndDate, isSimulationMode, generateSimulatedData]);

--- a/apps/psypnos/lib/db/site.ts
+++ b/apps/psypnos/lib/db/site.ts
@@ -19,13 +19,8 @@ let cachedSiteId: string | null = null;
  */
 export async function getSiteId(): Promise<string> {
   if (cachedSiteId) {
-    // eslint-disable-next-line no-console
-    console.log('[getSiteId] Using cached siteId:', cachedSiteId);
     return cachedSiteId;
   }
-
-  // eslint-disable-next-line no-console
-  console.log('[getSiteId] Fetching site from database, slug:', SITE_SLUG);
 
   const site = await prisma.site.findUnique({
     where: { slug: SITE_SLUG },
@@ -33,13 +28,8 @@ export async function getSiteId(): Promise<string> {
   });
 
   if (!site) {
-    // eslint-disable-next-line no-console
-    console.error('[getSiteId] Site not found:', SITE_SLUG);
     throw new Error(`Site "${SITE_SLUG}" not found in database`);
   }
-
-  // eslint-disable-next-line no-console
-  console.log('[getSiteId] Found site:', site.id);
 
   cachedSiteId = site.id;
   return cachedSiteId;

--- a/packages/analytics/src/server/stores/analytics.ts
+++ b/packages/analytics/src/server/stores/analytics.ts
@@ -31,7 +31,9 @@ const VALID_DATE_TRUNC_PERIODS = new Set([
 /** Get analytics summary for a date range using SQL aggregations */
 export async function getAnalyticsSummary(startDate?: string, endDate?: string) {
   const { prisma, getSiteId, cache } = getAnalyticsContext();
+  const siteId = await getSiteId();
   const cacheKey = cache.buildKey(ANALYTICS_CACHE_KEYS.SUMMARY, {
+    siteId,
     start: startDate,
     end: endDate,
   });
@@ -39,7 +41,6 @@ export async function getAnalyticsSummary(startDate?: string, endDate?: string) 
   return cache.getCached(
     cacheKey,
     async () => {
-      const siteId = await getSiteId();
       const dateFilter = buildDateFilter(startDate, endDate);
 
       // Count total page views (excluding bots) and unique sessions via SQL
@@ -331,7 +332,9 @@ export async function getVisitsByPeriod(
   }
 
   const { prisma, getSiteId, cache } = getAnalyticsContext();
+  const siteId = await getSiteId();
   const cacheKey = cache.buildKey(ANALYTICS_CACHE_KEYS.VISITS_BY_PERIOD, {
+    siteId,
     period,
     start: startDate,
     end: endDate,
@@ -340,7 +343,6 @@ export async function getVisitsByPeriod(
   return cache.getCached(
     cacheKey,
     async () => {
-      const siteId = await getSiteId();
       const start = startDate
         ? new Date(startDate)
         : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
@@ -476,7 +478,9 @@ export async function getAnalyticsSummaryWithComparison(
 /** Get section engagement heatmap using SQL aggregation */
 export async function getSectionHeatmap(startDate?: string, endDate?: string) {
   const { prisma, getSiteId, cache } = getAnalyticsContext();
+  const siteId = await getSiteId();
   const cacheKey = cache.buildKey(ANALYTICS_CACHE_KEYS.HEATMAP, {
+    siteId,
     start: startDate,
     end: endDate,
   });
@@ -484,7 +488,6 @@ export async function getSectionHeatmap(startDate?: string, endDate?: string) {
   return cache.getCached(
     cacheKey,
     async () => {
-      const siteId = await getSiteId();
       const start = startDate
         ? new Date(startDate)
         : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
@@ -546,7 +549,9 @@ export async function getSectionHeatmap(startDate?: string, endDate?: string) {
 /** Get traffic sources breakdown using SQL aggregation */
 export async function getTrafficSources(startDate?: string, endDate?: string) {
   const { prisma, getSiteId, cache } = getAnalyticsContext();
+  const siteId = await getSiteId();
   const cacheKey = cache.buildKey(ANALYTICS_CACHE_KEYS.TRAFFIC_SOURCES, {
+    siteId,
     start: startDate,
     end: endDate,
   });
@@ -554,7 +559,6 @@ export async function getTrafficSources(startDate?: string, endDate?: string) {
   return cache.getCached(
     cacheKey,
     async () => {
-      const siteId = await getSiteId();
       const start = startDate
         ? new Date(startDate)
         : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
@@ -614,7 +618,9 @@ export async function getTrafficSources(startDate?: string, endDate?: string) {
  */
 export async function getDeviceBreakdown(startDate?: string, endDate?: string) {
   const { prisma, getSiteId, cache } = getAnalyticsContext();
+  const siteId = await getSiteId();
   const cacheKey = cache.buildKey(ANALYTICS_CACHE_KEYS.DEVICE_BREAKDOWN, {
+    siteId,
     start: startDate,
     end: endDate,
   });
@@ -622,7 +628,6 @@ export async function getDeviceBreakdown(startDate?: string, endDate?: string) {
   return cache.getCached(
     cacheKey,
     async () => {
-      const siteId = await getSiteId();
       const start = startDate
         ? new Date(startDate)
         : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);

--- a/packages/analytics/src/server/stores/attribution.ts
+++ b/packages/analytics/src/server/stores/attribution.ts
@@ -13,8 +13,10 @@ import { getPageVisits } from './page-visits';
 
 /** Get marketing attribution analysis using multiple models */
 export async function getMarketingAttribution(startDate?: string, endDate?: string) {
-  const { cache } = getAnalyticsContext();
+  const { cache, getSiteId } = getAnalyticsContext();
+  const siteId = await getSiteId();
   const cacheKey = cache.buildKey(ANALYTICS_CACHE_KEYS.ATTRIBUTION, {
+    siteId,
     start: startDate,
     end: endDate,
   });

--- a/packages/analytics/src/server/stores/cohorts.ts
+++ b/packages/analytics/src/server/stores/cohorts.ts
@@ -18,8 +18,10 @@ export async function getCohortAnalysis(
   startDate?: string,
   endDate?: string
 ) {
-  const { cache } = getAnalyticsContext();
+  const { cache, getSiteId } = getAnalyticsContext();
+  const siteId = await getSiteId();
   const cacheKey = cache.buildKey(ANALYTICS_CACHE_KEYS.COHORTS, {
+    siteId,
     cohortBy,
     start: startDate,
     end: endDate,

--- a/packages/db/prisma/migrations/20260316120000_backfill_siteId_blog_clicks/migration.sql
+++ b/packages/db/prisma/migrations/20260316120000_backfill_siteId_blog_clicks/migration.sql
@@ -1,0 +1,19 @@
+-- Fix: Backfill siteId for BlogFaqClick, BlogCtaClick, BotVisit, and Appointment
+-- The migration 20260312181500 set DEFAULT '' instead of backfilling existing rows
+-- with the actual psypnos site ID. This corrects those empty-string siteId values.
+
+UPDATE "BlogFaqClick"
+SET "siteId" = (SELECT id FROM "Site" WHERE slug = 'psypnos' LIMIT 1)
+WHERE "siteId" = '';
+
+UPDATE "BlogCtaClick"
+SET "siteId" = (SELECT id FROM "Site" WHERE slug = 'psypnos' LIMIT 1)
+WHERE "siteId" = '';
+
+UPDATE "BotVisit"
+SET "siteId" = (SELECT id FROM "Site" WHERE slug = 'psypnos' LIMIT 1)
+WHERE "siteId" = '';
+
+UPDATE "Appointment"
+SET "siteId" = (SELECT id FROM "Site" WHERE slug = 'psypnos' LIMIT 1)
+WHERE "siteId" = '';


### PR DESCRIPTION
## Résumé

Corrige les problèmes de collecte, stockage et affichage des données analytics dans le dashboard admin (`/admin/analytics`).

- **Bug 1** : Ajout des filtres `siteId` manquants sur les requêtes `BlogAnalytics`, `BlogCtaClick` et `BlogFaqClick` dans `dashboard/route.ts`
- **Bug 2** : Migration de backfill pour corriger les enregistrements `BlogFaqClick`/`BlogCtaClick`/`BotVisit`/`Appointment` avec `siteId` vide (hérité de la migration précédente)
- **Bug 3** : Réécriture de `blog/stats/route.ts` — suppression de `@ts-nocheck`, utilisation du singleton Prisma, ajout de `siteId` sur toutes les requêtes
- **Bug 4** : Nettoyage des `console.log` debug en production (`getSiteId`, `useAnalytics`)
- **Bug 5** : Ajout de `siteId` aux clés de cache du package `@kairn/analytics` pour éviter les collisions multi-tenant

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `apps/psypnos/app/api/analytics/dashboard/route.ts` | Ajout `siteId` sur 3 requêtes blog |
| `apps/psypnos/app/api/analytics/blog/stats/route.ts` | Réécriture complète (singleton Prisma, siteId, suppression @ts-nocheck) |
| `apps/psypnos/lib/db/site.ts` | Suppression console.log debug |
| `apps/psypnos/components/analytics/v2/hooks/useAnalytics.ts` | Suppression console.log debug PostsPanel |
| `packages/analytics/src/server/stores/analytics.ts` | Ajout siteId aux clés de cache (5 fonctions) |
| `packages/analytics/src/server/stores/attribution.ts` | Ajout siteId à la clé de cache |
| `packages/analytics/src/server/stores/cohorts.ts` | Ajout siteId à la clé de cache |
| `packages/db/prisma/migrations/20260316120000_.../migration.sql` | Backfill siteId pour 4 tables |

## Test plan

- [x] Lint (0 erreurs)
- [x] Type-check (pass)
- [x] Tests unitaires (1431 passed)
- [x] Build (pass)

Fixes #405

https://claude.ai/code/session_012DVzPB3UYDvXwpCjk9KpJu