### PR TITLE
fix(ui): corriger affichage page d'accueil et tarifs séminaires

### DIFF
--- a/apps/psypnos/app/(pages)/sections/blog.tsx
+++ b/apps/psypnos/app/(pages)/sections/blog.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable no-console */
 
 import { BlogSection as BlogSectionUI } from '@kairn/ui';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
@@ -130,6 +131,9 @@ export function BlogSection({ initialData, ssrError = false }: BlogSectionProps)
       }}
       categoryColors={CATEGORY_COLORS}
       linkComponent={Link}
+      imageComponent={({ src, alt, fill, className, sizes }) => (
+        <Image src={src} alt={alt} fill={fill} className={className} sizes={sizes} />
+      )}
       ctaComponent={
         <CTAButton variant="secondary" href="/blog">
           Découvrir tous les articles

--- a/apps/psypnos/app/(pages)/sections/hero.tsx
+++ b/apps/psypnos/app/(pages)/sections/hero.tsx
@@ -79,13 +79,13 @@ export function HeroSection() {
         <motion.div
           initial={fadeInInitial}
           animate={fadeIn}
-          transition={hasMounted ? { duration: 2, ease: 'easeOut' } : { duration: 0 }}
+          transition={hasMounted ? { duration: 1.2, ease: 'easeOut' } : { duration: 0 }}
           className="bg-night/40 flex flex-col items-center justify-center"
         >
           <motion.svg
             initial={hasMounted ? { scale: 0.25, rotate: -360 } : { scale: 0.75, rotate: 0 }}
             animate={{ scale: 1, rotate: 0 }}
-            transition={hasMounted ? { duration: 2.2, ease: 'easeOut' } : { duration: 0 }}
+            transition={hasMounted ? { duration: 1.4, ease: 'easeOut' } : { duration: 0 }}
             width="100"
             height="100"
             viewBox="0 0 600 600"
@@ -109,7 +109,9 @@ export function HeroSection() {
           <motion.span
             initial={fadeInInitial}
             animate={fadeIn}
-            transition={hasMounted ? { duration: 2, delay: 1, ease: 'easeOut' } : { duration: 0 }}
+            transition={
+              hasMounted ? { duration: 1.2, delay: 0.8, ease: 'easeOut' } : { duration: 0 }
+            }
             className="font-display text-gold text-2xl font-semibold"
           >
             Psypnos
@@ -119,7 +121,7 @@ export function HeroSection() {
         <motion.div
           initial={slideUpInitial}
           animate={slideUp}
-          transition={hasMounted ? { duration: 0.8, delay: 3.3, ease: 'easeOut' } : { duration: 0 }}
+          transition={hasMounted ? { duration: 0.8, delay: 1.5, ease: 'easeOut' } : { duration: 0 }}
           className="max-w-3xl"
         >
           <h1 className="text-gold-accessible mb-2 text-sm uppercase tracking-[0.3em]">
@@ -134,7 +136,7 @@ export function HeroSection() {
         <motion.div
           initial={slideUpInitial}
           animate={slideUp}
-          transition={hasMounted ? { duration: 0.8, delay: 3.5, ease: 'easeOut' } : { duration: 0 }}
+          transition={hasMounted ? { duration: 0.8, delay: 1.7, ease: 'easeOut' } : { duration: 0 }}
           className="flex flex-col items-center gap-6"
         >
           {/* Boutons principaux */}
@@ -193,7 +195,7 @@ export function HeroSection() {
         <motion.div
           initial={hasMounted ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={hasMounted ? { duration: 2, delay: 3.6, ease: 'easeOut' } : { duration: 0 }}
+          transition={hasMounted ? { duration: 1.5, delay: 1.9, ease: 'easeOut' } : { duration: 0 }}
           className="relative flex w-full flex-col items-center justify-center gap-8 overflow-hidden lg:flex-row lg:items-start lg:justify-center"
         >
           <Image

--- a/apps/psypnos/components/ApproachInfographic.tsx
+++ b/apps/psypnos/components/ApproachInfographic.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-"use client";
+'use client';
 
-import { motion, useScroll, useTransform } from "framer-motion";
-import Image from "next/image";
-import { useRef } from "react";
+import { motion, useScroll, useTransform } from 'framer-motion';
+import Image from 'next/image';
+import { useRef } from 'react';
 
 type ApproachItem = {
   title: string;
@@ -22,7 +22,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
-    offset: ["start center", "end center"],
+    offset: ['start center', 'end center'],
   });
 
   // Create staggered parallax effects for each item
@@ -61,9 +61,9 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                   className="group relative"
                 >
                   {/* Card with gradient border effect */}
-                  <div className="relative h-full overflow-hidden rounded-2xl border border-gold/20 bg-gradient-to-br from-night/60 via-night/40 to-night/60 p-8 shadow-lg backdrop-blur-sm transition-all duration-300 hover:border-gold/50 hover:shadow-[0_0_30px_rgba(199,169,98,0.2)]">
+                  <div className="border-gold/20 from-night/60 via-night/40 to-night/60 hover:border-gold/50 relative h-full overflow-hidden rounded-2xl border bg-gradient-to-br p-8 shadow-lg backdrop-blur-sm transition-all duration-300 hover:shadow-[0_0_30px_rgba(199,169,98,0.2)]">
                     {/* Animated background gradient */}
-                    <div className="absolute inset-0 bg-gradient-to-br from-gold/5 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                    <div className="from-gold/5 absolute inset-0 bg-gradient-to-br via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
                     {/* Content */}
                     <div className="relative z-10 flex h-full flex-col">
@@ -71,15 +71,15 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                       <motion.div
                         initial={{ scale: 0, rotateY: 90 }}
                         whileInView={{ scale: 1, rotateY: 0 }}
-                        viewport={{ once: true, amount: 0.5 }}
+                        viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
                         className="relative mb-6 inline-flex h-16 w-16 items-center justify-center"
                       >
                         {/* Glow background */}
-                        <div className="absolute inset-0 rounded-full bg-gold/15 blur-xl" />
+                        <div className="bg-gold/15 absolute inset-0 rounded-full blur-xl" />
 
                         {/* Icon background circle */}
-                        <div className="absolute inset-0 rounded-full border border-gold/30 bg-gradient-to-br from-gold/10 to-transparent" />
+                        <div className="border-gold/30 from-gold/10 absolute inset-0 rounded-full border bg-gradient-to-br to-transparent" />
 
                         {/* Icon */}
                         <Image
@@ -92,12 +92,12 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                       </motion.div>
 
                       {/* Title */}
-                      <h3 className="text-lg font-semibold text-gold transition-colors duration-300 group-hover:text-gold">
+                      <h3 className="text-gold group-hover:text-gold text-lg font-semibold transition-colors duration-300">
                         {item.title}
                       </h3>
 
                       {/* Description */}
-                      <p className="mt-3 flex-grow text-sm leading-relaxed text-ivory/75 transition-colors duration-300 group-hover:text-ivory/90">
+                      <p className="text-ivory/75 group-hover:text-ivory/90 mt-3 flex-grow text-sm leading-relaxed transition-colors duration-300">
                         {item.description}
                       </p>
 
@@ -105,9 +105,9 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                       <motion.div
                         initial={{ scaleX: 0 }}
                         whileInView={{ scaleX: 1 }}
-                        viewport={{ once: true, amount: 0.5 }}
+                        viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
-                        className="mt-6 h-0.5 w-12 origin-left bg-gradient-to-r from-gold to-gold/0"
+                        className="from-gold to-gold/0 mt-6 h-0.5 w-12 origin-left bg-gradient-to-r"
                       />
                     </div>
                   </div>
@@ -129,9 +129,9 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
               className="group relative"
             >
               {/* Mobile card */}
-              <div className="relative overflow-hidden rounded-2xl border border-gold/20 bg-gradient-to-br from-night/60 via-night/40 to-night/60 p-6 shadow-lg backdrop-blur-sm transition-all duration-300 hover:border-gold/50">
+              <div className="border-gold/20 from-night/60 via-night/40 to-night/60 hover:border-gold/50 relative overflow-hidden rounded-2xl border bg-gradient-to-br p-6 shadow-lg backdrop-blur-sm transition-all duration-300">
                 {/* Animated background gradient */}
-                <div className="absolute inset-0 bg-gradient-to-br from-gold/5 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                <div className="from-gold/5 absolute inset-0 bg-gradient-to-br via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
                 {/* Content */}
                 <div className="relative z-10">
@@ -141,15 +141,15 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                     <motion.div
                       initial={{ scale: 0 }}
                       whileInView={{ scale: 1 }}
-                      viewport={{ once: true, amount: 0.5 }}
+                      viewport={{ once: true, amount: 0.2 }}
                       transition={{ duration: 0.5, delay: index * 0.1 }}
                       className="relative mt-1 inline-flex h-12 w-12 flex-shrink-0 items-center justify-center"
                     >
                       {/* Glow background */}
-                      <div className="absolute inset-0 rounded-full bg-gold/15 blur-lg" />
+                      <div className="bg-gold/15 absolute inset-0 rounded-full blur-lg" />
 
                       {/* Icon background circle */}
-                      <div className="absolute inset-0 rounded-full border border-gold/30 bg-gradient-to-br from-gold/10 to-transparent" />
+                      <div className="border-gold/30 from-gold/10 absolute inset-0 rounded-full border bg-gradient-to-br to-transparent" />
 
                       {/* Icon */}
                       <Image
@@ -162,21 +162,19 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                     </motion.div>
 
                     {/* Title */}
-                    <h3 className="text-base font-semibold text-gold">{item.title}</h3>
+                    <h3 className="text-gold text-base font-semibold">{item.title}</h3>
                   </div>
 
                   {/* Description */}
-                  <p className="mt-4 text-sm leading-relaxed text-ivory/75">
-                    {item.description}
-                  </p>
+                  <p className="text-ivory/75 mt-4 text-sm leading-relaxed">{item.description}</p>
 
                   {/* Bottom accent */}
                   <motion.div
                     initial={{ scaleX: 0 }}
                     whileInView={{ scaleX: 1 }}
-                    viewport={{ once: true, amount: 0.5 }}
+                    viewport={{ once: true, amount: 0.2 }}
                     transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}
-                    className="mt-4 h-0.5 w-8 origin-left bg-gradient-to-r from-gold to-gold/0"
+                    className="from-gold to-gold/0 mt-4 h-0.5 w-8 origin-left bg-gradient-to-r"
                   />
                 </div>
               </div>

--- a/apps/psypnos/components/JourneyInfographic.tsx
+++ b/apps/psypnos/components/JourneyInfographic.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-"use client";
+'use client';
 
-import { motion, useScroll, useTransform } from "framer-motion";
-import Image from "next/image";
-import { useRef } from "react";
+import { motion, useScroll, useTransform } from 'framer-motion';
+import Image from 'next/image';
+import { useRef } from 'react';
 
 type JourneyStep = {
   number: number;
@@ -18,24 +18,27 @@ type JourneyStep = {
 const steps: JourneyStep[] = [
   {
     number: 1,
-    title: "Acceptation",
-    description: "Reconnaître pleinement ce qui est vécu, sans jugement, pour apaiser la résistance et ouvrir un espace de transformation.",
-    icon: "/images/icons/journey-acceptation.svg",
-    iconAlt: "Acceptation",
+    title: 'Acceptation',
+    description:
+      'Reconnaître pleinement ce qui est vécu, sans jugement, pour apaiser la résistance et ouvrir un espace de transformation.',
+    icon: '/images/icons/journey-acceptation.svg',
+    iconAlt: 'Acceptation',
   },
   {
     number: 2,
-    title: "Exploration",
-    description: "Aller à la rencontre des émotions, des pensées et des expériences profondes afin d'en comprendre le sens et les messages.",
-    icon: "/images/icons/journey-exploration.svg",
-    iconAlt: "Exploration",
+    title: 'Exploration',
+    description:
+      "Aller à la rencontre des émotions, des pensées et des expériences profondes afin d'en comprendre le sens et les messages.",
+    icon: '/images/icons/journey-exploration.svg',
+    iconAlt: 'Exploration',
   },
   {
     number: 3,
-    title: "Intégration",
-    description: "Transformer ces prises de conscience en nouveaux équilibres intérieurs, pour retrouver cohérence, alignement et liberté d'être.",
-    icon: "/images/icons/journey-integration.svg",
-    iconAlt: "Intégration",
+    title: 'Intégration',
+    description:
+      "Transformer ces prises de conscience en nouveaux équilibres intérieurs, pour retrouver cohérence, alignement et liberté d'être.",
+    icon: '/images/icons/journey-integration.svg',
+    iconAlt: 'Intégration',
   },
 ];
 
@@ -43,7 +46,7 @@ export function JourneyInfographic() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
-    offset: ["start center", "end center"],
+    offset: ['start center', 'end center'],
   });
 
   // Parallax effects for each step
@@ -68,17 +71,17 @@ export function JourneyInfographic() {
                     className="flex w-1/3 flex-col items-center px-4"
                   >
                     {/* Positioning: odd steps on top, even in middle */}
-                    <div className={index !== 1 ? "mb-32" : "mb-0"}>
+                    <div className={index !== 1 ? 'mb-32' : 'mb-0'}>
                       {/* Step circle */}
                       <motion.div
                         initial={{ scale: 0, opacity: 0 }}
                         whileInView={{ scale: 1, opacity: 1 }}
-                        viewport={{ once: true, amount: 0.5 }}
+                        viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.2 }}
-                        className="relative mb-8 flex h-20 w-20 items-center justify-center rounded-full border-2 border-gold bg-night/60 shadow-lg"
+                        className="border-gold bg-night/60 relative mb-8 flex h-20 w-20 items-center justify-center rounded-full border-2 shadow-lg"
                       >
                         {/* Icon background glow */}
-                        <div className="absolute inset-0 rounded-full bg-gold/10 blur-xl" />
+                        <div className="bg-gold/10 absolute inset-0 rounded-full blur-xl" />
 
                         {/* SVG Icon */}
                         <Image
@@ -90,7 +93,7 @@ export function JourneyInfographic() {
                         />
 
                         {/* Step number */}
-                        <div className="absolute -right-3 -top-3 flex h-8 w-8 items-center justify-center rounded-full border-2 border-gold bg-night text-sm font-bold text-gold">
+                        <div className="border-gold bg-night text-gold absolute -right-3 -top-3 flex h-8 w-8 items-center justify-center rounded-full border-2 text-sm font-bold">
                           {step.number}
                         </div>
                       </motion.div>
@@ -99,12 +102,12 @@ export function JourneyInfographic() {
                       <motion.div
                         initial={{ opacity: 0, y: 20 }}
                         whileInView={{ opacity: 1, y: 0 }}
-                        viewport={{ once: true, amount: 0.5 }}
+                        viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.2 + 0.2 }}
-                        className="rounded-2xl border border-gold/20 bg-gradient-to-br from-night/50 to-night/30 p-6 text-center shadow-lg backdrop-blur-sm"
+                        className="border-gold/20 from-night/50 to-night/30 rounded-2xl border bg-gradient-to-br p-6 text-center shadow-lg backdrop-blur-sm"
                       >
-                        <h3 className="text-xl font-semibold text-gold">{step.title}</h3>
-                        <p className="mt-3 text-sm text-ivory/75 leading-relaxed">
+                        <h3 className="text-gold text-xl font-semibold">{step.title}</h3>
+                        <p className="text-ivory/75 mt-3 text-sm leading-relaxed">
                           {step.description}
                         </p>
                       </motion.div>
@@ -123,7 +126,7 @@ export function JourneyInfographic() {
               key={step.number}
               initial={{ opacity: 0, x: -20 }}
               whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true, amount: 0.5 }}
+              viewport={{ once: true, amount: 0.2 }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
               className="flex gap-6"
             >
@@ -133,11 +136,11 @@ export function JourneyInfographic() {
                 <motion.div
                   initial={{ scale: 0 }}
                   whileInView={{ scale: 1 }}
-                  viewport={{ once: true, amount: 0.5 }}
+                  viewport={{ once: true, amount: 0.2 }}
                   transition={{ duration: 0.5, delay: index * 0.1 }}
-                  className="relative flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full border-2 border-gold bg-night/60 shadow-lg"
+                  className="border-gold bg-night/60 relative flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full border-2 shadow-lg"
                 >
-                  <div className="absolute inset-0 rounded-full bg-gold/10 blur-xl" />
+                  <div className="bg-gold/10 absolute inset-0 rounded-full blur-xl" />
 
                   {/* SVG Icon */}
                   <Image
@@ -148,14 +151,14 @@ export function JourneyInfographic() {
                     className="relative h-7 w-7 object-contain"
                   />
 
-                  <div className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full border-2 border-gold bg-night text-xs font-bold text-gold">
+                  <div className="border-gold bg-night text-gold absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full border-2 text-xs font-bold">
                     {step.number}
                   </div>
                 </motion.div>
 
                 {/* Vertical line connector */}
                 {index < steps.length - 1 && (
-                  <div className="mt-4 h-12 w-0.5 bg-gradient-to-b from-gold to-transparent" />
+                  <div className="from-gold mt-4 h-12 w-0.5 bg-gradient-to-b to-transparent" />
                 )}
               </div>
 
@@ -163,14 +166,12 @@ export function JourneyInfographic() {
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.5 }}
+                viewport={{ once: true, amount: 0.2 }}
                 transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
-                className="flex-1 rounded-xl border border-gold/20 bg-gradient-to-br from-night/50 to-night/30 p-4 shadow-md backdrop-blur-sm"
+                className="border-gold/20 from-night/50 to-night/30 flex-1 rounded-xl border bg-gradient-to-br p-4 shadow-md backdrop-blur-sm"
               >
-                <h3 className="text-lg font-semibold text-gold">{step.title}</h3>
-                <p className="mt-2 text-sm text-ivory/75 leading-relaxed">
-                  {step.description}
-                </p>
+                <h3 className="text-gold text-lg font-semibold">{step.title}</h3>
+                <p className="text-ivory/75 mt-2 text-sm leading-relaxed">{step.description}</p>
               </motion.div>
             </motion.div>
           ))}

--- a/apps/psypnos/components/NavigationMenu.tsx
+++ b/apps/psypnos/components/NavigationMenu.tsx
@@ -106,10 +106,9 @@ function HamburgerIcon({ isOpen, className = '' }: { isOpen: boolean; className?
       />
       {/* Ligne du milieu */}
       <span
-        className={`bg-gold absolute left-0 top-2.5 block h-0.5 w-6 transition-all duration-300 ease-in-out ${
+        className={`bg-gold absolute left-0 top-1/2 block h-0.5 w-6 -translate-y-1/2 transition-all duration-300 ease-in-out ${
           isOpen ? 'scale-x-0 opacity-0' : 'scale-x-100 opacity-100'
         }`}
-        style={{ transform: `translateY(-50%) ${isOpen ? 'scaleX(0)' : 'scaleX(1)'}` }}
       />
       {/* Ligne du bas */}
       <span
@@ -256,7 +255,7 @@ export function NavigationMenu({ forceVisible = false }: NavigationMenuProps) {
             <button
               ref={hamburgerButtonRef}
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="text-ivory hover:bg-gold/10 hover:text-gold-accessible focus:ring-gold focus:ring-offset-night relative z-50 rounded-lg p-2 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 md:hidden"
+              className="text-ivory hover:bg-gold/10 hover:text-gold-accessible focus:ring-gold focus:ring-offset-night relative z-50 flex h-11 w-11 items-center justify-center rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 md:hidden"
               aria-label="Menu de navigation"
               aria-expanded={isMobileMenuOpen}
               aria-controls="mobile-menu"
@@ -287,6 +286,9 @@ export function NavigationMenu({ forceVisible = false }: NavigationMenuProps) {
           isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
+        {/* Espace réservé pour le header nav (h-16) */}
+        <div className="h-16 flex-shrink-0" />
+
         {/* En-tête du menu avec logo */}
         <div className="border-gold/20 flex items-center gap-3 border-b px-6 py-5">
           <PsypnosLogo size={40} />

--- a/apps/psypnos/components/SectionTitle.tsx
+++ b/apps/psypnos/components/SectionTitle.tsx
@@ -14,7 +14,7 @@ export function SectionTitle({ eyebrow, title, description }: SectionTitleProps)
     <motion.header
       initial={{ opacity: 0, y: 24 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.4 }}
+      viewport={{ once: true, amount: 0.2, margin: '0px 0px -50px 0px' }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
       className="mx-auto max-w-3xl text-center"
     >

--- a/apps/psypnos/components/SessionFormatsInfographic.tsx
+++ b/apps/psypnos/components/SessionFormatsInfographic.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // TODO: Migration - Type incompatibilities to fix
-"use client";
+'use client';
 
-import { motion, useScroll, useTransform } from "framer-motion";
-import Image from "next/image";
-import { useRef } from "react";
+import { motion, useScroll, useTransform } from 'framer-motion';
+import Image from 'next/image';
+import { useRef } from 'react';
 
 type SessionFormat = {
   title: string;
@@ -22,7 +22,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
-    offset: ["start center", "end center"],
+    offset: ['start center', 'end center'],
   });
 
   // Create parallax effects for each format
@@ -58,9 +58,9 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                   className="group relative"
                 >
                   {/* Card */}
-                  <div className="relative h-full overflow-hidden rounded-2xl border border-gold/20 bg-gradient-to-br from-night/60 via-night/40 to-night/60 p-8 shadow-lg backdrop-blur-sm transition-all duration-300 hover:border-gold/50 hover:shadow-[0_0_30px_rgba(199,169,98,0.2)]">
+                  <div className="border-gold/20 from-night/60 via-night/40 to-night/60 hover:border-gold/50 relative h-full overflow-hidden rounded-2xl border bg-gradient-to-br p-8 shadow-lg backdrop-blur-sm transition-all duration-300 hover:shadow-[0_0_30px_rgba(199,169,98,0.2)]">
                     {/* Animated background gradient */}
-                    <div className="absolute inset-0 bg-gradient-to-br from-gold/5 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                    <div className="from-gold/5 absolute inset-0 bg-gradient-to-br via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
                     {/* Content */}
                     <div className="relative z-10 flex h-full flex-col items-center text-center">
@@ -68,15 +68,15 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                       <motion.div
                         initial={{ scale: 0, rotateY: 90 }}
                         whileInView={{ scale: 1, rotateY: 0 }}
-                        viewport={{ once: true, amount: 0.5 }}
+                        viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
                         className="relative mb-6 inline-flex h-20 w-20 items-center justify-center"
                       >
                         {/* Glow background */}
-                        <div className="absolute inset-0 rounded-full bg-gold/15 blur-xl" />
+                        <div className="bg-gold/15 absolute inset-0 rounded-full blur-xl" />
 
                         {/* Icon background circle */}
-                        <div className="absolute inset-0 rounded-full border border-gold/30 bg-gradient-to-br from-gold/10 to-transparent" />
+                        <div className="border-gold/30 from-gold/10 absolute inset-0 rounded-full border bg-gradient-to-br to-transparent" />
 
                         {/* Icon */}
                         <Image
@@ -89,12 +89,12 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                       </motion.div>
 
                       {/* Title */}
-                      <h3 className="text-lg font-semibold text-gold transition-colors duration-300 group-hover:text-gold">
+                      <h3 className="text-gold group-hover:text-gold text-lg font-semibold transition-colors duration-300">
                         {format.title}
                       </h3>
 
                       {/* Description */}
-                      <p className="mt-3 flex-grow text-sm leading-relaxed text-ivory/75 transition-colors duration-300 group-hover:text-ivory/90">
+                      <p className="text-ivory/75 group-hover:text-ivory/90 mt-3 flex-grow text-sm leading-relaxed transition-colors duration-300">
                         {format.description}
                       </p>
 
@@ -102,9 +102,9 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                       <motion.div
                         initial={{ scaleX: 0 }}
                         whileInView={{ scaleX: 1 }}
-                        viewport={{ once: true, amount: 0.5 }}
+                        viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
-                        className="mt-6 h-0.5 w-8 origin-center bg-gradient-to-r from-gold/0 via-gold to-gold/0"
+                        className="from-gold/0 via-gold to-gold/0 mt-6 h-0.5 w-8 origin-center bg-gradient-to-r"
                       />
                     </div>
                   </div>
@@ -126,9 +126,9 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
               className="group relative"
             >
               {/* Mobile card */}
-              <div className="relative overflow-hidden rounded-2xl border border-gold/20 bg-gradient-to-br from-night/60 via-night/40 to-night/60 p-6 shadow-lg backdrop-blur-sm transition-all duration-300 hover:border-gold/50">
+              <div className="border-gold/20 from-night/60 via-night/40 to-night/60 hover:border-gold/50 relative overflow-hidden rounded-2xl border bg-gradient-to-br p-6 shadow-lg backdrop-blur-sm transition-all duration-300">
                 {/* Animated background gradient */}
-                <div className="absolute inset-0 bg-gradient-to-br from-gold/5 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                <div className="from-gold/5 absolute inset-0 bg-gradient-to-br via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
                 {/* Content */}
                 <div className="relative z-10">
@@ -138,15 +138,15 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                     <motion.div
                       initial={{ scale: 0 }}
                       whileInView={{ scale: 1 }}
-                      viewport={{ once: true, amount: 0.5 }}
+                      viewport={{ once: true, amount: 0.2 }}
                       transition={{ duration: 0.5, delay: index * 0.1 }}
                       className="relative mb-4 inline-flex h-16 w-16 items-center justify-center"
                     >
                       {/* Glow background */}
-                      <div className="absolute inset-0 rounded-full bg-gold/15 blur-lg" />
+                      <div className="bg-gold/15 absolute inset-0 rounded-full blur-lg" />
 
                       {/* Icon background circle */}
-                      <div className="absolute inset-0 rounded-full border border-gold/30 bg-gradient-to-br from-gold/10 to-transparent" />
+                      <div className="border-gold/30 from-gold/10 absolute inset-0 rounded-full border bg-gradient-to-br to-transparent" />
 
                       {/* Icon */}
                       <Image
@@ -159,11 +159,11 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                     </motion.div>
 
                     {/* Title */}
-                    <h3 className="text-base font-semibold text-gold">{format.title}</h3>
+                    <h3 className="text-gold text-base font-semibold">{format.title}</h3>
                   </div>
 
                   {/* Description */}
-                  <p className="mt-4 text-center text-sm leading-relaxed text-ivory/75">
+                  <p className="text-ivory/75 mt-4 text-center text-sm leading-relaxed">
                     {format.description}
                   </p>
 
@@ -171,11 +171,11 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                   <motion.div
                     initial={{ scaleX: 0 }}
                     whileInView={{ scaleX: 1 }}
-                    viewport={{ once: true, amount: 0.5 }}
+                    viewport={{ once: true, amount: 0.2 }}
                     transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}
                     className="mt-4 flex justify-center"
                   >
-                    <div className="h-0.5 w-8 bg-gradient-to-r from-gold/0 via-gold to-gold/0" />
+                    <div className="from-gold/0 via-gold to-gold/0 h-0.5 w-8 bg-gradient-to-r" />
                   </motion.div>
                 </div>
               </div>

--- a/packages/ui/src/components/sections/blog-section.tsx
+++ b/packages/ui/src/components/sections/blog-section.tsx
@@ -148,6 +148,7 @@ export function BlogSection({
   ctaHref = '/blog',
   readLabel = "Lire l'article",
   linkComponent: LinkComp,
+  imageComponent: ImageComp,
   ctaComponent,
   trackingName = 'Blog',
   className,
@@ -228,6 +229,27 @@ export function BlogSection({
                   href={`/blog/${post.slug}`}
                   className="focus:ring-gold focus:ring-offset-night flex h-full flex-col focus:outline-none focus:ring-2 focus:ring-offset-2"
                 >
+                  {/* Cover image */}
+                  {post.image && (
+                    <div className="from-night/80 relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br to-transparent">
+                      {ImageComp ? (
+                        <ImageComp
+                          src={post.image}
+                          alt={post.title}
+                          fill
+                          className="object-cover transition-transform duration-500 group-hover:scale-105"
+                          sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                        />
+                      ) : (
+                        <img
+                          src={post.image}
+                          alt={post.title}
+                          className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                        />
+                      )}
+                    </div>
+                  )}
+
                   <div className="flex flex-1 flex-col p-6 pl-8">
                     {/* Category badge */}
                     <div className="mb-3">

--- a/packages/ui/src/components/sections/seminars-section.tsx
+++ b/packages/ui/src/components/sections/seminars-section.tsx
@@ -23,6 +23,10 @@ export interface SeminarSectionItem {
   seminarType?: string;
   /** Number of available places */
   capacity: number;
+  /** Price in euros */
+  price?: number;
+  /** Deposit amount in euros */
+  deposit?: number;
   /** Optional thumbnail image URL */
   thumbnail?: string | null;
 }
@@ -51,6 +55,10 @@ export interface SeminarsSectionProps {
   timezone?: string;
   /** "places" label */
   placesLabel?: string;
+  /** Currency symbol for price display */
+  currencySymbol?: string;
+  /** Label for deposit (e.g. "acompte") */
+  depositLabel?: string;
   /** Custom image component */
   imageComponent?: React.ComponentType<{
     src: string;
@@ -157,6 +165,8 @@ export function SeminarsSection({
   locale = 'fr-FR',
   timezone = 'Europe/Paris',
   placesLabel = 'places',
+  currencySymbol = '€',
+  depositLabel = 'acompte',
   imageComponent: ImageComp,
   trackingName = 'Séminaires',
   className,
@@ -264,6 +274,22 @@ export function SeminarsSection({
                       </span>
                     </div>
                   </dl>
+
+                  {/* Price display */}
+                  {seminar.price != null && seminar.price > 0 && (
+                    <div className="border-gold/20 from-gold/5 mt-5 rounded-xl border bg-gradient-to-r to-transparent px-4 py-3">
+                      <div className="flex items-baseline justify-between">
+                        <span className="text-gold text-2xl font-bold">
+                          {seminar.price} {currencySymbol}
+                        </span>
+                        {seminar.deposit != null && seminar.deposit > 0 && (
+                          <span className="text-ivory/50 text-xs">
+                            {depositLabel} : {seminar.deposit} {currencySymbol}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
 
                   <div className="mt-6 flex justify-center">
                     {ctaComponent ? (


### PR DESCRIPTION
## Résumé

- **Images blog absentes** : le composant `BlogSection` de `@kairn/ui` avait les props `image` et `imageComponent` définis mais jamais rendus dans le template de carte. Ajout du rendu des images de couverture avec support Next.js Image.
- **Menu hamburger mobile** : agrandi le touch target (44px min), supprimé les styles inline conflictuels sur la ligne du milieu, ajouté un espace réservé pour le header nav dans le panneau mobile.
- **Contenus absents** : réduit les seuils `viewport.amount` de framer-motion (0.4-0.5 → 0.2) pour fiabiliser le déclenchement des animations `whileInView` sur mobile. Réduit les délais d'animation du hero (3.3s → 1.5s).
- **Tarifs séminaires (#408)** : ajouté les champs `price` et `deposit` au type `SeminarSectionItem`, rendu du prix avec style premium dans les cartes séminaires.

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `packages/ui/src/components/sections/blog-section.tsx` | Ajout rendu image de couverture |
| `packages/ui/src/components/sections/seminars-section.tsx` | Ajout champs price/deposit + affichage tarif |
| `apps/psypnos/app/(pages)/sections/blog.tsx` | Passage de imageComponent (Next.js Image) |
| `apps/psypnos/app/(pages)/sections/hero.tsx` | Réduction délais animations |
| `apps/psypnos/components/NavigationMenu.tsx` | Fix hamburger mobile |
| `apps/psypnos/components/SectionTitle.tsx` | Seuil viewport réduit |
| `apps/psypnos/components/ApproachInfographic.tsx` | Seuil viewport réduit |
| `apps/psypnos/components/JourneyInfographic.tsx` | Seuil viewport réduit |
| `apps/psypnos/components/SessionFormatsInfographic.tsx` | Seuil viewport réduit |

## Validation

- [x] Lint : 0 erreurs
- [x] Type-check : OK
- [x] Tests unitaires : 1431 passed
- [x] Tests UI : 192 passed
- [x] Build : OK

Fixes #407, Fixes #408

https://claude.ai/code/session_01E7pF37P2BnHZTduqYuUbmK