### PR TITLE
fix(psypnos): corriger contenus invisibles et menu hamburger

### DIFF
--- a/apps/psypnos/components/ApproachInfographic.tsx
+++ b/apps/psypnos/components/ApproachInfographic.tsx
@@ -5,7 +5,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type ApproachItem = {
   title: string;
@@ -18,12 +18,21 @@ interface ApproachInfographicProps {
   items: ApproachItem[];
 }
 
+/**
+ * Approach infographic with parallax and scroll-reveal animations.
+ * Uses hasMounted guard so content is visible on SSR and only animates after hydration.
+ */
 export function ApproachInfographic({ items }: ApproachInfographicProps) {
+  const [hasMounted, setHasMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
   });
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   // Create staggered parallax effects for each item
   const parallaxValues = items.map((_, index) => {
@@ -38,6 +47,13 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
       [direction * baseAmplitude, -direction * baseAmplitude]
     );
   });
+
+  // SSR-safe initial values: visible on server, animate only after hydration
+  const cardInitial = hasMounted ? { opacity: 0, scale: 0.9 } : { opacity: 1, scale: 1 };
+  const iconInitial = hasMounted ? { scale: 0, rotateY: 90 } : { scale: 1, rotateY: 0 };
+  const lineInitial = hasMounted ? { scaleX: 0 } : { scaleX: 1 };
+  const mobileCardInitial = hasMounted ? { opacity: 0, x: -20 } : { opacity: 1, x: 0 };
+  const mobileIconInitial = hasMounted ? { scale: 0 } : { scale: 1 };
 
   return (
     <div ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
@@ -54,7 +70,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                   key={item.title}
                   ref={containerRef}
                   style={{ y: yTransform }}
-                  initial={{ opacity: 0, scale: 0.9 }}
+                  initial={cardInitial}
                   whileInView={{ opacity: 1, scale: 1 }}
                   viewport={{ once: true, amount: 0.3 }}
                   transition={{ duration: 0.6, delay: index * 0.1 }}
@@ -69,7 +85,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                     <div className="relative z-10 flex h-full flex-col">
                       {/* Icon container with glow effect */}
                       <motion.div
-                        initial={{ scale: 0, rotateY: 90 }}
+                        initial={iconInitial}
                         whileInView={{ scale: 1, rotateY: 0 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
@@ -103,7 +119,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
 
                       {/* Bottom accent line */}
                       <motion.div
-                        initial={{ scaleX: 0 }}
+                        initial={lineInitial}
                         whileInView={{ scaleX: 1 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
@@ -122,7 +138,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
           {items.map((item, index) => (
             <motion.article
               key={item.title}
-              initial={{ opacity: 0, x: -20 }}
+              initial={mobileCardInitial}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true, amount: 0.3 }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -139,7 +155,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                   <div className="flex items-start gap-4">
                     {/* Icon */}
                     <motion.div
-                      initial={{ scale: 0 }}
+                      initial={mobileIconInitial}
                       whileInView={{ scale: 1 }}
                       viewport={{ once: true, amount: 0.2 }}
                       transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -170,7 +186,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
 
                   {/* Bottom accent */}
                   <motion.div
-                    initial={{ scaleX: 0 }}
+                    initial={lineInitial}
                     whileInView={{ scaleX: 1 }}
                     viewport={{ once: true, amount: 0.2 }}
                     transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}

--- a/apps/psypnos/components/JourneyInfographic.tsx
+++ b/apps/psypnos/components/JourneyInfographic.tsx
@@ -5,7 +5,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type JourneyStep = {
   number: number;
@@ -42,17 +42,33 @@ const steps: JourneyStep[] = [
   },
 ];
 
+/**
+ * Journey infographic with parallax and scroll-reveal animations.
+ * Uses hasMounted guard so content is visible on SSR and only animates after hydration.
+ */
 export function JourneyInfographic() {
+  const [hasMounted, setHasMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
   });
 
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
   // Parallax effects for each step
   const step1Y = useTransform(scrollYProgress, [0, 1], [40, -40]);
   const step2Y = useTransform(scrollYProgress, [0, 1], [0, 0]);
   const step3Y = useTransform(scrollYProgress, [0, 1], [-40, 40]);
+
+  // SSR-safe initial values: visible on server, animate only after hydration
+  const circleInitial = hasMounted ? { scale: 0, opacity: 0 } : { scale: 1, opacity: 1 };
+  const cardInitial = hasMounted ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 };
+  const mobileContainerInitial = hasMounted ? { opacity: 0, x: -20 } : { opacity: 1, x: 0 };
+  const mobileCircleInitial = hasMounted ? { scale: 0 } : { scale: 1 };
+  const mobileCardInitial = hasMounted ? { opacity: 0, y: 10 } : { opacity: 1, y: 0 };
 
   return (
     <section ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
@@ -74,7 +90,7 @@ export function JourneyInfographic() {
                     <div className={index !== 1 ? 'mb-32' : 'mb-0'}>
                       {/* Step circle */}
                       <motion.div
-                        initial={{ scale: 0, opacity: 0 }}
+                        initial={circleInitial}
                         whileInView={{ scale: 1, opacity: 1 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.2 }}
@@ -100,7 +116,7 @@ export function JourneyInfographic() {
 
                       {/* Content card */}
                       <motion.div
-                        initial={{ opacity: 0, y: 20 }}
+                        initial={cardInitial}
                         whileInView={{ opacity: 1, y: 0 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.2 + 0.2 }}
@@ -124,7 +140,7 @@ export function JourneyInfographic() {
           {steps.map((step, index) => (
             <motion.div
               key={step.number}
-              initial={{ opacity: 0, x: -20 }}
+              initial={mobileContainerInitial}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true, amount: 0.2 }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
@@ -134,7 +150,7 @@ export function JourneyInfographic() {
               <div className="relative flex flex-col items-center">
                 {/* Circle */}
                 <motion.div
-                  initial={{ scale: 0 }}
+                  initial={mobileCircleInitial}
                   whileInView={{ scale: 1 }}
                   viewport={{ once: true, amount: 0.2 }}
                   transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -164,7 +180,7 @@ export function JourneyInfographic() {
 
               {/* Content */}
               <motion.div
-                initial={{ opacity: 0, y: 10 }}
+                initial={mobileCardInitial}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.2 }}
                 transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}

--- a/apps/psypnos/components/NavigationMenu.tsx
+++ b/apps/psypnos/components/NavigationMenu.tsx
@@ -282,7 +282,7 @@ export function NavigationMenu({ forceVisible = false }: NavigationMenuProps) {
         role="dialog"
         aria-modal="true"
         aria-label="Menu de navigation"
-        className={`bg-night-light fixed bottom-0 right-0 top-0 z-40 flex w-80 max-w-[85vw] flex-col shadow-2xl transition-transform duration-300 ease-out md:hidden ${
+        className={`bg-night-light fixed bottom-0 right-0 top-0 z-[45] flex w-80 max-w-[85vw] flex-col shadow-2xl transition-transform duration-300 ease-out md:hidden ${
           isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >

--- a/apps/psypnos/components/SectionTitle.tsx
+++ b/apps/psypnos/components/SectionTitle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { ReactNode } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 interface SectionTitleProps {
   eyebrow?: string;
@@ -9,10 +9,23 @@ interface SectionTitleProps {
   description?: ReactNode;
 }
 
+/**
+ * Section title with scroll-reveal animation.
+ * Uses hasMounted guard so content is visible on SSR (opacity:1)
+ * and only animates after client hydration.
+ */
 export function SectionTitle({ eyebrow, title, description }: SectionTitleProps) {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  const initial = hasMounted ? { opacity: 0, y: 24 } : { opacity: 1, y: 0 };
+
   return (
     <motion.header
-      initial={{ opacity: 0, y: 24 }}
+      initial={initial}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.2, margin: '0px 0px -50px 0px' }}
       transition={{ duration: 0.6, ease: 'easeOut' }}

--- a/apps/psypnos/components/SessionFormatsInfographic.tsx
+++ b/apps/psypnos/components/SessionFormatsInfographic.tsx
@@ -5,7 +5,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type SessionFormat = {
   title: string;
@@ -18,12 +18,21 @@ interface SessionFormatsInfographicProps {
   formats: SessionFormat[];
 }
 
+/**
+ * Session formats infographic with parallax and scroll-reveal animations.
+ * Uses hasMounted guard so content is visible on SSR and only animates after hydration.
+ */
 export function SessionFormatsInfographic({ formats }: SessionFormatsInfographicProps) {
+  const [hasMounted, setHasMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
   });
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   // Create parallax effects for each format
   const parallaxValues = formats.map((_, index) => {
@@ -38,6 +47,13 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
     );
   });
 
+  // SSR-safe initial values: visible on server, animate only after hydration
+  const cardInitial = hasMounted ? { opacity: 0, scale: 0.9 } : { opacity: 1, scale: 1 };
+  const iconInitial = hasMounted ? { scale: 0, rotateY: 90 } : { scale: 1, rotateY: 0 };
+  const lineInitial = hasMounted ? { scaleX: 0 } : { scaleX: 1 };
+  const mobileCardInitial = hasMounted ? { opacity: 0, x: -20 } : { opacity: 1, x: 0 };
+  const mobileIconInitial = hasMounted ? { scale: 0 } : { scale: 1 };
+
   return (
     <div ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
       <div className="mx-auto max-w-4xl">
@@ -51,7 +67,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                 <motion.article
                   key={format.title}
                   style={{ y: yTransform }}
-                  initial={{ opacity: 0, scale: 0.9 }}
+                  initial={cardInitial}
                   whileInView={{ opacity: 1, scale: 1 }}
                   viewport={{ once: true, amount: 0.3 }}
                   transition={{ duration: 0.6, delay: index * 0.1 }}
@@ -66,7 +82,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                     <div className="relative z-10 flex h-full flex-col items-center text-center">
                       {/* Icon container with glow effect */}
                       <motion.div
-                        initial={{ scale: 0, rotateY: 90 }}
+                        initial={iconInitial}
                         whileInView={{ scale: 1, rotateY: 0 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
@@ -100,7 +116,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
 
                       {/* Bottom accent line */}
                       <motion.div
-                        initial={{ scaleX: 0 }}
+                        initial={lineInitial}
                         whileInView={{ scaleX: 1 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
@@ -119,7 +135,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
           {formats.map((format, index) => (
             <motion.article
               key={format.title}
-              initial={{ opacity: 0, x: -20 }}
+              initial={mobileCardInitial}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true, amount: 0.3 }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -136,7 +152,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                   <div className="flex flex-col items-center">
                     {/* Icon */}
                     <motion.div
-                      initial={{ scale: 0 }}
+                      initial={mobileIconInitial}
                       whileInView={{ scale: 1 }}
                       viewport={{ once: true, amount: 0.2 }}
                       transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -169,7 +185,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
 
                   {/* Bottom accent */}
                   <motion.div
-                    initial={{ scaleX: 0 }}
+                    initial={lineInitial}
                     whileInView={{ scaleX: 1 }}
                     viewport={{ once: true, amount: 0.2 }}
                     transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}


### PR DESCRIPTION
## Summary

- **Fix invisible sections on homepage**: Applied `hasMounted` pattern to all framer-motion animated components so content is visible on SSR
- **Fix hamburger menu z-index**: Mobile menu panel bumped from `z-40` to `z-[45]`
- **Seminar prices**: Pipeline verified end-to-end

Closes #407, Closes #408

## Test plan
- [ ] All homepage sections visible on initial page load
- [ ] Hamburger menu works on mobile
- [ ] Scroll animations still work after hydration
- [ ] Build passes

https://claude.ai/code/session_01E7pF37P2BnHZTduqYuUbmK