### PR TITLE
fix(psypnos): corriger affichage mobile — issues #411-#417

### DIFF
--- a/apps/psypnos/app/(pages)/sections/approach.tsx
+++ b/apps/psypnos/app/(pages)/sections/approach.tsx
@@ -60,7 +60,7 @@ export function ApproachSection() {
   return (
     <section
       id="approche"
-      className="px-6 py-20 sm:px-10 lg:px-16"
+      className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16"
       data-track-section="approche"
       data-track-section-name="Approche"
     >

--- a/apps/psypnos/app/(pages)/sections/dynamic-sections.tsx
+++ b/apps/psypnos/app/(pages)/sections/dynamic-sections.tsx
@@ -1,20 +1,16 @@
-'use client';
-
 /**
- * Client Component wrapper for dynamically loaded sections
- * These sections use ssr: false to avoid hydration mismatches
+ * Dynamically loaded sections with code splitting.
+ * SSR is enabled so sections are visible even before JS hydration.
  */
 import dynamic from 'next/dynamic';
 
 import { RespirationSectionSkeleton, ContactSectionSkeleton } from './skeletons';
 
-// Sections avec interactions lourdes - chargement côté client pour éviter les problèmes d'hydratation
 export const RespirationSection = dynamic(
   () => import('./respiration').then(mod => mod.RespirationSection),
-  { loading: () => <RespirationSectionSkeleton />, ssr: false }
+  { loading: () => <RespirationSectionSkeleton /> }
 );
 
 export const ContactSection = dynamic(() => import('./contact').then(mod => mod.ContactSection), {
   loading: () => <ContactSectionSkeleton />,
-  ssr: false,
 });

--- a/apps/psypnos/app/(pages)/sections/formats.tsx
+++ b/apps/psypnos/app/(pages)/sections/formats.tsx
@@ -39,7 +39,7 @@ export function SessionFormatsSection() {
   return (
     <section
       id="formats-seance"
-      className="px-6 py-20 sm:px-10 lg:px-16"
+      className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16"
       data-track-section="formats"
       data-track-section-name="Formats de séance"
     >

--- a/apps/psypnos/app/(pages)/sections/journey.tsx
+++ b/apps/psypnos/app/(pages)/sections/journey.tsx
@@ -7,7 +7,7 @@ import { SectionTitle } from '../../../components/SectionTitle';
 export function JourneySection() {
   return (
     <section
-      className="px-6 py-20 sm:px-10 lg:px-16"
+      className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16"
       data-track-section="parcours"
       data-track-section-name="Parcours"
     >

--- a/apps/psypnos/app/(pages)/sections/respiration.tsx
+++ b/apps/psypnos/app/(pages)/sections/respiration.tsx
@@ -10,7 +10,7 @@ export function RespirationSection() {
   return (
     <section
       id="respiration-holotropique"
-      className="from-night via-night/95 to-night bg-gradient-to-br px-6 py-20 sm:px-10 lg:px-16"
+      className="from-night via-night/95 to-night bg-gradient-to-br px-6 py-12 sm:px-10 sm:py-20 lg:px-16"
       data-track-section="respiration"
       data-track-section-name="Respiration holotropique"
     >

--- a/apps/psypnos/app/(pages)/sections/skeletons.tsx
+++ b/apps/psypnos/app/(pages)/sections/skeletons.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '../../../components/ui/skeleton';
 
 export function SectionSkeleton() {
   return (
-    <section className="px-6 py-20 sm:px-10 lg:px-16">
+    <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         {/* Title skeleton */}
         <div className="space-y-4 text-center">
@@ -30,7 +30,7 @@ export function SectionSkeleton() {
 
 export function ApproachSectionSkeleton() {
   return (
-    <section className="px-6 py-20 sm:px-10 lg:px-16">
+    <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         <div className="space-y-4 text-center">
           <Skeleton className="bg-night/40 mx-auto h-4 w-32" />
@@ -53,7 +53,7 @@ export function ApproachSectionSkeleton() {
 
 export function JourneySectionSkeleton() {
   return (
-    <section className="px-6 py-20 sm:px-10 lg:px-16">
+    <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         <div className="space-y-4 text-center">
           <Skeleton className="bg-night/40 mx-auto h-4 w-32" />
@@ -75,7 +75,7 @@ export function JourneySectionSkeleton() {
 
 export function PricingSectionSkeleton() {
   return (
-    <section className="px-6 py-20 sm:px-10 lg:px-16">
+    <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-10 lg:grid lg:grid-cols-2 lg:items-start lg:gap-10">
         <div className="space-y-6">
           <div className="space-y-4">
@@ -102,7 +102,7 @@ export function PricingSectionSkeleton() {
 
 export function FormatsSectionSkeleton() {
   return (
-    <section className="px-6 py-20 sm:px-10 lg:px-16">
+    <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         <div className="space-y-4 text-center">
           <Skeleton className="bg-night/40 mx-auto h-4 w-32" />
@@ -129,7 +129,7 @@ export function FormatsSectionSkeleton() {
 export function TherapySectionsSkeleton() {
   return (
     <>
-      <section className="px-6 py-20 sm:px-10 lg:px-16">
+      <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
         <div className="mx-auto max-w-6xl space-y-12 text-center">
           <div className="space-y-4">
             <Skeleton className="bg-night/40 mx-auto h-4 w-32" />
@@ -138,7 +138,7 @@ export function TherapySectionsSkeleton() {
           </div>
         </div>
       </section>
-      <section className="px-6 py-20 sm:px-10 lg:px-16">
+      <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
         <div className="mx-auto max-w-6xl space-y-12 text-center">
           <div className="space-y-4">
             <Skeleton className="bg-night/40 mx-auto h-4 w-32" />
@@ -153,7 +153,7 @@ export function TherapySectionsSkeleton() {
 
 export function RespirationSectionSkeleton() {
   return (
-    <section className="from-night via-night/95 to-night bg-gradient-to-br px-6 py-20 sm:px-10 lg:px-16">
+    <section className="from-night via-night/95 to-night bg-gradient-to-br px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-5xl space-y-12">
         <div className="space-y-4 text-center">
           <Skeleton className="bg-night/40 mx-auto h-4 w-32" />
@@ -175,7 +175,7 @@ export function RespirationSectionSkeleton() {
 
 export function SeminarsSectionSkeleton() {
   return (
-    <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+    <section className="bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         <div className="space-y-4 text-center">
           <Skeleton className="bg-night/40 mx-auto h-4 w-32" />
@@ -202,7 +202,7 @@ export function SeminarsSectionSkeleton() {
 
 export function TestimonialsSectionSkeleton() {
   return (
-    <section className="bg-night/60 overflow-hidden py-20">
+    <section className="bg-night/60 overflow-hidden py-12 sm:py-20">
       <div className="mx-auto max-w-6xl space-y-10 px-6 sm:px-10 lg:px-16">
         <div className="space-y-4">
           <Skeleton className="bg-night/40 h-4 w-24" />
@@ -239,7 +239,7 @@ export function TestimonialsSectionSkeleton() {
 
 export function BlogSectionSkeleton() {
   return (
-    <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+    <section className="bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         <div className="space-y-4 text-center">
           <Skeleton className="bg-night/40 mx-auto h-4 w-48" />
@@ -272,7 +272,7 @@ export function BlogSectionSkeleton() {
 
 export function ContactSectionSkeleton() {
   return (
-    <section className="px-6 py-20 sm:px-10 lg:px-16">
+    <section className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-4xl space-y-12">
         <div className="space-y-4 text-center">
           <Skeleton className="bg-night/40 mx-auto h-4 w-32" />

--- a/apps/psypnos/app/(pages)/sections/therapy.tsx
+++ b/apps/psypnos/app/(pages)/sections/therapy.tsx
@@ -8,7 +8,7 @@ export function TherapySections() {
     <>
       <section
         id="psychotherapie"
-        className="px-6 py-20 sm:px-10 lg:px-16"
+        className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16"
         data-track-section="psychotherapie"
         data-track-section-name="Psychothérapie"
       >
@@ -48,7 +48,7 @@ export function TherapySections() {
       </section>
       <section
         id="hypnose"
-        className="px-6 py-20 sm:px-10 lg:px-16"
+        className="px-6 py-12 sm:px-10 sm:py-20 lg:px-16"
         data-track-section="hypnose"
         data-track-section-name="Hypnose"
       >

--- a/apps/psypnos/app/api/seminars/prisma-store.ts
+++ b/apps/psypnos/app/api/seminars/prisma-store.ts
@@ -309,13 +309,14 @@ function toIsoString(value: string): string {
 }
 
 /**
- * Get numeric value from Decimal or number
+ * Get numeric value from Decimal or number.
+ * Uses Number() instead of instanceof Decimal to handle bundled environments
+ * where the Decimal class may differ from Prisma's runtime instance.
  */
-function getNumericValue(val: Decimal | number | null): number | undefined {
-  if (val === null) return undefined;
-  if (typeof val === 'number') return val;
-  if (val instanceof Decimal) return val.toNumber();
-  return undefined;
+function getNumericValue(val: unknown): number | undefined {
+  if (val === null || val === undefined) return undefined;
+  const num = Number(val);
+  return Number.isNaN(num) ? undefined : num;
 }
 
 /**
@@ -329,8 +330,8 @@ function formatSeminarOutput(seminar: {
   startAt: Date;
   endAt: Date;
   capacity: number;
-  price: Decimal | null;
-  deposit: Decimal | null;
+  price: unknown;
+  deposit: unknown;
   displayOrder: string | null;
   tags: string[];
   thumbnail: string | null;

--- a/apps/psypnos/components/ChatWidgetWrapper.tsx
+++ b/apps/psypnos/components/ChatWidgetWrapper.tsx
@@ -29,7 +29,7 @@ function getChatSessionId(): string {
  */
 export function PsypnosChatWidget() {
   const pathname = usePathname();
-  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [enabled, setEnabled] = useState(true);
 
   useEffect(() => {
     async function checkStatus() {
@@ -37,20 +37,18 @@ export function PsypnosChatWidget() {
         const response = await fetch('/api/chatbot-status');
         if (response.ok) {
           const data = await response.json();
-          setEnabled(data.enabled);
-        } else {
-          setEnabled(true);
+          setEnabled(data.enabled !== false);
         }
       } catch {
-        setEnabled(true);
+        // On error, keep enabled (default)
       }
     }
     void checkStatus();
   }, []);
 
-  // Don't render on admin pages or while checking status
+  // Don't render on admin pages or if explicitly disabled
   if (pathname?.startsWith('/admin') || pathname?.startsWith('/login')) return null;
-  if (enabled === null || !enabled) return null;
+  if (!enabled) return null;
 
   const handleBookAppointment = () => {
     trackConversionEvent('appointment_request', 'chatbot_suggestion', false);

--- a/apps/psypnos/components/NavigationMenu.tsx
+++ b/apps/psypnos/components/NavigationMenu.tsx
@@ -283,7 +283,7 @@ export function NavigationMenu({ forceVisible = false }: NavigationMenuProps) {
         aria-modal="true"
         aria-label="Menu de navigation"
         className={`bg-night-light fixed bottom-0 right-0 top-0 z-[45] flex w-80 max-w-[85vw] flex-col shadow-2xl transition-transform duration-300 ease-out md:hidden ${
-          isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
+          isMobileMenuOpen ? 'translate-x-0' : 'pointer-events-none translate-x-full'
         }`}
       >
         {/* Espace réservé pour le header nav (h-16) */}

--- a/apps/psypnos/lib/server/data-fetchers.ts
+++ b/apps/psypnos/lib/server/data-fetchers.ts
@@ -7,8 +7,6 @@
  * All queries filter by siteId to ensure tenant isolation.
  */
 
-import { Decimal } from '@prisma/client/runtime/library';
-
 import prisma from '@/lib/db/prisma';
 import { getSiteId } from '@/lib/db/site';
 
@@ -195,13 +193,14 @@ export async function getTestimonials(limit = 10): Promise<TestimonialData[]> {
 // ============================================
 
 /**
- * Get numeric value from Decimal or number
+ * Get numeric value from Decimal or number.
+ * Uses Number() instead of instanceof Decimal to handle bundled environments
+ * where the Decimal class may differ from Prisma's runtime instance.
  */
-function getNumericValue(val: Decimal | number | null): number | undefined {
-  if (val === null) return undefined;
-  if (typeof val === 'number') return val;
-  if (val instanceof Decimal) return val.toNumber();
-  return undefined;
+function getNumericValue(val: unknown): number | undefined {
+  if (val === null || val === undefined) return undefined;
+  const num = Number(val);
+  return Number.isNaN(num) ? undefined : num;
 }
 
 function formatSeminar(seminar: {
@@ -212,8 +211,8 @@ function formatSeminar(seminar: {
   startAt: Date;
   endAt: Date;
   capacity: number;
-  price: Decimal | null;
-  deposit: Decimal | null;
+  price: unknown;
+  deposit: unknown;
   tags: string[];
   thumbnail: string | null;
   seminarType: string | null;

--- a/packages/ui/src/components/floating-contact-button/FloatingContactButton.tsx
+++ b/packages/ui/src/components/floating-contact-button/FloatingContactButton.tsx
@@ -103,6 +103,9 @@ function useScrollDirection() {
       return;
     }
 
+    // Initialize lastScrollY to current position to avoid large delta on first scroll
+    lastScrollY.current = window.scrollY;
+
     const handleScroll = () => {
       const currentScrollY = window.scrollY;
       const scrollDelta = currentScrollY - lastScrollY.current;
@@ -153,16 +156,7 @@ export function FloatingContactButton({
   const { isVisible } = useScrollDirection();
   const pathname = usePathname();
 
-  const colors = { ...DEFAULT_COLORS, ...customColors };
-  const labels = { ...DEFAULT_LABELS, ...customLabels };
-
-  // Hide on specified paths
-  const shouldHide = hiddenPaths.some(path => pathname?.startsWith(path));
-  if (shouldHide) {
-    return null;
-  }
-
-  // Pulse animation
+  // Pulse animation — must be called before any conditional return (Rules of Hooks)
   useEffect(() => {
     if (!enablePulse) return;
 
@@ -182,6 +176,15 @@ export function FloatingContactButton({
   const handleClose = useCallback(() => {
     setIsModalOpen(false);
   }, []);
+
+  const colors = { ...DEFAULT_COLORS, ...customColors };
+  const labels = { ...DEFAULT_LABELS, ...customLabels };
+
+  // Hide on specified paths — after all hooks
+  const shouldHide = hiddenPaths.some(path => pathname?.startsWith(path));
+  if (shouldHide) {
+    return null;
+  }
 
   const iconElement: ReactNode = icon ?? (
     <Calendar className="h-5 w-5 transition-transform group-hover:scale-110 md:h-6 md:w-6" />

--- a/packages/ui/src/components/sections/blog-section.tsx
+++ b/packages/ui/src/components/sections/blog-section.tsx
@@ -84,7 +84,7 @@ export interface BlogSectionProps {
  */
 function BlogSkeleton() {
   return (
-    <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+    <section className="bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         <div className="space-y-4">
           <div className="bg-ivory/10 h-4 w-32 animate-pulse rounded" />
@@ -161,7 +161,7 @@ export function BlogSection({
     return (
       <section
         id="blog"
-        className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}
+        className={cn('bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16', className)}
         data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
         data-track-section-name={trackingName}
       >
@@ -194,7 +194,7 @@ export function BlogSection({
   return (
     <section
       id="blog"
-      className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}
+      className={cn('bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16', className)}
       data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
       data-track-section-name={trackingName}
     >

--- a/packages/ui/src/components/sections/contact-section.tsx
+++ b/packages/ui/src/components/sections/contact-section.tsx
@@ -55,7 +55,7 @@ export function ContactSection({
   return (
     <section
       id="contact"
-      className={cn('px-6 py-20 sm:px-10 lg:px-16', className)}
+      className={cn('px-6 py-12 sm:px-10 sm:py-20 lg:px-16', className)}
       data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
       data-track-section-name={trackingName}
     >

--- a/packages/ui/src/components/sections/seminars-section.tsx
+++ b/packages/ui/src/components/sections/seminars-section.tsx
@@ -111,7 +111,7 @@ function formatSeminarDate(
  */
 function SeminarsSkeleton({ title }: { title: SectionTitleProps }) {
   return (
-    <section className="bg-night/60 px-6 py-20 sm:px-10 lg:px-16">
+    <section className="bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16">
       <div className="mx-auto max-w-6xl space-y-12">
         <SectionTitle {...title} />
         <div className="grid gap-10 md:grid-cols-3">
@@ -178,7 +178,7 @@ export function SeminarsSection({
   return (
     <section
       id="seminaires"
-      className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}
+      className={cn('bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16', className)}
       data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
       data-track-section-name={trackingName}
     >

--- a/packages/ui/src/components/sections/testimonials-section.tsx
+++ b/packages/ui/src/components/sections/testimonials-section.tsx
@@ -110,7 +110,7 @@ function DefaultTestimonialCard({
  */
 function TestimonialsSkeleton() {
   return (
-    <section className="bg-night/60 overflow-hidden py-20">
+    <section className="bg-night/60 overflow-hidden py-12 sm:py-20">
       <div className="mx-auto max-w-6xl space-y-10 px-6 sm:px-10 lg:px-16">
         <div className="space-y-4">
           <div className="bg-ivory/10 h-4 w-24 animate-pulse rounded" />
@@ -190,7 +190,7 @@ export function TestimonialsSection({
   // Empty state
   if (testimonials.length === 0) {
     return (
-      <section className={cn('bg-night/60 px-6 py-20 sm:px-10 lg:px-16', className)}>
+      <section className={cn('bg-night/60 px-6 py-12 sm:px-10 sm:py-20 lg:px-16', className)}>
         <div className="mx-auto max-w-6xl space-y-12">
           <SectionTitle {...title} />
           <div className="border-ivory/10 bg-ivory/[0.02] text-ivory/60 rounded-2xl border p-8 text-center text-sm">
@@ -209,7 +209,7 @@ export function TestimonialsSection({
 
   return (
     <section
-      className={cn('bg-night/60 overflow-hidden py-20', className)}
+      className={cn('bg-night/60 overflow-hidden py-12 sm:py-20', className)}
       data-track-section={trackingName.toLowerCase().replace(/\s+/g, '-')}
       data-track-section-name={trackingName}
     >


### PR DESCRIPTION
## Résumé

Correction de 7 problèmes d'affichage sur la page d'accueil mobile de Psypnos.

| # | Issue | Correction |
|---|-------|------------|
| #411 | Menu hamburger inactif | `pointer-events-none` sur menu fermé |
| #412 | Formulaire contact absent | Retrait `ssr: false` des imports dynamiques |
| #413 | Tarifs séminaires absents | `Number()` pour conversion Decimal |
| #414 | Section RH absente | Retrait `ssr: false` des imports dynamiques |
| #415 | Espacement mobile excessif | `py-12 sm:py-20` |
| #416 | Bouton FAB absent | Fix Rules of Hooks + init lastScrollY |
| #417 | Bouton ChatBot absent | Default `enabled: true` |

Fixes #411, Fixes #412, Fixes #413, Fixes #414, Fixes #415, Fixes #416, Fixes #417

https://claude.ai/code/session_014dZNg7J7Yt6CD8MiZMjjGY