### PR TITLE
fix(psypnos): corriger animations parallax au rechargement

### DIFF
--- a/apps/psypnos/__tests__/unit/parallax-animations.test.ts
+++ b/apps/psypnos/__tests__/unit/parallax-animations.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests de non-régression pour les animations parallax de la page d'accueil.
+ *
+ * Vérifie que le pattern hasMounted (anti-pattern empêchant les animations
+ * de se jouer au rechargement) n'est pas réintroduit dans les composants animés.
+ *
+ * Contexte : Framer Motion v11 applique les styles `initial` pendant le SSR
+ * via inline styles, garantissant que le rendu serveur et client matchent
+ * sans nécessiter de guard hasMounted. Le guard empêchait les animations
+ * de se déclencher au rechargement car `initial` ne se réapplique pas
+ * après le montage et `whileInView` avec `once: true` enregistrait les
+ * éléments comme déjà vus pendant l'hydratation.
+ *
+ * @see https://github.com/dduquenne/kairn/issues/419
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { describe, it, expect } from 'vitest';
+
+const PSYPNOS_ROOT = join(__dirname, '..', '..');
+
+/** Fichiers avec animations parallax / scroll-reveal */
+const ANIMATED_COMPONENT_FILES = [
+  'app/(pages)/sections/hero.tsx',
+  'components/SectionTitle.tsx',
+  'components/ApproachInfographic.tsx',
+  'components/JourneyInfographic.tsx',
+  'components/SessionFormatsInfographic.tsx',
+  'app/(pages)/sections/pricing.tsx',
+];
+
+/**
+ * Pattern anti-pattern hasMounted : un useState(false) suivi d'un useEffect
+ * qui passe à true, utilisé pour conditionner les valeurs initial/animate.
+ */
+const HAS_MOUNTED_PATTERN = /const\s+\[hasMounted,\s*setHasMounted\]\s*=\s*useState\(false\)/;
+
+/**
+ * Pattern de conditionnement des animations sur hasMounted.
+ * Ex: `hasMounted ? { opacity: 0 } : { opacity: 1 }`
+ */
+const CONDITIONAL_ANIMATION_PATTERN = /hasMounted\s*\?\s*\{[^}]*opacity/;
+
+describe('Animations parallax — non-régression (#419)', () => {
+  ANIMATED_COMPONENT_FILES.forEach(filePath => {
+    const fullPath = join(PSYPNOS_ROOT, filePath);
+    const fileName = filePath.split('/').pop();
+
+    describe(fileName!, () => {
+      const content = readFileSync(fullPath, 'utf-8');
+
+      it('ne contient pas le pattern hasMounted anti-animation', () => {
+        expect(content).not.toMatch(HAS_MOUNTED_PATTERN);
+      });
+
+      it('ne conditionne pas les valeurs initial/animate sur hasMounted', () => {
+        expect(content).not.toMatch(CONDITIONAL_ANIMATION_PATTERN);
+      });
+    });
+  });
+
+  describe("hero.tsx — animations d'entrée", () => {
+    const heroContent = readFileSync(join(PSYPNOS_ROOT, 'app/(pages)/sections/hero.tsx'), 'utf-8');
+
+    it('utilise des valeurs initial statiques (pas conditionnelles)', () => {
+      // Vérifie que initial={{ opacity: 0 }} ou initial={{ opacity: 0, y: ... }}
+      // est utilisé directement, pas via une variable conditionnelle
+      expect(heroContent).toMatch(/initial=\{\{\s*opacity:\s*0/);
+    });
+
+    it('utilise des transitions avec durée non-nulle', () => {
+      // Vérifie qu'il n'y a pas de `{ duration: 0 }` (ancien fallback SSR)
+      expect(heroContent).not.toMatch(/duration:\s*0\s*[,}]/);
+    });
+
+    it('conserve les effets parallax via useScroll/useTransform', () => {
+      expect(heroContent).toMatch(/useScroll/);
+      expect(heroContent).toMatch(/useTransform/);
+      expect(heroContent).toMatch(/heroParallax/);
+    });
+  });
+
+  describe('composants whileInView — animation au scroll', () => {
+    const components = [
+      'components/SectionTitle.tsx',
+      'components/ApproachInfographic.tsx',
+      'components/JourneyInfographic.tsx',
+      'components/SessionFormatsInfographic.tsx',
+    ];
+
+    components.forEach(filePath => {
+      const content = readFileSync(join(PSYPNOS_ROOT, filePath), 'utf-8');
+      const fileName = filePath.split('/').pop();
+
+      it(`${fileName} utilise whileInView avec once: true`, () => {
+        expect(content).toMatch(/whileInView/);
+        expect(content).toMatch(/once:\s*true/);
+      });
+
+      it(`${fileName} n'importe pas useState (plus nécessaire pour hasMounted)`, () => {
+        // SectionTitle et les infographiques n'ont plus besoin de useState
+        // après suppression du pattern hasMounted
+        if (!content.includes('useState(0)') && !content.includes('useState(')) {
+          expect(content).not.toMatch(/\buseState\b/);
+        }
+      });
+    });
+  });
+});

--- a/apps/psypnos/app/(pages)/sections/hero.tsx
+++ b/apps/psypnos/app/(pages)/sections/hero.tsx
@@ -3,7 +3,7 @@
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRef, useEffect, useState } from 'react';
+import { useRef } from 'react';
 
 import { CTAButton } from '../../../components/CTAButton';
 
@@ -30,12 +30,6 @@ const heroPractitioner = {
 
 export function HeroSection() {
   const heroRef = useRef<HTMLDivElement>(null);
-  const [hasMounted, setHasMounted] = useState(false);
-
-  // Track mounting to enable animations only after hydration
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
 
   const { scrollYProgress } = useScroll({
     target: heroRef,
@@ -44,12 +38,6 @@ export function HeroSection() {
   const heroParallax = useTransform(scrollYProgress, [0, 1], [0, -140]);
   const secondaryParallax = useTransform(scrollYProgress, [0, 1], [0, -70]);
   const glowOpacity = useTransform(scrollYProgress, [0, 1], [0.6, 0.2]);
-
-  // Animation variants - only animate after hydration to prevent mismatch
-  const fadeIn = hasMounted ? { opacity: 1 } : { opacity: 1 };
-  const fadeInInitial = hasMounted ? { opacity: 0 } : { opacity: 1 };
-  const slideUp = hasMounted ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 };
-  const slideUpInitial = hasMounted ? { opacity: 0, y: 24 } : { opacity: 1, y: 0 };
 
   return (
     <header
@@ -77,15 +65,15 @@ export function HeroSection() {
 
       <div className="mx-auto flex max-w-6xl flex-col items-center gap-10 text-center">
         <motion.div
-          initial={fadeInInitial}
-          animate={fadeIn}
-          transition={hasMounted ? { duration: 1.2, ease: 'easeOut' } : { duration: 0 }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 1.2, ease: 'easeOut' }}
           className="bg-night/40 flex flex-col items-center justify-center"
         >
           <motion.svg
-            initial={hasMounted ? { scale: 0.25, rotate: -360 } : { scale: 0.75, rotate: 0 }}
+            initial={{ scale: 0.25, rotate: -360 }}
             animate={{ scale: 1, rotate: 0 }}
-            transition={hasMounted ? { duration: 1.4, ease: 'easeOut' } : { duration: 0 }}
+            transition={{ duration: 1.4, ease: 'easeOut' }}
             width="100"
             height="100"
             viewBox="0 0 600 600"
@@ -107,11 +95,9 @@ export function HeroSection() {
             />
           </motion.svg>
           <motion.span
-            initial={fadeInInitial}
-            animate={fadeIn}
-            transition={
-              hasMounted ? { duration: 1.2, delay: 0.8, ease: 'easeOut' } : { duration: 0 }
-            }
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 1.2, delay: 0.8, ease: 'easeOut' }}
             className="font-display text-gold text-2xl font-semibold"
           >
             Psypnos
@@ -119,9 +105,9 @@ export function HeroSection() {
         </motion.div>
 
         <motion.div
-          initial={slideUpInitial}
-          animate={slideUp}
-          transition={hasMounted ? { duration: 0.8, delay: 1.5, ease: 'easeOut' } : { duration: 0 }}
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 1.5, ease: 'easeOut' }}
           className="max-w-3xl"
         >
           <h1 className="text-gold-accessible mb-2 text-sm uppercase tracking-[0.3em]">
@@ -134,9 +120,9 @@ export function HeroSection() {
           <p className="text-ivory mt-6 text-base sm:text-lg">{heroContent.subtitle}</p>
         </motion.div>
         <motion.div
-          initial={slideUpInitial}
-          animate={slideUp}
-          transition={hasMounted ? { duration: 0.8, delay: 1.7, ease: 'easeOut' } : { duration: 0 }}
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 1.7, ease: 'easeOut' }}
           className="flex flex-col items-center gap-6"
         >
           {/* Boutons principaux */}
@@ -193,9 +179,9 @@ export function HeroSection() {
           </Link>
         </motion.div>
         <motion.div
-          initial={hasMounted ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 }}
+          initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={hasMounted ? { duration: 1.5, delay: 1.9, ease: 'easeOut' } : { duration: 0 }}
+          transition={{ duration: 1.5, delay: 1.9, ease: 'easeOut' }}
           className="relative flex w-full flex-col items-center justify-center gap-8 overflow-hidden lg:flex-row lg:items-start lg:justify-center"
         >
           <Image

--- a/apps/psypnos/app/(pages)/sections/pricing.tsx
+++ b/apps/psypnos/app/(pages)/sections/pricing.tsx
@@ -8,12 +8,7 @@ import { SectionTitle } from '../../../components/SectionTitle';
 export function PricingSection() {
   const sectionRef = useRef<HTMLElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [hasMounted, setHasMounted] = useState(false);
   const [offset, setOffset] = useState(0);
-
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -103,15 +98,11 @@ export function PricingSection() {
                 variant="primary"
                 href="/demande-rendez-vous"
                 className="inline-flex w-auto"
-                animationProps={
-                  hasMounted
-                    ? {
-                        initial: { opacity: 0, y: 24 },
-                        animate: { opacity: 1, y: 0 },
-                        transition: { duration: 0.8, delay: 1.3, ease: 'easeOut' },
-                      }
-                    : undefined
-                }
+                animationProps={{
+                  initial: { opacity: 0, y: 24 },
+                  animate: { opacity: 1, y: 0 },
+                  transition: { duration: 0.8, delay: 1.3, ease: 'easeOut' },
+                }}
               >
                 Demander un rendez-vous
               </CTAButton>

--- a/apps/psypnos/components/ApproachInfographic.tsx
+++ b/apps/psypnos/components/ApproachInfographic.tsx
@@ -5,7 +5,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 type ApproachItem = {
   title: string;
@@ -20,19 +20,14 @@ interface ApproachInfographicProps {
 
 /**
  * Approach infographic with parallax and scroll-reveal animations.
- * Uses hasMounted guard so content is visible on SSR and only animates after hydration.
+ * Framer Motion v11 applies initial styles during SSR, so no hasMounted guard is needed.
  */
 export function ApproachInfographic({ items }: ApproachInfographicProps) {
-  const [hasMounted, setHasMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
   });
-
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
 
   // Create staggered parallax effects for each item
   const parallaxValues = items.map((_, index) => {
@@ -47,13 +42,6 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
       [direction * baseAmplitude, -direction * baseAmplitude]
     );
   });
-
-  // SSR-safe initial values: visible on server, animate only after hydration
-  const cardInitial = hasMounted ? { opacity: 0, scale: 0.9 } : { opacity: 1, scale: 1 };
-  const iconInitial = hasMounted ? { scale: 0, rotateY: 90 } : { scale: 1, rotateY: 0 };
-  const lineInitial = hasMounted ? { scaleX: 0 } : { scaleX: 1 };
-  const mobileCardInitial = hasMounted ? { opacity: 0, x: -20 } : { opacity: 1, x: 0 };
-  const mobileIconInitial = hasMounted ? { scale: 0 } : { scale: 1 };
 
   return (
     <div ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
@@ -70,7 +58,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                   key={item.title}
                   ref={containerRef}
                   style={{ y: yTransform }}
-                  initial={cardInitial}
+                  initial={{ opacity: 0, scale: 0.9 }}
                   whileInView={{ opacity: 1, scale: 1 }}
                   viewport={{ once: true, amount: 0.3 }}
                   transition={{ duration: 0.6, delay: index * 0.1 }}
@@ -85,7 +73,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                     <div className="relative z-10 flex h-full flex-col">
                       {/* Icon container with glow effect */}
                       <motion.div
-                        initial={iconInitial}
+                        initial={{ scale: 0, rotateY: 90 }}
                         whileInView={{ scale: 1, rotateY: 0 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
@@ -119,7 +107,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
 
                       {/* Bottom accent line */}
                       <motion.div
-                        initial={lineInitial}
+                        initial={{ scaleX: 0 }}
                         whileInView={{ scaleX: 1 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
@@ -138,7 +126,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
           {items.map((item, index) => (
             <motion.article
               key={item.title}
-              initial={mobileCardInitial}
+              initial={{ opacity: 0, x: -20 }}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true, amount: 0.3 }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -155,7 +143,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                   <div className="flex items-start gap-4">
                     {/* Icon */}
                     <motion.div
-                      initial={mobileIconInitial}
+                      initial={{ scale: 0 }}
                       whileInView={{ scale: 1 }}
                       viewport={{ once: true, amount: 0.2 }}
                       transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -186,7 +174,7 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
 
                   {/* Bottom accent */}
                   <motion.div
-                    initial={lineInitial}
+                    initial={{ scaleX: 0 }}
                     whileInView={{ scaleX: 1 }}
                     viewport={{ once: true, amount: 0.2 }}
                     transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}

--- a/apps/psypnos/components/JourneyInfographic.tsx
+++ b/apps/psypnos/components/JourneyInfographic.tsx
@@ -5,7 +5,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 type JourneyStep = {
   number: number;
@@ -44,31 +44,19 @@ const steps: JourneyStep[] = [
 
 /**
  * Journey infographic with parallax and scroll-reveal animations.
- * Uses hasMounted guard so content is visible on SSR and only animates after hydration.
+ * Framer Motion v11 applies initial styles during SSR, so no hasMounted guard is needed.
  */
 export function JourneyInfographic() {
-  const [hasMounted, setHasMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
   });
 
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
-
   // Parallax effects for each step
   const step1Y = useTransform(scrollYProgress, [0, 1], [40, -40]);
   const step2Y = useTransform(scrollYProgress, [0, 1], [0, 0]);
   const step3Y = useTransform(scrollYProgress, [0, 1], [-40, 40]);
-
-  // SSR-safe initial values: visible on server, animate only after hydration
-  const circleInitial = hasMounted ? { scale: 0, opacity: 0 } : { scale: 1, opacity: 1 };
-  const cardInitial = hasMounted ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 };
-  const mobileContainerInitial = hasMounted ? { opacity: 0, x: -20 } : { opacity: 1, x: 0 };
-  const mobileCircleInitial = hasMounted ? { scale: 0 } : { scale: 1 };
-  const mobileCardInitial = hasMounted ? { opacity: 0, y: 10 } : { opacity: 1, y: 0 };
 
   return (
     <section ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
@@ -90,7 +78,7 @@ export function JourneyInfographic() {
                     <div className={index !== 1 ? 'mb-32' : 'mb-0'}>
                       {/* Step circle */}
                       <motion.div
-                        initial={circleInitial}
+                        initial={{ scale: 0, opacity: 0 }}
                         whileInView={{ scale: 1, opacity: 1 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.2 }}
@@ -116,7 +104,7 @@ export function JourneyInfographic() {
 
                       {/* Content card */}
                       <motion.div
-                        initial={cardInitial}
+                        initial={{ opacity: 0, y: 20 }}
                         whileInView={{ opacity: 1, y: 0 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.2 + 0.2 }}
@@ -140,7 +128,7 @@ export function JourneyInfographic() {
           {steps.map((step, index) => (
             <motion.div
               key={step.number}
-              initial={mobileContainerInitial}
+              initial={{ opacity: 0, x: -20 }}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true, amount: 0.2 }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
@@ -150,7 +138,7 @@ export function JourneyInfographic() {
               <div className="relative flex flex-col items-center">
                 {/* Circle */}
                 <motion.div
-                  initial={mobileCircleInitial}
+                  initial={{ scale: 0 }}
                   whileInView={{ scale: 1 }}
                   viewport={{ once: true, amount: 0.2 }}
                   transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -180,7 +168,7 @@ export function JourneyInfographic() {
 
               {/* Content */}
               <motion.div
-                initial={mobileCardInitial}
+                initial={{ opacity: 0, y: 10 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.2 }}
                 transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}

--- a/apps/psypnos/components/SectionTitle.tsx
+++ b/apps/psypnos/components/SectionTitle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { type ReactNode, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 
 interface SectionTitleProps {
   eyebrow?: string;
@@ -11,21 +11,13 @@ interface SectionTitleProps {
 
 /**
  * Section title with scroll-reveal animation.
- * Uses hasMounted guard so content is visible on SSR (opacity:1)
- * and only animates after client hydration.
+ * Framer Motion v11 applies initial styles during SSR, ensuring
+ * server and client renders match without a hasMounted guard.
  */
 export function SectionTitle({ eyebrow, title, description }: SectionTitleProps) {
-  const [hasMounted, setHasMounted] = useState(false);
-
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
-
-  const initial = hasMounted ? { opacity: 0, y: 24 } : { opacity: 1, y: 0 };
-
   return (
     <motion.header
-      initial={initial}
+      initial={{ opacity: 0, y: 24 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.2, margin: '0px 0px -50px 0px' }}
       transition={{ duration: 0.6, ease: 'easeOut' }}

--- a/apps/psypnos/components/SessionFormatsInfographic.tsx
+++ b/apps/psypnos/components/SessionFormatsInfographic.tsx
@@ -5,7 +5,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 type SessionFormat = {
   title: string;
@@ -20,19 +20,14 @@ interface SessionFormatsInfographicProps {
 
 /**
  * Session formats infographic with parallax and scroll-reveal animations.
- * Uses hasMounted guard so content is visible on SSR and only animates after hydration.
+ * Framer Motion v11 applies initial styles during SSR, so no hasMounted guard is needed.
  */
 export function SessionFormatsInfographic({ formats }: SessionFormatsInfographicProps) {
-  const [hasMounted, setHasMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
   });
-
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
 
   // Create parallax effects for each format
   const parallaxValues = formats.map((_, index) => {
@@ -47,13 +42,6 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
     );
   });
 
-  // SSR-safe initial values: visible on server, animate only after hydration
-  const cardInitial = hasMounted ? { opacity: 0, scale: 0.9 } : { opacity: 1, scale: 1 };
-  const iconInitial = hasMounted ? { scale: 0, rotateY: 90 } : { scale: 1, rotateY: 0 };
-  const lineInitial = hasMounted ? { scaleX: 0 } : { scaleX: 1 };
-  const mobileCardInitial = hasMounted ? { opacity: 0, x: -20 } : { opacity: 1, x: 0 };
-  const mobileIconInitial = hasMounted ? { scale: 0 } : { scale: 1 };
-
   return (
     <div ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
       <div className="mx-auto max-w-4xl">
@@ -67,7 +55,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                 <motion.article
                   key={format.title}
                   style={{ y: yTransform }}
-                  initial={cardInitial}
+                  initial={{ opacity: 0, scale: 0.9 }}
                   whileInView={{ opacity: 1, scale: 1 }}
                   viewport={{ once: true, amount: 0.3 }}
                   transition={{ duration: 0.6, delay: index * 0.1 }}
@@ -82,7 +70,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                     <div className="relative z-10 flex h-full flex-col items-center text-center">
                       {/* Icon container with glow effect */}
                       <motion.div
-                        initial={iconInitial}
+                        initial={{ scale: 0, rotateY: 90 }}
                         whileInView={{ scale: 1, rotateY: 0 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
@@ -116,7 +104,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
 
                       {/* Bottom accent line */}
                       <motion.div
-                        initial={lineInitial}
+                        initial={{ scaleX: 0 }}
                         whileInView={{ scaleX: 1 }}
                         viewport={{ once: true, amount: 0.2 }}
                         transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
@@ -135,7 +123,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
           {formats.map((format, index) => (
             <motion.article
               key={format.title}
-              initial={mobileCardInitial}
+              initial={{ opacity: 0, x: -20 }}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true, amount: 0.3 }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -152,7 +140,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                   <div className="flex flex-col items-center">
                     {/* Icon */}
                     <motion.div
-                      initial={mobileIconInitial}
+                      initial={{ scale: 0 }}
                       whileInView={{ scale: 1 }}
                       viewport={{ once: true, amount: 0.2 }}
                       transition={{ duration: 0.5, delay: index * 0.1 }}
@@ -185,7 +173,7 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
 
                   {/* Bottom accent */}
                   <motion.div
-                    initial={lineInitial}
+                    initial={{ scaleX: 0 }}
                     whileInView={{ scaleX: 1 }}
                     viewport={{ once: true, amount: 0.2 }}
                     transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}


### PR DESCRIPTION
## Résumé

- Supprime le pattern `hasMounted` (anti-pattern) de 6 composants animés de la page d'accueil
- Les animations parallax et scroll-reveal se jouent désormais correctement au rechargement
- Ajoute un test de non-régression vérifiant l'absence du pattern cassé

## Cause racine

Le prop `initial` de Framer Motion ne se réapplique pas après le montage. Le pattern `hasMounted` conditionnait `initial` sur un état React qui changeait après l'hydratation, mais ce changement n'avait aucun effet car le composant était déjà monté. De plus, `whileInView` avec `once: true` enregistrait les éléments comme déjà vus pendant l'hydratation.

Framer Motion v11 applique les styles `initial` en inline pendant le SSR, garantissant que serveur et client matchent sans guard `hasMounted`.

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `app/(pages)/sections/hero.tsx` | Suppression hasMounted, animations directes |
| `components/SectionTitle.tsx` | Suppression hasMounted + useState/useEffect |
| `components/ApproachInfographic.tsx` | Suppression hasMounted + useState/useEffect |
| `components/JourneyInfographic.tsx` | Suppression hasMounted + useState/useEffect |
| `components/SessionFormatsInfographic.tsx` | Suppression hasMounted + useState/useEffect |
| `app/(pages)/sections/pricing.tsx` | Suppression conditionnel hasMounted sur CTAButton |
| `__tests__/unit/parallax-animations.test.ts` | Test de non-régression |

## Checklist
- [x] Lint : 0 erreurs
- [x] Type-check : OK
- [x] Tests : 81 tests unitaires + 192 tests UI passent
- [x] Build : OK
- [x] Isolation multi-tenant non impactée
- [x] Aucune donnée sensible exposée

Fixes #419