### PR TITLE
fix(psypnos): corriger régression sections invisibles (#419)

### DIFF
--- a/apps/psypnos/__tests__/unit/parallax-animations.test.ts
+++ b/apps/psypnos/__tests__/unit/parallax-animations.test.ts
@@ -1,15 +1,19 @@
 /**
  * Tests de non-régression pour les animations parallax de la page d'accueil.
  *
- * Vérifie que le pattern hasMounted (anti-pattern empêchant les animations
- * de se jouer au rechargement) n'est pas réintroduit dans les composants animés.
+ * Vérifie que :
+ * 1. Le pattern hasMounted conditionnel sur `initial` (cassé) n'est pas utilisé
+ * 2. Les composants utilisent `useScrollReveal` pour un scroll-reveal SSR-safe
+ * 3. Les composants utilisent `initial={false}` (pas de styles inline SSR)
+ * 4. Le hero conserve ses effets parallax
  *
- * Contexte : Framer Motion v11 applique les styles `initial` pendant le SSR
- * via inline styles, garantissant que le rendu serveur et client matchent
- * sans nécessiter de guard hasMounted. Le guard empêchait les animations
- * de se déclencher au rechargement car `initial` ne se réapplique pas
- * après le montage et `whileInView` avec `once: true` enregistrait les
- * éléments comme déjà vus pendant l'hydratation.
+ * Contexte (#419) : L'ancien pattern conditionnait `initial` sur `hasMounted`,
+ * ce qui ne fonctionne pas car `initial` ne se réapplique pas après le montage.
+ * Le nouveau pattern utilise `useScrollReveal` (useInView + hasMounted) avec
+ * `initial={false}` + `animate` contrôlé par `shouldShow`, garantissant :
+ * - SSR : contenu visible (pas de styles inline)
+ * - Après hydratation, hors viewport : masqué instantanément
+ * - Au scroll dans le viewport : animation fluide
  *
  * @see https://github.com/dduquenne/kairn/issues/419
  */
@@ -21,58 +25,82 @@ import { describe, it, expect } from 'vitest';
 
 const PSYPNOS_ROOT = join(__dirname, '..', '..');
 
-/** Fichiers avec animations parallax / scroll-reveal */
-const ANIMATED_COMPONENT_FILES = [
-  'app/(pages)/sections/hero.tsx',
-  'components/SectionTitle.tsx',
-  'components/ApproachInfographic.tsx',
-  'components/JourneyInfographic.tsx',
-  'components/SessionFormatsInfographic.tsx',
-  'app/(pages)/sections/pricing.tsx',
-];
+/**
+ * Anti-pattern : conditionner `initial` sur hasMounted.
+ * Ex: `const cardInitial = hasMounted ? { opacity: 0 } : { opacity: 1 }`
+ * Ne fonctionne pas car `initial` ne se réapplique pas après le montage.
+ */
+const CONDITIONAL_INITIAL_PATTERN = /hasMounted\s*\?\s*\{[^}]*opacity/;
 
 /**
- * Pattern anti-pattern hasMounted : un useState(false) suivi d'un useEffect
- * qui passe à true, utilisé pour conditionner les valeurs initial/animate.
+ * Anti-pattern : `initial={{ opacity: 0 }}` direct (sans `initial={false}`).
+ * Cause des éléments invisibles pendant le SSR car Framer Motion applique
+ * `initial` en inline styles.
+ *
+ * Exception : hero.tsx utilise `initial` + `animate` (animation au montage).
  */
-const HAS_MOUNTED_PATTERN = /const\s+\[hasMounted,\s*setHasMounted\]\s*=\s*useState\(false\)/;
-
-/**
- * Pattern de conditionnement des animations sur hasMounted.
- * Ex: `hasMounted ? { opacity: 0 } : { opacity: 1 }`
- */
-const CONDITIONAL_ANIMATION_PATTERN = /hasMounted\s*\?\s*\{[^}]*opacity/;
+const STATIC_OPACITY_ZERO_INITIAL = /initial=\{\{\s*opacity:\s*0/;
 
 describe('Animations parallax — non-régression (#419)', () => {
-  ANIMATED_COMPONENT_FILES.forEach(filePath => {
-    const fullPath = join(PSYPNOS_ROOT, filePath);
-    const fileName = filePath.split('/').pop();
+  describe('Anti-pattern hasMounted conditionnel sur initial', () => {
+    const allFiles = [
+      'app/(pages)/sections/hero.tsx',
+      'components/SectionTitle.tsx',
+      'components/ApproachInfographic.tsx',
+      'components/JourneyInfographic.tsx',
+      'components/SessionFormatsInfographic.tsx',
+      'app/(pages)/sections/pricing.tsx',
+    ];
 
-    describe(fileName!, () => {
-      const content = readFileSync(fullPath, 'utf-8');
+    allFiles.forEach(filePath => {
+      const fullPath = join(PSYPNOS_ROOT, filePath);
+      const fileName = filePath.split('/').pop();
 
-      it('ne contient pas le pattern hasMounted anti-animation', () => {
-        expect(content).not.toMatch(HAS_MOUNTED_PATTERN);
-      });
-
-      it('ne conditionne pas les valeurs initial/animate sur hasMounted', () => {
-        expect(content).not.toMatch(CONDITIONAL_ANIMATION_PATTERN);
+      it(`${fileName} ne conditionne pas initial sur hasMounted`, () => {
+        const content = readFileSync(fullPath, 'utf-8');
+        expect(content).not.toMatch(CONDITIONAL_INITIAL_PATTERN);
       });
     });
   });
 
-  describe("hero.tsx — animations d'entrée", () => {
+  describe('Composants scroll-reveal — pattern useScrollReveal', () => {
+    const scrollRevealComponents = [
+      'components/SectionTitle.tsx',
+      'components/ApproachInfographic.tsx',
+      'components/JourneyInfographic.tsx',
+      'components/SessionFormatsInfographic.tsx',
+    ];
+
+    scrollRevealComponents.forEach(filePath => {
+      const content = readFileSync(join(PSYPNOS_ROOT, filePath), 'utf-8');
+      const fileName = filePath.split('/').pop();
+
+      it(`${fileName} utilise useScrollReveal`, () => {
+        expect(content).toMatch(/useScrollReveal/);
+      });
+
+      it(`${fileName} utilise initial={false} (pas de styles inline SSR)`, () => {
+        expect(content).toMatch(/initial=\{false\}/);
+      });
+
+      it(`${fileName} utilise shouldShow pour contrôler animate`, () => {
+        expect(content).toMatch(/shouldShow/);
+      });
+
+      it(`${fileName} n'utilise pas initial={{ opacity: 0 }} direct`, () => {
+        expect(content).not.toMatch(STATIC_OPACITY_ZERO_INITIAL);
+      });
+    });
+  });
+
+  describe("hero.tsx — animations d'entrée (montage)", () => {
     const heroContent = readFileSync(join(PSYPNOS_ROOT, 'app/(pages)/sections/hero.tsx'), 'utf-8');
 
-    it('utilise des valeurs initial statiques (pas conditionnelles)', () => {
-      // Vérifie que initial={{ opacity: 0 }} ou initial={{ opacity: 0, y: ... }}
-      // est utilisé directement, pas via une variable conditionnelle
+    it('utilise initial + animate (animation au montage)', () => {
+      // Le hero utilise initial={{ opacity: 0 }} + animate={{ opacity: 1 }}
+      // C'est acceptable car c'est une animation de montage (above the fold)
       expect(heroContent).toMatch(/initial=\{\{\s*opacity:\s*0/);
-    });
-
-    it('utilise des transitions avec durée non-nulle', () => {
-      // Vérifie qu'il n'y a pas de `{ duration: 0 }` (ancien fallback SSR)
-      expect(heroContent).not.toMatch(/duration:\s*0\s*[,}]/);
+      expect(heroContent).toMatch(/animate=\{\{\s*opacity:\s*1/);
     });
 
     it('conserve les effets parallax via useScroll/useTransform', () => {
@@ -82,30 +110,24 @@ describe('Animations parallax — non-régression (#419)', () => {
     });
   });
 
-  describe('composants whileInView — animation au scroll', () => {
-    const components = [
-      'components/SectionTitle.tsx',
-      'components/ApproachInfographic.tsx',
-      'components/JourneyInfographic.tsx',
-      'components/SessionFormatsInfographic.tsx',
-    ];
+  describe('useScrollReveal hook', () => {
+    const hookContent = readFileSync(join(PSYPNOS_ROOT, 'hooks/useScrollReveal.ts'), 'utf-8');
 
-    components.forEach(filePath => {
-      const content = readFileSync(join(PSYPNOS_ROOT, filePath), 'utf-8');
-      const fileName = filePath.split('/').pop();
+    it('utilise useInView de framer-motion', () => {
+      expect(hookContent).toMatch(/useInView/);
+    });
 
-      it(`${fileName} utilise whileInView avec once: true`, () => {
-        expect(content).toMatch(/whileInView/);
-        expect(content).toMatch(/once:\s*true/);
-      });
+    it('utilise hasMounted pour la sécurité SSR', () => {
+      expect(hookContent).toMatch(/hasMounted/);
+    });
 
-      it(`${fileName} n'importe pas useState (plus nécessaire pour hasMounted)`, () => {
-        // SectionTitle et les infographiques n'ont plus besoin de useState
-        // après suppression du pattern hasMounted
-        if (!content.includes('useState(0)') && !content.includes('useState(')) {
-          expect(content).not.toMatch(/\buseState\b/);
-        }
-      });
+    it('exporte shouldShow qui combine hasMounted et isInView', () => {
+      expect(hookContent).toMatch(/shouldShow/);
+      expect(hookContent).toMatch(/!hasMounted\s*\|\|\s*isInView/);
+    });
+
+    it('configure once: true via useInView', () => {
+      expect(hookContent).toMatch(/once:\s*true/);
     });
   });
 });

--- a/apps/psypnos/components/ApproachInfographic.tsx
+++ b/apps/psypnos/components/ApproachInfographic.tsx
@@ -7,6 +7,8 @@ import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
 import { useRef } from 'react';
 
+import { useScrollReveal } from '../hooks/useScrollReveal';
+
 type ApproachItem = {
   title: string;
   description: string;
@@ -20,10 +22,14 @@ interface ApproachInfographicProps {
 
 /**
  * Approach infographic with parallax and scroll-reveal animations.
- * Framer Motion v11 applies initial styles during SSR, so no hasMounted guard is needed.
+ *
+ * Uses useScrollReveal for SSR-safe visibility: content is visible
+ * during SSR, hidden instantly after hydration (if below viewport),
+ * then animated in when scrolled into view.
  */
 export function ApproachInfographic({ items }: ApproachInfographicProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const { ref: revealRef, shouldShow, hasMounted } = useScrollReveal({ amount: 0.1 });
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
@@ -43,10 +49,18 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
     );
   });
 
+  /**
+   * Build transition: instant when hiding or pre-mount, smooth when revealing.
+   */
+  const cardTransition = (delay: number) =>
+    !hasMounted || !shouldShow
+      ? { duration: 0 }
+      : { duration: 0.6, delay, ease: 'easeOut' as const };
+
   return (
     <div ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
       {/* Desktop: Hexagonal/Grid layout with parallax */}
-      <div className="mx-auto max-w-6xl">
+      <div ref={revealRef} className="mx-auto max-w-6xl">
         {/* Desktop Grid - Hidden on mobile */}
         <div className="hidden md:block">
           <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
@@ -56,12 +70,13 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
               return (
                 <motion.article
                   key={item.title}
-                  ref={containerRef}
                   style={{ y: yTransform }}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
+                  initial={false}
+                  animate={{
+                    opacity: shouldShow ? 1 : 0,
+                    scale: shouldShow ? 1 : 0.9,
+                  }}
+                  transition={cardTransition(index * 0.1)}
                   className="group relative"
                 >
                   {/* Card with gradient border effect */}
@@ -73,10 +88,12 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                     <div className="relative z-10 flex h-full flex-col">
                       {/* Icon container with glow effect */}
                       <motion.div
-                        initial={{ scale: 0, rotateY: 90 }}
-                        whileInView={{ scale: 1, rotateY: 0 }}
-                        viewport={{ once: true, amount: 0.2 }}
-                        transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
+                        initial={false}
+                        animate={{
+                          scale: shouldShow ? 1 : 0,
+                          rotateY: shouldShow ? 0 : 90,
+                        }}
+                        transition={cardTransition(index * 0.1 + 0.1)}
                         className="relative mb-6 inline-flex h-16 w-16 items-center justify-center"
                       >
                         {/* Glow background */}
@@ -107,10 +124,9 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
 
                       {/* Bottom accent line */}
                       <motion.div
-                        initial={{ scaleX: 0 }}
-                        whileInView={{ scaleX: 1 }}
-                        viewport={{ once: true, amount: 0.2 }}
-                        transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
+                        initial={false}
+                        animate={{ scaleX: shouldShow ? 1 : 0 }}
+                        transition={cardTransition(index * 0.1 + 0.2)}
                         className="from-gold to-gold/0 mt-6 h-0.5 w-12 origin-left bg-gradient-to-r"
                       />
                     </div>
@@ -126,10 +142,12 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
           {items.map((item, index) => (
             <motion.article
               key={item.title}
-              initial={{ opacity: 0, x: -20 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
+              initial={false}
+              animate={{
+                opacity: shouldShow ? 1 : 0,
+                x: shouldShow ? 0 : -20,
+              }}
+              transition={cardTransition(index * 0.1)}
               className="group relative"
             >
               {/* Mobile card */}
@@ -143,10 +161,9 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
                   <div className="flex items-start gap-4">
                     {/* Icon */}
                     <motion.div
-                      initial={{ scale: 0 }}
-                      whileInView={{ scale: 1 }}
-                      viewport={{ once: true, amount: 0.2 }}
-                      transition={{ duration: 0.5, delay: index * 0.1 }}
+                      initial={false}
+                      animate={{ scale: shouldShow ? 1 : 0 }}
+                      transition={cardTransition(index * 0.1)}
                       className="relative mt-1 inline-flex h-12 w-12 flex-shrink-0 items-center justify-center"
                     >
                       {/* Glow background */}
@@ -174,10 +191,9 @@ export function ApproachInfographic({ items }: ApproachInfographicProps) {
 
                   {/* Bottom accent */}
                   <motion.div
-                    initial={{ scaleX: 0 }}
-                    whileInView={{ scaleX: 1 }}
-                    viewport={{ once: true, amount: 0.2 }}
-                    transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}
+                    initial={false}
+                    animate={{ scaleX: shouldShow ? 1 : 0 }}
+                    transition={cardTransition(index * 0.1 + 0.15)}
                     className="from-gold to-gold/0 mt-4 h-0.5 w-8 origin-left bg-gradient-to-r"
                   />
                 </div>

--- a/apps/psypnos/components/JourneyInfographic.tsx
+++ b/apps/psypnos/components/JourneyInfographic.tsx
@@ -7,6 +7,8 @@ import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
 import { useRef } from 'react';
 
+import { useScrollReveal } from '../hooks/useScrollReveal';
+
 type JourneyStep = {
   number: number;
   title: string;
@@ -44,10 +46,14 @@ const steps: JourneyStep[] = [
 
 /**
  * Journey infographic with parallax and scroll-reveal animations.
- * Framer Motion v11 applies initial styles during SSR, so no hasMounted guard is needed.
+ *
+ * Uses useScrollReveal for SSR-safe visibility: content is visible
+ * during SSR, hidden instantly after hydration (if below viewport),
+ * then animated in when scrolled into view.
  */
 export function JourneyInfographic() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const { ref: revealRef, shouldShow, hasMounted } = useScrollReveal({ amount: 0.1 });
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
@@ -58,9 +64,17 @@ export function JourneyInfographic() {
   const step2Y = useTransform(scrollYProgress, [0, 1], [0, 0]);
   const step3Y = useTransform(scrollYProgress, [0, 1], [-40, 40]);
 
+  /**
+   * Build transition: instant when hiding or pre-mount, smooth when revealing.
+   */
+  const revealTransition = (delay: number) =>
+    !hasMounted || !shouldShow
+      ? { duration: 0 }
+      : { duration: 0.6, delay, ease: 'easeOut' as const };
+
   return (
     <section ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
-      <div className="mx-auto max-w-6xl space-y-16">
+      <div ref={revealRef} className="mx-auto max-w-6xl space-y-16">
         <div className="hidden md:block">
           <div className="relative h-96">
             {/* Steps container */}
@@ -78,10 +92,12 @@ export function JourneyInfographic() {
                     <div className={index !== 1 ? 'mb-32' : 'mb-0'}>
                       {/* Step circle */}
                       <motion.div
-                        initial={{ scale: 0, opacity: 0 }}
-                        whileInView={{ scale: 1, opacity: 1 }}
-                        viewport={{ once: true, amount: 0.2 }}
-                        transition={{ duration: 0.6, delay: index * 0.2 }}
+                        initial={false}
+                        animate={{
+                          scale: shouldShow ? 1 : 0,
+                          opacity: shouldShow ? 1 : 0,
+                        }}
+                        transition={revealTransition(index * 0.2)}
                         className="border-gold bg-night/60 relative mb-8 flex h-20 w-20 items-center justify-center rounded-full border-2 shadow-lg"
                       >
                         {/* Icon background glow */}
@@ -104,10 +120,12 @@ export function JourneyInfographic() {
 
                       {/* Content card */}
                       <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        whileInView={{ opacity: 1, y: 0 }}
-                        viewport={{ once: true, amount: 0.2 }}
-                        transition={{ duration: 0.6, delay: index * 0.2 + 0.2 }}
+                        initial={false}
+                        animate={{
+                          opacity: shouldShow ? 1 : 0,
+                          y: shouldShow ? 0 : 20,
+                        }}
+                        transition={revealTransition(index * 0.2 + 0.2)}
                         className="border-gold/20 from-night/50 to-night/30 rounded-2xl border bg-gradient-to-br p-6 text-center shadow-lg backdrop-blur-sm"
                       >
                         <h3 className="text-gold text-xl font-semibold">{step.title}</h3>
@@ -128,20 +146,21 @@ export function JourneyInfographic() {
           {steps.map((step, index) => (
             <motion.div
               key={step.number}
-              initial={{ opacity: 0, x: -20 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true, amount: 0.2 }}
-              transition={{ duration: 0.6, delay: index * 0.1 }}
+              initial={false}
+              animate={{
+                opacity: shouldShow ? 1 : 0,
+                x: shouldShow ? 0 : -20,
+              }}
+              transition={revealTransition(index * 0.1)}
               className="flex gap-6"
             >
               {/* Timeline line and circle */}
               <div className="relative flex flex-col items-center">
                 {/* Circle */}
                 <motion.div
-                  initial={{ scale: 0 }}
-                  whileInView={{ scale: 1 }}
-                  viewport={{ once: true, amount: 0.2 }}
-                  transition={{ duration: 0.5, delay: index * 0.1 }}
+                  initial={false}
+                  animate={{ scale: shouldShow ? 1 : 0 }}
+                  transition={revealTransition(index * 0.1)}
                   className="border-gold bg-night/60 relative flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full border-2 shadow-lg"
                 >
                   <div className="bg-gold/10 absolute inset-0 rounded-full blur-xl" />
@@ -168,10 +187,12 @@ export function JourneyInfographic() {
 
               {/* Content */}
               <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.2 }}
-                transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
+                initial={false}
+                animate={{
+                  opacity: shouldShow ? 1 : 0,
+                  y: shouldShow ? 0 : 10,
+                }}
+                transition={revealTransition(index * 0.1 + 0.1)}
                 className="border-gold/20 from-night/50 to-night/30 flex-1 rounded-xl border bg-gradient-to-br p-4 shadow-md backdrop-blur-sm"
               >
                 <h3 className="text-gold text-lg font-semibold">{step.title}</h3>

--- a/apps/psypnos/components/SectionTitle.tsx
+++ b/apps/psypnos/components/SectionTitle.tsx
@@ -3,6 +3,8 @@
 import { motion } from 'framer-motion';
 import type { ReactNode } from 'react';
 
+import { useScrollReveal } from '../hooks/useScrollReveal';
+
 interface SectionTitleProps {
   eyebrow?: string;
   title: string;
@@ -10,17 +12,21 @@ interface SectionTitleProps {
 }
 
 /**
- * Section title with scroll-reveal animation.
- * Framer Motion v11 applies initial styles during SSR, ensuring
- * server and client renders match without a hasMounted guard.
+ * Section title with SSR-safe scroll-reveal animation.
+ *
+ * Uses useScrollReveal to keep content visible during SSR,
+ * hide it instantly after hydration (if below viewport),
+ * then animate it in when scrolled into view.
  */
 export function SectionTitle({ eyebrow, title, description }: SectionTitleProps) {
+  const { ref, shouldShow, hasMounted } = useScrollReveal();
+
   return (
     <motion.header
-      initial={{ opacity: 0, y: 24 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.2, margin: '0px 0px -50px 0px' }}
-      transition={{ duration: 0.6, ease: 'easeOut' }}
+      ref={ref}
+      initial={false}
+      animate={{ opacity: shouldShow ? 1 : 0, y: shouldShow ? 0 : 24 }}
+      transition={!hasMounted || !shouldShow ? { duration: 0 } : { duration: 0.6, ease: 'easeOut' }}
       className="mx-auto max-w-3xl text-center"
     >
       {eyebrow && <p className="text-gold/80 mb-2 text-sm uppercase tracking-[0.3em]">{eyebrow}</p>}

--- a/apps/psypnos/components/SessionFormatsInfographic.tsx
+++ b/apps/psypnos/components/SessionFormatsInfographic.tsx
@@ -7,6 +7,8 @@ import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
 import { useRef } from 'react';
 
+import { useScrollReveal } from '../hooks/useScrollReveal';
+
 type SessionFormat = {
   title: string;
   description: string;
@@ -20,10 +22,14 @@ interface SessionFormatsInfographicProps {
 
 /**
  * Session formats infographic with parallax and scroll-reveal animations.
- * Framer Motion v11 applies initial styles during SSR, so no hasMounted guard is needed.
+ *
+ * Uses useScrollReveal for SSR-safe visibility: content is visible
+ * during SSR, hidden instantly after hydration (if below viewport),
+ * then animated in when scrolled into view.
  */
 export function SessionFormatsInfographic({ formats }: SessionFormatsInfographicProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const { ref: revealRef, shouldShow, hasMounted } = useScrollReveal({ amount: 0.1 });
   const { scrollYProgress } = useScroll({
     target: containerRef,
     offset: ['start center', 'end center'],
@@ -42,9 +48,17 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
     );
   });
 
+  /**
+   * Build transition: instant when hiding or pre-mount, smooth when revealing.
+   */
+  const revealTransition = (delay: number) =>
+    !hasMounted || !shouldShow
+      ? { duration: 0 }
+      : { duration: 0.6, delay, ease: 'easeOut' as const };
+
   return (
     <div ref={containerRef} className="relative px-6 py-20 sm:px-10 lg:px-16">
-      <div className="mx-auto max-w-4xl">
+      <div ref={revealRef} className="mx-auto max-w-4xl">
         {/* Desktop: Grid layout with parallax */}
         <div className="hidden md:block">
           <div className="grid gap-8 md:grid-cols-3">
@@ -55,10 +69,12 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                 <motion.article
                   key={format.title}
                   style={{ y: yTransform }}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
+                  initial={false}
+                  animate={{
+                    opacity: shouldShow ? 1 : 0,
+                    scale: shouldShow ? 1 : 0.9,
+                  }}
+                  transition={revealTransition(index * 0.1)}
                   className="group relative"
                 >
                   {/* Card */}
@@ -70,10 +86,12 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                     <div className="relative z-10 flex h-full flex-col items-center text-center">
                       {/* Icon container with glow effect */}
                       <motion.div
-                        initial={{ scale: 0, rotateY: 90 }}
-                        whileInView={{ scale: 1, rotateY: 0 }}
-                        viewport={{ once: true, amount: 0.2 }}
-                        transition={{ duration: 0.6, delay: index * 0.1 + 0.1 }}
+                        initial={false}
+                        animate={{
+                          scale: shouldShow ? 1 : 0,
+                          rotateY: shouldShow ? 0 : 90,
+                        }}
+                        transition={revealTransition(index * 0.1 + 0.1)}
                         className="relative mb-6 inline-flex h-20 w-20 items-center justify-center"
                       >
                         {/* Glow background */}
@@ -104,10 +122,9 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
 
                       {/* Bottom accent line */}
                       <motion.div
-                        initial={{ scaleX: 0 }}
-                        whileInView={{ scaleX: 1 }}
-                        viewport={{ once: true, amount: 0.2 }}
-                        transition={{ duration: 0.8, delay: index * 0.1 + 0.2 }}
+                        initial={false}
+                        animate={{ scaleX: shouldShow ? 1 : 0 }}
+                        transition={revealTransition(index * 0.1 + 0.2)}
                         className="from-gold/0 via-gold to-gold/0 mt-6 h-0.5 w-8 origin-center bg-gradient-to-r"
                       />
                     </div>
@@ -123,10 +140,12 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
           {formats.map((format, index) => (
             <motion.article
               key={format.title}
-              initial={{ opacity: 0, x: -20 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
+              initial={false}
+              animate={{
+                opacity: shouldShow ? 1 : 0,
+                x: shouldShow ? 0 : -20,
+              }}
+              transition={revealTransition(index * 0.1)}
               className="group relative"
             >
               {/* Mobile card */}
@@ -140,10 +159,9 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
                   <div className="flex flex-col items-center">
                     {/* Icon */}
                     <motion.div
-                      initial={{ scale: 0 }}
-                      whileInView={{ scale: 1 }}
-                      viewport={{ once: true, amount: 0.2 }}
-                      transition={{ duration: 0.5, delay: index * 0.1 }}
+                      initial={false}
+                      animate={{ scale: shouldShow ? 1 : 0 }}
+                      transition={revealTransition(index * 0.1)}
                       className="relative mb-4 inline-flex h-16 w-16 items-center justify-center"
                     >
                       {/* Glow background */}
@@ -173,10 +191,9 @@ export function SessionFormatsInfographic({ formats }: SessionFormatsInfographic
 
                   {/* Bottom accent */}
                   <motion.div
-                    initial={{ scaleX: 0 }}
-                    whileInView={{ scaleX: 1 }}
-                    viewport={{ once: true, amount: 0.2 }}
-                    transition={{ duration: 0.6, delay: index * 0.1 + 0.15 }}
+                    initial={false}
+                    animate={{ scaleX: shouldShow ? 1 : 0 }}
+                    transition={revealTransition(index * 0.1 + 0.15)}
                     className="mt-4 flex justify-center"
                   >
                     <div className="from-gold/0 via-gold to-gold/0 h-0.5 w-8 bg-gradient-to-r" />

--- a/apps/psypnos/hooks/useScrollReveal.ts
+++ b/apps/psypnos/hooks/useScrollReveal.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useInView } from 'framer-motion';
+import { useEffect, useRef, useState } from 'react';
+
+interface ScrollRevealOptions {
+  /** Fraction of the element that must be visible (0–1). Default: 0.2 */
+  amount?: number;
+}
+
+/**
+ * Hook for SSR-safe scroll-reveal animations.
+ *
+ * **Behaviour by phase:**
+ * 1. SSR + first client render: `shouldShow = true` → content visible (no flash)
+ * 2. After mount, element NOT in viewport: `shouldShow = false` (instant hide — user can't see it)
+ * 3. Element scrolled into viewport: `shouldShow = true` (animated reveal)
+ *
+ * Use with Framer Motion:
+ * ```tsx
+ * const { ref, shouldShow, hasMounted } = useScrollReveal();
+ * <motion.div
+ *   ref={ref}
+ *   initial={false}
+ *   animate={{ opacity: shouldShow ? 1 : 0, y: shouldShow ? 0 : 24 }}
+ *   transition={!hasMounted || !shouldShow ? { duration: 0 } : { duration: 0.6 }}
+ * />
+ * ```
+ */
+export function useScrollReveal(options: ScrollRevealOptions = {}) {
+  const { amount = 0.2 } = options;
+  const [hasMounted, setHasMounted] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ref = useRef(null) as any;
+  const isInView = useInView(ref, { once: true, amount });
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  // SSR + pre-mount: visible. After mount: controlled by IntersectionObserver.
+  const shouldShow = !hasMounted || isInView;
+
+  return { ref, shouldShow, hasMounted };
+}


### PR DESCRIPTION
## Résumé

Le fix précédent (#423) rendait les sections invisibles pendant le SSR car `initial={{ opacity: 0 }}` est appliqué en inline par Framer Motion.

Ce fix introduit un hook `useScrollReveal` qui combine `useInView` + `hasMounted` pour :
- **SSR** : contenu visible (`initial={false}` → aucun style inline)
- **Après hydratation, hors viewport** : masqué instantanément (`duration: 0`)
- **Au scroll dans le viewport** : animation fluide de révélation

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `hooks/useScrollReveal.ts` | Nouveau hook SSR-safe |
| `components/SectionTitle.tsx` | Migration vers useScrollReveal |
| `components/ApproachInfographic.tsx` | Migration vers useScrollReveal |
| `components/JourneyInfographic.tsx` | Migration vers useScrollReveal |
| `components/SessionFormatsInfographic.tsx` | Migration vers useScrollReveal |
| `__tests__/unit/parallax-animations.test.ts` | Tests mis à jour |

## Test plan
- [ ] Vérifier que les sections sont visibles au chargement SSR (désactiver JS)
- [ ] Vérifier que les animations de scroll-reveal fonctionnent au rechargement
- [ ] Vérifier sur mobile et desktop
- [ ] Vérifier que le hero conserve son animation d'entrée

Fixes #419

https://claude.ai/code/session_019V5CKhfgMiKH7d3xq3xsT6