### PR TITLE
fix(psypnos): masquer la barre de navigation avant le scroll sur l'accueil

### DIFF
--- a/apps/psypnos/components/NavigationMenu.tsx
+++ b/apps/psypnos/components/NavigationMenu.tsx
@@ -191,11 +191,14 @@ export function NavigationMenu({ forceVisible = false }: NavigationMenuProps) {
   }, [isMobileMenuOpen, closeMenu]);
 
   const showBackground = hasMounted && (isScrolled || forceVisible);
+  const isVisible = forceVisible || (hasMounted && isScrolled);
 
   return (
     <>
       <nav
-        className={`fixed left-0 right-0 top-0 z-50 translate-y-0 opacity-100 transition-all duration-300 ${
+        className={`fixed left-0 right-0 top-0 z-50 transition-all duration-300 ${
+          isVisible ? 'translate-y-0 opacity-100' : '-translate-y-full opacity-0'
+        } ${
           showBackground
             ? 'border-gold/20 bg-night/90 shadow-night/50 border-b shadow-lg backdrop-blur-md'
             : 'border-transparent bg-transparent'


### PR DESCRIPTION
## Résumé

- La barre de navigation s'affichait en permanence sur la page d'accueil sans fond, causant un mélange du texte avec le contenu
- Elle est désormais masquée initialement (`-translate-y-full opacity-0`) et apparaît avec transition au scroll (> 100px) avec son fond semi-transparent
- Les pages avec `forceVisible` (blog, hypnose, etc.) ne sont pas impactées

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `apps/psypnos/components/NavigationMenu.tsx` | Ajout d'une condition `isVisible` contrôlant la visibilité de la nav |

## Validation

- [x] Lint (0 erreurs)
- [x] Type-check
- [x] Tests unitaires (192 passed)
- [x] Tests coverage
- [x] Build production

Fixes #441

https://claude.ai/code/session_01D2GADqmWUDYPaQcn6wUbMn