### PR TITLE
fix(psypnos): classifier credit_exhausted et logs debug pour générations IA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,13 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @kairn/db db:generate
 
+      - name: Build workspace packages
+        # Vitest résout les imports `@kairn/*` via leurs entry points compilés
+        # (ex: @kairn/ai → ./dist/index.js). On doit donc builder les packages
+        # avant de lancer les tests, sinon Vitest échoue avec
+        # "Failed to resolve entry for package @kairn/ai".
+        run: pnpm turbo run build --filter='./packages/*'
+
       - name: Run unit tests with coverage
         run: pnpm test:coverage
 

--- a/apps/psypnos/__tests__/unit/ai-error-handler.test.ts
+++ b/apps/psypnos/__tests__/unit/ai-error-handler.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests unitaires pour le classifier d'erreurs IA.
+ *
+ * Vérifie que chaque type d'erreur Anthropic / OpenAI est correctement
+ * classifié et qu'un message utilisateur français clair est retourné.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { classifyAIError, formatAIErrorResponse } from '../../app/api/common/ai-error-handler';
+
+describe('classifyAIError', () => {
+  it('retourne "unknown" pour null/undefined', () => {
+    expect(classifyAIError(null).type).toBe('unknown');
+    expect(classifyAIError(undefined).type).toBe('unknown');
+  });
+
+  it("classifie l'erreur d'authentification (401)", () => {
+    const error = Object.assign(new Error('authentication failed: invalid api key'), {
+      status: 401,
+    });
+    const info = classifyAIError(error);
+    expect(info.type).toBe('auth');
+    expect(info.retryable).toBe(false);
+    expect(info.userMessage).toMatch(/clé API/i);
+  });
+
+  it('classifie "credit balance is too low" (Anthropic) comme credit_exhausted, PAS invalid_request', () => {
+    // Reproduction de l'erreur réelle observée en production (issue #454)
+    const error = Object.assign(
+      new Error(
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}'
+      ),
+      { status: 400 }
+    );
+    const info = classifyAIError(error);
+    expect(info.type).toBe('credit_exhausted');
+    expect(info.retryable).toBe(false);
+    expect(info.userMessage).toMatch(/crédit/i);
+    expect(info.userMessage).toMatch(/administrateur/i);
+    expect(info.httpStatus).toBe(402);
+  });
+
+  it('classifie "insufficient_quota" (OpenAI) comme credit_exhausted', () => {
+    const error = Object.assign(new Error('insufficient_quota: You exceeded your current quota'), {
+      status: 429,
+    });
+    const info = classifyAIError(error);
+    expect(info.type).toBe('credit_exhausted');
+  });
+
+  it('classifie une erreur de billing (OpenAI) comme credit_exhausted', () => {
+    const error = new Error('billing_hard_limit_reached');
+    const info = classifyAIError(error).type;
+    expect(info).toBe('credit_exhausted');
+  });
+
+  it('classifie le vrai rate limit (429 sans billing) comme rate_limit', () => {
+    const error = Object.assign(new Error('rate_limit_error: too many requests'), { status: 429 });
+    const info = classifyAIError(error);
+    expect(info.type).toBe('rate_limit');
+    expect(info.retryable).toBe(true);
+  });
+
+  it('classifie un modèle introuvable (404)', () => {
+    const error = Object.assign(new Error('model not found: claude-xyz'), { status: 404 });
+    expect(classifyAIError(error).type).toBe('model_not_found');
+  });
+
+  it('classifie overloaded (529)', () => {
+    const error = Object.assign(new Error('overloaded_error'), { status: 529 });
+    const info = classifyAIError(error);
+    expect(info.type).toBe('overloaded');
+    expect(info.retryable).toBe(true);
+  });
+
+  it('classifie timeout', () => {
+    const info = classifyAIError(new Error('Operation timed out after 60000ms'));
+    expect(info.type).toBe('timeout');
+    expect(info.retryable).toBe(true);
+  });
+
+  it('classifie content_filter', () => {
+    expect(classifyAIError(new Error('content_policy violation')).type).toBe('content_filter');
+  });
+
+  it('classifie invalid_request (400 sans billing)', () => {
+    const error = Object.assign(new Error('invalid_request_error: malformed payload'), {
+      status: 400,
+    });
+    expect(classifyAIError(error).type).toBe('invalid_request');
+  });
+
+  it('classifie les erreurs réseau', () => {
+    expect(classifyAIError(new Error('ECONNRESET')).type).toBe('network');
+    expect(classifyAIError(new Error('fetch failed')).type).toBe('network');
+  });
+
+  it('classifie 5xx générique comme overloaded', () => {
+    const error = Object.assign(new Error('internal server error'), { status: 500 });
+    expect(classifyAIError(error).type).toBe('overloaded');
+  });
+
+  it('préserve le technicalDetail pour le debug', () => {
+    const raw = 'Detailed error with request_id req_abc123';
+    const info = classifyAIError(new Error(raw));
+    expect(info.technicalDetail).toBe(raw);
+  });
+});
+
+describe('formatAIErrorResponse', () => {
+  it('retourne une réponse structurée avec les champs attendus', () => {
+    const error = new Error('Your credit balance is too low');
+    const response = formatAIErrorResponse(error);
+
+    expect(response.status).toBe(402);
+    expect(response.body.errorType).toBe('credit_exhausted');
+    expect(response.body.message).toMatch(/crédit/i);
+    expect(response.body.retryable).toBe(false);
+    expect(response.body.technicalDetail).toBeTruthy();
+  });
+});

--- a/apps/psypnos/app/api/blog/generate/route.ts
+++ b/apps/psypnos/app/api/blog/generate/route.ts
@@ -173,8 +173,15 @@ export async function POST(request: Request) {
       tone: singleTone,
     });
   } catch (error) {
-    console.error("Erreur lors de la génération de l'article:", error);
     const { body, status } = formatAIErrorResponse(error);
+    console.error("[BlogGenerate] Erreur lors de la génération de l'article:", {
+      errorType: body.errorType,
+      status,
+      userMessage: body.message,
+      technicalDetail: body.technicalDetail,
+      retryable: body.retryable,
+      raw: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(body, { status });
   }
 }

--- a/apps/psypnos/app/api/blog/jobs/step-executor.ts
+++ b/apps/psypnos/app/api/blog/jobs/step-executor.ts
@@ -16,10 +16,10 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { CLAUDE_DEFAULT_MODEL } from '@kairn/ai';
 
-import { classifyAIError } from '@/app/api/common/ai-error-handler';
 import { prisma } from '@/lib/db/prisma';
 import { getSiteId } from '@/lib/db/site';
 
+import { classifyAIError } from '../../common/ai-error-handler';
 import {
   generateArticleSectional,
   type SectionalGenerationOptions,
@@ -254,7 +254,15 @@ export async function executeNextStep(jobId: string): Promise<StepExecutionResul
     };
   } catch (error) {
     const aiError = classifyAIError(error);
-    console.error(`[BlogJob:${jobId}] Erreur étape ${stepIndex + 1}:`, error);
+    console.error(`[BlogJob:${jobId}] Erreur étape ${stepIndex + 1}:`, {
+      step: STEP_NAMES[stepIndex],
+      errorType: aiError.type,
+      userMessage: aiError.userMessage,
+      technicalDetail: aiError.technicalDetail,
+      retryable: aiError.retryable,
+      httpStatus: aiError.httpStatus,
+      raw: error instanceof Error ? error.message : String(error),
+    });
 
     await markJobAsFailed(jobId, aiError.userMessage);
 

--- a/apps/psypnos/app/api/common/ai-error-handler.ts
+++ b/apps/psypnos/app/api/common/ai-error-handler.ts
@@ -8,6 +8,7 @@
 export type AIErrorType =
   | 'auth'
   | 'rate_limit'
+  | 'credit_exhausted'
   | 'model_not_found'
   | 'overloaded'
   | 'timeout'
@@ -57,6 +58,26 @@ export function classifyAIError(error: unknown): AIErrorInfo {
       technicalDetail: message,
       retryable: false,
       httpStatus: 401,
+    };
+  }
+
+  if (
+    lowerMessage.includes('credit balance') ||
+    lowerMessage.includes('credit_balance') ||
+    lowerMessage.includes('insufficient_quota') ||
+    lowerMessage.includes('insufficient credits') ||
+    lowerMessage.includes('billing') ||
+    lowerMessage.includes('plans & billing') ||
+    lowerMessage.includes('payment required') ||
+    statusCode === 402
+  ) {
+    return {
+      type: 'credit_exhausted',
+      userMessage:
+        "Le crédit du service IA est épuisé. Contactez l'administrateur pour recharger le compte (Plans & Billing).",
+      technicalDetail: message,
+      retryable: false,
+      httpStatus: 402,
     };
   }
 


### PR DESCRIPTION
## Résumé

Les générations IA (articles blog, posts sociaux) échouaient en production avec un message trompeur « La requête envoyée au service IA est invalide » alors que le **vrai problème est le crédit Anthropic épuisé** (confirmé en BDD : 3 jobs FAILED consécutifs avec `400 invalid_request_error` + `Your credit balance is too low`).

## Cause racine

Le classifier `ai-error-handler.ts` rangeait l'erreur « credit balance is too low » dans le bucket générique `invalid_request` (parce qu'Anthropic répond avec un HTTP 400 + `invalid_request_error`), ce qui masquait la vraie cause à l'utilisateur et à l'admin.

À noter : ce PR **n'achète pas** de crédits Anthropic — action admin requise sur https://console.anthropic.com/settings/billing. Le code ne peut que clarifier le diagnostic.

## Changements

| Fichier | Modification |
|---|---|
| `apps/psypnos/app/api/common/ai-error-handler.ts` | Ajoute le type `credit_exhausted`, matche `credit_balance` / `insufficient_quota` / `billing` / `402` AVANT `invalid_request`. Message utilisateur explicite. |
| `apps/psypnos/app/api/blog/generate/route.ts` | Logs d'erreur enrichis (`errorType`, `userMessage`, `technicalDetail`, `raw`) pour debug local. |
| `apps/psypnos/app/api/blog/jobs/step-executor.ts` | Idem + corrige un import `@/app/api/common/...` cassé qui bloquait `blog-jobs-step.test.ts` depuis PR #453. |
| `apps/psypnos/__tests__/unit/ai-error-handler.test.ts` | **Nouveau** — 15 tests couvrant les 10 types d'erreurs + régression explicite du cas « credit balance ». |

## Validation

| Étape | Statut |
|---|---|
| Lint | ✅ 0 erreurs |
| Type-check | ✅ (après `.next/` clean) |
| Tests unit+integration | ✅ 1486/1486 |
| Tests UI | ✅ 192/192 |
| Build | ✅ turbo affected |

## Test plan

- [ ] Vérifier CI verte
- [ ] Après merge : recharger les crédits Anthropic côté admin
- [ ] Tester une génération de blog sur psypnos.fr → l'erreur affichée côté UI doit mentionner explicitement « crédit épuisé » si la situation se reproduit
- [ ] Les logs Vercel serverless doivent montrer `errorType: "credit_exhausted"` sur les futures erreurs

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)